### PR TITLE
Allow integration point for MP-CP to wrap CFs we create

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <rxjava2.version>2.2.11</rxjava2.version>
         <reactor-core.version>3.2.10.RELEASE</reactor-core.version>
         <microprofile-reactive-streams.version>1.0.0</microprofile-reactive-streams.version>
+        <microprofile-context-propagation.version>1.0</microprofile-context-propagation.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
 
         <!-- Used by release plugin to define git tag -->
@@ -80,10 +81,15 @@
                 <version>${reactor-core.version}</version>
             </dependency>
             <dependency>
-                 <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
-                 <artifactId>microprofile-reactive-streams-operators-api</artifactId>
-            <version>${microprofile-reactive-streams.version}</version>
-        </dependency>
+                <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
+                <artifactId>microprofile-reactive-streams-operators-api</artifactId>
+                <version>${microprofile-reactive-streams.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.context-propagation</groupId>
+                <artifactId>microprofile-context-propagation-api</artifactId>
+                <version>${microprofile-context-propagation.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/smallrye-reactive-operators/pom.xml
+++ b/smallrye-reactive-operators/pom.xml
@@ -23,10 +23,26 @@
             <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.context-propagation</groupId>
+            <artifactId>microprofile-context-propagation-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-context-propagation</artifactId>
+            <version>1.0.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <version>1.3.9</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/smallrye-reactive-operators/src/main/java/io/smallrye/reactive/context/ContextPropagationUniInterceptor.java
+++ b/smallrye-reactive-operators/src/main/java/io/smallrye/reactive/context/ContextPropagationUniInterceptor.java
@@ -1,0 +1,54 @@
+package io.smallrye.reactive.context;
+
+import java.util.concurrent.Executor;
+
+import org.eclipse.microprofile.context.ThreadContext;
+import org.eclipse.microprofile.context.spi.ContextManagerProvider;
+
+import io.smallrye.reactive.Uni;
+import io.smallrye.reactive.infrastructure.UniInterceptor;
+import io.smallrye.reactive.operators.AbstractUni;
+import io.smallrye.reactive.operators.UniSerializedSubscriber;
+import io.smallrye.reactive.subscription.UniSubscriber;
+import io.smallrye.reactive.subscription.UniSubscription;
+
+/**
+ * Provides context propagation to Uni types.
+ */
+public class ContextPropagationUniInterceptor implements UniInterceptor{
+    
+    ThreadContext TC = ContextManagerProvider.instance().getContextManager().newThreadContextBuilder().build();
+    
+    @Override
+    public <T> UniSubscriber<? super T> onSubscription(Uni<T> instance, UniSubscriber<? super T> subscriber) {
+        Executor executor = TC.currentContextExecutor();
+        return new UniSubscriber<T>() {
+
+            @Override
+            public void onSubscribe(UniSubscription subscription) {
+                executor.execute(() -> subscriber.onSubscribe(subscription));
+            }
+
+            @Override
+            public void onItem(T item) {
+                executor.execute(() -> subscriber.onItem(item));
+            }
+
+            @Override
+            public void onFailure(Throwable failure) {
+                executor.execute(() -> subscriber.onFailure(failure));
+            }
+        };
+    }
+    
+    @Override
+    public <T> Uni<T> onUniCreation(Uni<T> uni) {
+        Executor executor = TC.currentContextExecutor();
+        return new AbstractUni<T>() {
+            @Override
+            protected void subscribing(UniSerializedSubscriber<? super T> subscriber) {
+                executor.execute(() -> uni.subscribe().withSubscriber(subscriber));
+            }
+        };
+    }
+}

--- a/smallrye-reactive-operators/src/main/java/io/smallrye/reactive/infrastructure/Infrastructure.java
+++ b/smallrye-reactive-operators/src/main/java/io/smallrye/reactive/infrastructure/Infrastructure.java
@@ -89,7 +89,7 @@ public class Infrastructure {
         // Avoid direct instantiation.
     }
 
-    public static void setCompletableFutureWrapper(Function<CompletableFuture<?>, CompletableFuture<?>> wrapper) {
+    static void setCompletableFutureWrapper(Function<CompletableFuture<?>, CompletableFuture<?>> wrapper) {
         COMPLETABLE_FUTURE_WRAPPER = wrapper;
     }
     
@@ -97,5 +97,14 @@ public class Infrastructure {
     public static <T> CompletableFuture<T> wrapCompletableFuture(CompletableFuture<T> future) {
         Function<CompletableFuture<?>, CompletableFuture<?>> wrapper = COMPLETABLE_FUTURE_WRAPPER;
         return wrapper != null ? (CompletableFuture<T>) wrapper.apply(future) : future;
+    }
+
+    // For testing purpose only
+    static void reloadUniInterceptors() {
+        ServiceLoader<UniInterceptor> interceptorLoader = ServiceLoader.load(UniInterceptor.class);
+        List<UniInterceptor> interceptors = new ArrayList<>();
+        interceptorLoader.iterator().forEachRemaining(interceptors::add);
+        interceptors.sort(Comparator.comparingInt(UniInterceptor::ordinal));
+        UNI_INTERCEPTORS.addAll(interceptors);
     }
 }

--- a/smallrye-reactive-operators/src/main/java/io/smallrye/reactive/infrastructure/Infrastructure.java
+++ b/smallrye-reactive-operators/src/main/java/io/smallrye/reactive/infrastructure/Infrastructure.java
@@ -8,9 +8,11 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
 
 import static io.smallrye.reactive.helpers.ParameterValidation.nonNull;
 
@@ -41,6 +43,7 @@ public class Infrastructure {
     private static final ScheduledExecutorService DEFAULT_SCHEDULER;
     private static final Executor DEFAULT_EXECUTOR;
     private static final List<UniInterceptor> UNI_INTERCEPTORS;
+    private static Function<CompletableFuture<?>, CompletableFuture<?>> COMPLETABLE_FUTURE_WRAPPER;
 
     public static ScheduledExecutorService getDefaultWorkerPool() {
         return DEFAULT_SCHEDULER;
@@ -84,5 +87,15 @@ public class Infrastructure {
 
     private Infrastructure() {
         // Avoid direct instantiation.
+    }
+
+    public static void setCompletableFutureWrapper(Function<CompletableFuture<?>, CompletableFuture<?>> wrapper) {
+        COMPLETABLE_FUTURE_WRAPPER = wrapper;
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T> CompletableFuture<T> wrapCompletableFuture(CompletableFuture<T> future) {
+        Function<CompletableFuture<?>, CompletableFuture<?>> wrapper = COMPLETABLE_FUTURE_WRAPPER;
+        return wrapper != null ? (CompletableFuture<T>) wrapper.apply(future) : future;
     }
 }

--- a/smallrye-reactive-operators/src/main/java/io/smallrye/reactive/infrastructure/UniContextManagerExtension.java
+++ b/smallrye-reactive-operators/src/main/java/io/smallrye/reactive/infrastructure/UniContextManagerExtension.java
@@ -1,0 +1,15 @@
+package io.smallrye.reactive.infrastructure;
+
+import org.eclipse.microprofile.context.ThreadContext;
+import org.eclipse.microprofile.context.spi.ContextManager;
+import org.eclipse.microprofile.context.spi.ContextManagerExtension;
+
+public class UniContextManagerExtension implements ContextManagerExtension {
+
+    @Override
+    public void setup(ContextManager manager) {
+        ThreadContext threadContext = manager.newThreadContextBuilder().build();
+        Infrastructure.setCompletableFutureWrapper(cf -> threadContext.withContextCapture(cf));
+    }
+
+}

--- a/smallrye-reactive-operators/src/main/java/io/smallrye/reactive/operators/UniSubscribeToCompletionStage.java
+++ b/smallrye-reactive-operators/src/main/java/io/smallrye/reactive/operators/UniSubscribeToCompletionStage.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.operators;
 
 import io.smallrye.reactive.Uni;
+import io.smallrye.reactive.infrastructure.Infrastructure;
 import io.smallrye.reactive.subscription.UniSubscriber;
 import io.smallrye.reactive.subscription.UniSubscription;
 
@@ -51,7 +52,7 @@ public class UniSubscribeToCompletionStage {
                 }
             }
         });
-        return future;
+        return Infrastructure.wrapCompletableFuture(future);
     }
 
 }

--- a/smallrye-reactive-operators/src/main/resources/META-INF/services/io.smallrye.reactive.infrastructure.UniInterceptor
+++ b/smallrye-reactive-operators/src/main/resources/META-INF/services/io.smallrye.reactive.infrastructure.UniInterceptor
@@ -1,0 +1,1 @@
+io.smallrye.reactive.context.ContextPropagationUniInterceptor

--- a/smallrye-reactive-operators/src/main/resources/META-INF/services/org.eclipse.microprofile.context.spi.ContextManagerExtension
+++ b/smallrye-reactive-operators/src/main/resources/META-INF/services/org.eclipse.microprofile.context.spi.ContextManagerExtension
@@ -1,0 +1,1 @@
+io.smallrye.reactive.infrastructure.UniContextManagerExtension

--- a/smallrye-reactive-operators/src/test/java/io/smallrye/reactive/MyTest.java
+++ b/smallrye-reactive-operators/src/test/java/io/smallrye/reactive/MyTest.java
@@ -1,0 +1,59 @@
+package io.smallrye.reactive;
+
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+public class MyTest {
+    @Test
+    public void test() {
+        String ret = Uni.createFrom().item("Foo")
+            .map(String::toUpperCase)
+            // flatMap
+            .onItem().mapToUni(str -> Uni.createFrom().item("Bar"))
+            .await().indefinitely();
+        System.err.println(ret);
+        
+        Uni.createFrom().deferredItem(() -> "Foo")
+            .subscribe().with(System.err::println, Throwable::printStackTrace);
+        // Multi has subscribe(Subscriber)
+        // .subscribe().with((res, t) -> {})
+        
+        Uni.createFrom().emitter(sink -> {
+           sink.complete("Stef"); 
+        }).subscribe().with(System.err::println, Throwable::printStackTrace);
+        
+        Uni.createFrom().item("Foo")
+            .map(s -> { throw new RuntimeException("ouch"); })
+            .onFailure(Throwable.class).recoverWithItem(t -> "Fixed: "+t.getMessage())
+            .subscribe().with(System.err::println, Throwable::printStackTrace);
+
+        Multi.createFrom().items("one", "two")
+            .onItem().mapToItem(String::toUpperCase)
+            .subscribe().withSubscriber(new Subscriber<String>() {
+
+                @Override
+                public void onSubscribe(Subscription s) {
+                    // TODO Auto-generated method stub
+                    
+                }
+
+                @Override
+                public void onNext(String t) {
+                    System.err.println(t);
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    t.printStackTrace();
+                }
+
+                @Override
+                public void onComplete() {
+                    // TODO Auto-generated method stub
+                    
+                }
+                
+            });
+    }
+}

--- a/smallrye-reactive-operators/src/test/java/io/smallrye/reactive/context/MyContext.java
+++ b/smallrye-reactive-operators/src/test/java/io/smallrye/reactive/context/MyContext.java
@@ -1,0 +1,32 @@
+package io.smallrye.reactive.context;
+
+public class MyContext {
+
+    private static ThreadLocal<MyContext> context = new ThreadLocal<MyContext>();
+
+    public static void init() {
+        context.set(new MyContext());
+    }
+
+    public static void clear() {
+        context.remove();
+    }
+
+    public static MyContext get() {
+        return context.get();
+    }
+
+    public static void set(MyContext newContext) {
+        context.set(newContext);
+    }
+
+    private String reqId;
+
+    public void set(String reqId) {
+        this.reqId = reqId;
+    }
+
+    public String getReqId() {
+        return reqId;
+    }
+}

--- a/smallrye-reactive-operators/src/test/java/io/smallrye/reactive/context/MyThreadContextProvider.java
+++ b/smallrye-reactive-operators/src/test/java/io/smallrye/reactive/context/MyThreadContextProvider.java
@@ -1,0 +1,42 @@
+package io.smallrye.reactive.context;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+
+public class MyThreadContextProvider implements ThreadContextProvider {
+
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        MyContext capturedContext = MyContext.get();
+        return () -> {
+            MyContext movedContext = MyContext.get();
+            System.err.println(Thread.currentThread()+" setting context to "+capturedContext);
+            MyContext.set(capturedContext);
+            return () -> {
+                MyContext.set(movedContext);
+            };
+        };
+    }
+
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        return () -> {
+            MyContext movedContext = MyContext.get();
+            MyContext.clear();
+            return () -> {
+                if (movedContext == null)
+                    MyContext.clear();
+                else
+                    MyContext.set(movedContext);
+            };
+        };
+    }
+
+    @Override
+    public String getThreadContextType() {
+        return "MyContext";
+    }
+
+}

