### PR TITLE
Provide an implementation of Multi consuming a java.util.Stream in a lazy fashion

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/StreamBasedMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/StreamBasedMulti.java
@@ -1,0 +1,156 @@
+package io.smallrye.mutiny.operators.multi.builders;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.helpers.ParameterValidation;
+import io.smallrye.mutiny.helpers.Subscriptions;
+import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+public class StreamBasedMulti<T> extends AbstractMulti<T> {
+
+    private final Supplier<? extends Stream<? extends T>> supplier;
+
+    public StreamBasedMulti(Supplier<? extends Stream<? extends T>> supplier) {
+        this.supplier = supplier;
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super T> downstream) {
+        ParameterValidation.nonNullNpe(downstream, "subscriber");
+
+        Stream<? extends T> stream;
+
+        try {
+            stream = supplier.get();
+        } catch (Exception e) {
+            Subscriptions.fail(downstream, e);
+            return;
+        }
+
+        if (stream == null) {
+            Subscriptions.fail(downstream, new NullPointerException(ParameterValidation.SUPPLIER_PRODUCED_NULL));
+            return;
+        }
+
+        Iterator<? extends T> iterator;
+        try {
+            iterator = stream.iterator();
+
+            if (!iterator.hasNext()) {
+                Subscriptions.complete(downstream);
+                closeQuietly(stream);
+                return;
+            }
+        } catch (Throwable ex) {
+            Subscriptions.fail(downstream, ex);
+            closeQuietly(stream);
+            return;
+        }
+
+        downstream.onSubscribe(new StreamSubscription<>(downstream, iterator, stream));
+    }
+
+    private static void closeQuietly(AutoCloseable source) {
+        if (source == null) {
+            return;
+        }
+        try {
+            source.close();
+        } catch (Throwable ex) {
+            // ignore the exception
+        }
+    }
+
+    private static class StreamSubscription<T> implements Subscription {
+
+        private final Iterator<? extends T> iterator;
+        private final AutoCloseable closeable;
+        private final AtomicLong requested = new AtomicLong();
+        private final MultiSubscriber<T> downstream;
+        volatile boolean cancelled;
+
+        StreamSubscription(MultiSubscriber<T> downstream, Iterator<? extends T> iterator, AutoCloseable closeable) {
+            this.iterator = iterator;
+            this.closeable = closeable;
+            this.downstream = downstream;
+        }
+
+        @Override
+        public void request(long n) {
+            if (n > 0) {
+                if (Subscriptions.add(requested, n) == 0L) {
+                    pull(n);
+                }
+            } else {
+                downstream.onFailure(Subscriptions.getInvalidRequestException());
+            }
+        }
+
+        public void pull(long n) {
+            long emitted = 0L;
+            for (;;) {
+                if (cancelled) {
+                    closeQuietly(closeable);
+                    return;
+                } else {
+                    T item;
+                    try {
+                        item = iterator.next();
+                        if (item == null) {
+                            throw new NullPointerException("The stream iterator produced `null`");
+                        }
+                    } catch (Throwable ex) {
+                        downstream.onFailure(ex);
+                        cancelled = true;
+                        continue;
+                    }
+
+                    downstream.onItem(item);
+
+                    if (cancelled || handleCompletion()) {
+                        continue;
+                    }
+
+                    if (++emitted != n) {
+                        continue;
+                    }
+                }
+
+                n = requested.get();
+                if (emitted == n) {
+                    if (requested.compareAndSet(n, 0L)) {
+                        break;
+                    }
+                    n = requested.get();
+                }
+            }
+        }
+
+        private boolean handleCompletion() {
+            try {
+                if (!iterator.hasNext()) {
+                    downstream.onCompletion();
+                    cancelled = true;
+                    return true;
+                }
+            } catch (Throwable ex) {
+                downstream.onFailure(ex);
+                cancelled = true;
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+            request(1L);
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessor.java
@@ -1,20 +1,21 @@
 package io.smallrye.mutiny.operators.multi.processors;
 
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.helpers.queues.SpscLinkedArrayQueue;
 import io.smallrye.mutiny.operators.AbstractMulti;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
-import org.reactivestreams.Processor;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
-
-import java.util.Queue;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Implementation of a processor using a queue to store items and allows a single subscriber to receive
@@ -50,9 +51,9 @@ public class UnicastProcessor<T> extends AbstractMulti<T> implements Processor<T
     /**
      * Creates a new {@link UnicastProcessor} using the given queue.
      *
-     * @param queue         the queue, must not be {@code null}
+     * @param queue the queue, must not be {@code null}
      * @param onTermination the termination callback, can be {@code null}
-     * @param <I>           the type of item
+     * @param <I> the type of item
      * @return the unicast processor
      */
     public static <I> UnicastProcessor<I> create(Queue<I> queue, Runnable onTermination) {
@@ -75,7 +76,7 @@ public class UnicastProcessor<T> extends AbstractMulti<T> implements Processor<T
 
         final Queue<T> q = queue;
 
-        for (; ; ) {
+        for (;;) {
 
             long r = requested.get();
             long e = 0L;
@@ -122,7 +123,7 @@ public class UnicastProcessor<T> extends AbstractMulti<T> implements Processor<T
         }
 
         int missed = 1;
-        for (; ; ) {
+        for (;;) {
             Subscriber<? super T> actual = downstream.get();
             if (actual != null) {
                 drainWithDownstream(actual);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromItemsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromItemsTest.java
@@ -1,10 +1,14 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.testng.annotations.Test;
@@ -75,7 +79,7 @@ public class MultiCreateFromItemsTest {
     }
 
     @Test
-    public void testCreationFromAStream() {
+    public void testCreationFromAStreamWithRequest() {
         Multi<Integer> multi = Multi.createFrom().items(Stream.of(1, 2, 3));
         multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
@@ -85,6 +89,136 @@ public class MultiCreateFromItemsTest {
                 .request(3)
                 .assertReceived(1, 2, 3)
                 .assertCompletedSuccessfully();
+
+        AtomicInteger count = new AtomicInteger();
+        multi = Multi.createFrom().items(() -> {
+            count.incrementAndGet();
+            return Stream.of(1, 2, 3);
+        });
+        assertThat(count).hasValue(0);
+        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+                .run(() -> assertThat(count).hasValue(1))
+                .assertHasNotReceivedAnyItem()
+                .assertSubscribed()
+                .request(1)
+                .assertReceived(1)
+                .request(3)
+                .assertReceived(1, 2, 3)
+                .run(() -> assertThat(count).hasValue(1))
+                .assertCompletedSuccessfully();
+    }
+
+    @Test
+    public void testCreateFromEmptyStream() {
+        Multi.createFrom().<Integer> items(Stream.empty())
+                .subscribe().withSubscriber(MultiAssertSubscriber.create(100))
+                .assertCompletedSuccessfully()
+                .assertHasNotReceivedAnyItem();
+
+        Multi.createFrom().<Integer> items(Stream::empty)
+                .subscribe().withSubscriber(MultiAssertSubscriber.create(100))
+                .assertCompletedSuccessfully()
+                .assertHasNotReceivedAnyItem();
+    }
+
+    @Test
+    public void testCreateFromStreamOfOne() {
+        Multi.createFrom().items(Stream.of(1))
+                .subscribe().withSubscriber(MultiAssertSubscriber.create(100))
+                .assertCompletedSuccessfully()
+                .assertReceived(1);
+
+        Multi.createFrom().items(() -> Stream.of(2))
+                .subscribe().withSubscriber(MultiAssertSubscriber.create(100))
+                .assertCompletedSuccessfully()
+                .assertReceived(2);
+    }
+
+    @Test
+    public void testThatStreamCannotBeReused() {
+        Stream<Integer> stream = Stream.of(1, 2, 3, 4);
+        List<Integer> list = Multi.createFrom().items(stream)
+                .collectItems().asList()
+                .await().indefinitely();
+
+        assertThat(list).containsExactly(1, 2, 3, 4);
+
+        assertThatThrownBy(() -> Multi.createFrom().items(stream)
+                .collectItems().asList()
+                .await().indefinitely()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testThatMultiBasedOnStreamCannotBeReused() {
+        Stream<Integer> stream = Stream.of(1, 2, 3, 4);
+        Multi<Integer> multi = Multi.createFrom().items(stream);
+        List<Integer> list = multi
+                .collectItems().asList()
+                .await().indefinitely();
+
+        assertThat(list).containsExactly(1, 2, 3, 4);
+
+        assertThatThrownBy(() -> multi
+                .collectItems().asList()
+                .await().indefinitely()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testLimitOnMultiBasedOnStream() {
+        Multi.createFrom().items(() -> IntStream.iterate(0, operand -> operand + 1).boxed())
+                .transform().byTakingFirstItems(10)
+                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .assertCompletedSuccessfully()
+                .assertReceived(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+    }
+
+    @Test
+    public void testNullWithStreams() {
+        assertThatThrownBy(() -> Multi.createFrom().items((Stream<String>) null)).isInstanceOf(IllegalArgumentException.class);
+
+        Multi.createFrom().items(() -> null)
+                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .assertHasFailedWith(NullPointerException.class, "")
+                .assertHasNotReceivedAnyItem();
+
+        Multi.createFrom().items(Stream.of("a", "b", null, "c"))
+                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .assertHasFailedWith(NullPointerException.class, "")
+                .assertReceived("a", "b");
+    }
+
+    @Test
+    public void testCloseCallbackCalledWithStream() {
+        AtomicBoolean called = new AtomicBoolean();
+        Multi.createFrom().items(Stream.of("a", "b", "c").onClose(() -> called.set(true)))
+                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .assertReceived("a", "b", "c")
+                .assertCompletedSuccessfully()
+                .run(() -> assertThat(called).isTrue());
+
+        // Test that the callback is called when the subscriber cancels
+        called.set(false);
+        Multi.createFrom().items(Stream.of("a", "b", "c").onClose(() -> called.set(true)))
+                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .assertReceived("a")
+                .cancel()
+                .run(() -> assertThat(called).isTrue());
+    }
+
+    @Test
+    public void testStreamHasNextFailureWithStream() {
+        AtomicInteger counter = new AtomicInteger();
+        AtomicBoolean called = new AtomicBoolean();
+        Multi.createFrom().items(Stream.generate(() -> {
+            int value = counter.getAndIncrement();
+            if (value == 1) {
+                throw new IllegalStateException("boom");
+            }
+            return value;
+        }).onClose(() -> called.set(true))).subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .assertHasFailedWith(IllegalStateException.class, "boom")
+                .assertReceived(0);
+        assertThat(called).isTrue();
     }
 
     @Test

--- a/implementation/src/test/java/tck/MultiFromStreamTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromStreamTckTest.java
@@ -1,0 +1,16 @@
+package tck;
+
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
+
+public class MultiFromStreamTckTest extends AbstractPublisherTck<Long> {
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        Stream<Long> list = LongStream.rangeClosed(1, elements).boxed();
+        return Multi.createFrom().items(list);
+    }
+}


### PR DESCRIPTION
The previous implementation was eager and relied on calling forEach. It was not handling infinite stream.
This version does and also add support for the close callback.