### PR TITLE
Fix #28 - It should not be possible to not set the timeout

### DIFF
--- a/documentation/src/test/java/snippets/UniTimeoutTest.java
+++ b/documentation/src/test/java/snippets/UniTimeoutTest.java
@@ -1,14 +1,13 @@
 package snippets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.smallrye.mutiny.Uni;
+import org.junit.Test;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import io.smallrye.mutiny.Uni;
-
-public class TimeoutTest {
+public class UniTimeoutTest {
 
     @Test
     public void test() {
@@ -21,4 +20,5 @@ public class TimeoutTest {
 
         assertThat(item).isEqualTo("some fallback item");
     }
+
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -284,7 +284,7 @@ public interface Uni<T> {
      *
      * @return the on timeout group
      */
-    UniOnTimeout<T> ifNoItem();
+    UniIfNoItem<T> ifNoItem();
 
     /**
      * Produces a new {@link Uni} invoking the {@link UniSubscriber#onItem(Object)} and

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniIfNoItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniIfNoItem.java
@@ -1,0 +1,28 @@
+package io.smallrye.mutiny.groups;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.validate;
+
+import java.time.Duration;
+
+import io.smallrye.mutiny.Uni;
+
+public class UniIfNoItem<T> {
+
+    private final Uni<T> upstream;
+
+    public UniIfNoItem(Uni<T> upstream) {
+        this.upstream = nonNull(upstream, "upstream");
+    }
+
+    /**
+     * Configures the timeout duration.
+     *
+     * @param timeout the timeout, must not be {@code null}, must be strictly positive.
+     * @return a new {@link UniIfNoItem}
+     */
+    public UniOnTimeout<T> after(Duration timeout) {
+        return new UniOnTimeout<>(upstream, validate(timeout, "timeout"), null);
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
@@ -24,8 +24,8 @@ public abstract class AbstractUni<T> implements Uni<T> {
     }
 
     @Override
-    public UniOnTimeout<T> ifNoItem() {
-        return new UniOnTimeout<>(this, null, null);
+    public UniIfNoItem<T> ifNoItem() {
+        return new UniIfNoItem<>(this);
     }
 
     @Override

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 
-public class UniOnNoResultTest {
+public class UniIfNoItemTest {
 
     @Test
     public void testResultWhenTimeoutIsNotReached() {


### PR DESCRIPTION
Fix #28 
Introduce an intermediary group to avoid using recovery methods without timeout.