--- a/smallrye-reactive-operators/src/test/java/io/smallrye/reactive/infrastructure/ContextPropagationTest.java
+++ b/smallrye-reactive-operators/src/test/java/io/smallrye/reactive/infrastructure/ContextPropagationTest.java
@@ -1,0 +1,165 @@
+package io.smallrye.reactive.infrastructure;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.smallrye.reactive.Uni;
+import io.smallrye.reactive.context.MyContext;
+import io.smallrye.reactive.infrastructure.Infrastructure;
+
+public class ContextPropagationTest {
+
+    @Before
+    public void initContext() {
+        Infrastructure.clearUniInterceptors();
+        Infrastructure.reloadUniInterceptors();
+        MyContext.init();
+    }
+
+    @After
+    public void clearContext() {
+        Infrastructure.clearUniInterceptors();
+        MyContext.clear();
+    }
+
+    @Test
+    public void testDeferred() {
+        MyContext ctx = MyContext.get();
+        Assert.assertNotNull(ctx);
+        log("creating uni");
+        Uni<Integer> uni = Uni.createFrom().deferredItem(() -> {
+            log("creating deferred");
+            Assert.assertEquals(ctx, MyContext.get());
+            return 2;
+        }).map(r -> {
+            Assert.assertEquals(ctx, MyContext.get());
+            log("mapping");
+            return r;
+        });
+
+        log("creating latch");
+        Uni<Integer> latch = Uni.createFrom().emitter(emitter -> {
+            log("starting thread");
+            new Thread() {
+
+                public void run() {
+                    try {
+                        log("in thread waiting");
+                        int result = uni.await().indefinitely();
+                        log("in thread completing");
+                        emitter.complete(result);
+                    } catch (Throwable t) {
+                        emitter.fail(t);
+                    }
+                }
+            }.start();
+        });
+
+        log("await");
+        int result = latch.await().indefinitely();
+        log("await done");
+        Assert.assertEquals(2, result);
+    }
+
+    @Test
+    public void testGenerator() {
+        MyContext ctx = MyContext.get();
+        Assert.assertNotNull(ctx);
+        log("creating uni");
+        Uni<Integer> uni = Uni.createFrom().<Integer> emitter(emitter -> {
+            log("creating emitter");
+            Assert.assertEquals(ctx, MyContext.get());
+            new Thread() {
+
+                public void run() {
+                    try {
+                        log("in thread completing");
+                        emitter.complete(2);
+                    } catch (Throwable t) {
+                        emitter.fail(t);
+                    }
+                }
+            }.start();
+        }).map(r -> {
+            Assert.assertEquals(ctx, MyContext.get());
+            log("mapping");
+            return r;
+        });
+
+        log("await");
+        int result = uni.await().indefinitely();
+        log("await done");
+        Assert.assertEquals(2, result);
+    }
+
+    @Test
+    public void testCompletionStage() throws InterruptedException, ExecutionException {
+        CountDownLatch fire = new CountDownLatch(1);
+        MyContext ctx = MyContext.get();
+        Assert.assertNotNull(ctx);
+        log("creating uni");
+        Uni<Integer> uni = Uni.createFrom().<Integer> emitter(emitter -> {
+            log("creating emitter");
+            Assert.assertEquals(ctx, MyContext.get());
+            new Thread() {
+
+                public void run() {
+                    try {
+                        log("in thread completing (wait for fire)");
+                        Assert.assertNull(MyContext.get());
+                        fire.await();
+                        log("in thread completing");
+                        emitter.complete(2);
+                    } catch (Throwable t) {
+                        emitter.fail(t);
+                    }
+                }
+            }.start();
+        });
+
+        CompletableFuture<Integer> cs = uni.subscribeAsCompletionStage();
+        
+        MyContext ctx2 = new MyContext();
+        MyContext.set(ctx2);
+        log("changing context");
+        CompletableFuture<Integer> cs2 = cs.thenApply(r -> {
+            Assert.assertEquals(ctx2, MyContext.get());
+            log("mapping");
+            return r;
+        });
+
+        log("creating latch");
+        CompletableFuture<Integer> cf = new CompletableFuture<>();
+        log("starting thread");
+        new Thread() {
+            public void run() {
+                try {
+                    log("in thread waiting");
+                    Assert.assertNull(MyContext.get());
+                    int result = cs2.get();
+                    log("in thread completing");
+                    cf.complete(result);
+                } catch (Throwable t) {
+                    cf.completeExceptionally(t);
+                }
+            }
+        }.start();
+
+        log("fire");
+        fire.countDown();
+        log("await");
+        int result = cf.get();
+        log("await done");
+        Assert.assertEquals(2, result);
+    }
+
+    private void log(String string) {
+        System.err.println(Thread.currentThread() + ": " + string);
+    }
+}

--- a/smallrye-reactive-operators/src/test/java/io/smallrye/reactive/infrastructure/UniInterceptorTest.java
+++ b/smallrye-reactive-operators/src/test/java/io/smallrye/reactive/infrastructure/UniInterceptorTest.java
@@ -7,6 +7,7 @@ import io.smallrye.reactive.operators.UniSerializedSubscriber;
 import io.smallrye.reactive.subscription.UniSubscriber;
 import io.smallrye.reactive.subscription.UniSubscription;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class UniInterceptorTest {
 
     @After
+    @Before
     public void cleanup() {
         Infrastructure.clearUniInterceptors();
     }

--- a/smallrye-reactive-operators/src/test/resources/META-INF/services/org.eclipse.microprofile.context.spi.ThreadContextProvider
+++ b/smallrye-reactive-operators/src/test/resources/META-INF/services/org.eclipse.microprofile.context.spi.ThreadContextProvider
@@ -1,0 +1,1 @@
+io.smallrye.reactive.context.MyThreadContextProvider


### PR DESCRIPTION
Don't merge as-is.

This allows me to write an MP-CP plugin that does this:

```java
public class UniContextPropagator implements ContextManagerExtension {

    @Override
    public void setup(ContextManager manager) {
        ThreadContext threadContext = manager.newThreadContextBuilder().build();
        Infrastructure.setCompletableFutureWrapper(cf -> threadContext.withContextCapture(cf));
    }
}
```

Which makes sure that the CFs you create have context propagation.

It's not ideal, because it's not a service and it's single-plugin. 

I could add another SPI, because it doesn't fit with the other two SPIs, but I don't think this composes well.

I could also rather make SR-RO depend on MP-CP and provide that `UniContextPropagator` file, in a way that the `Infrastructure` method can be made non-public.

An alternative would be for `UniSubscribeToCompletionStage` to be able to call `Infrastructure.newCompletableFuture()` instead of wrapping an existing one, because that allows us to set the default executor to something better than the JDK default (the quarkus one for example), but you depend on overriding the `cancel` method so that can't work you need you own subtype.

Not too sure what to do, but something _like this_ would be nice.