### PR TITLE
Improvements around event handlers

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnEvent.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnEvent.java
@@ -105,6 +105,28 @@ public class MultiOnEvent<T> {
     }
 
     /**
+     * Attaches an action that is executed when the {@link Multi} emits a completion or a failure or when the subscriber
+     * cancels the subscription. Unlike {@link #termination(BiConsumer)}, the callback does not receive the failure or
+     * cancellation details.
+     *
+     * @param action the action to execute when the streams completes, fails or the subscription gets cancelled. Must
+     *        not be {@code null}.
+     * @return the new {@link Multi}
+     */
+    public Multi<T> termination(Runnable action) {
+        Runnable runnable = nonNull(action, "action");
+        return Infrastructure.onMultiCreation(new MultiSignalConsumerOp<>(
+                upstream,
+                null,
+                null,
+                null,
+                null,
+                (f, c) -> runnable.run(),
+                null,
+                null));
+    }
+
+    /**
      * Configures the action to execute when the observed {@link Multi} emits an item.
      *
      * <p>

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnEvent.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnEvent.java
@@ -68,6 +68,19 @@ public class UniOnEvent<T> {
     }
 
     /**
+     * Attaches an action that is executed when the {@link Uni} emits an item or a failure or when the subscriber
+     * cancels the subscription. Unlike {@link #termination(Functions.TriConsumer)}, the callback does not receive
+     * the item, failure or cancellation.
+     *
+     * @param action the action to run, must not be {@code null}
+     * @return the new {@link Uni}
+     */
+    public Uni<T> termination(Runnable action) {
+        Runnable runnable = nonNull(action, "action");
+        return Infrastructure.onUniCreation(new UniOnTermination<>(upstream, (i, f, c) -> runnable.run()));
+    }
+
+    /**
      * Configures the action to execute when the observed {@link Uni} emits the item (potentially {@code null}).
      *
      * <p>
@@ -90,12 +103,12 @@ public class UniOnEvent<T> {
     }
 
     /**
-     * Like {@link #onFailure(Predicate)} but applied to all failures fired by the upstream uni.
+     * Like {@link #failure(Predicate)} but applied to all failures fired by the upstream uni.
      * It allows configuring the on failure behavior (recovery, retry...).
      *
      * @return a UniOnFailure on which you can specify the on failure action
      */
-    public UniOnFailure<T> onFailure() {
+    public UniOnFailure<T> failure() {
         return upstream.onFailure();
     }
 
@@ -112,7 +125,7 @@ public class UniOnEvent<T> {
      * @param predicate the predicate, {@code null} means applied to all failures
      * @return a UniOnFailure configured with the given predicate on which you can specify the on failure action
      */
-    public UniOnFailure<T> onFailure(Predicate<? super Throwable> predicate) {
+    public UniOnFailure<T> failure(Predicate<? super Throwable> predicate) {
         return upstream.onFailure(predicate);
     }
 
@@ -129,7 +142,7 @@ public class UniOnEvent<T> {
      * @param typeOfFailure the class of exception, must not be {@code null}
      * @return a UniOnFailure configured with the given predicate on which you can specify the on failure action
      */
-    public UniOnFailure<T> onFailure(Class<? extends Throwable> typeOfFailure) {
+    public UniOnFailure<T> failure(Class<? extends Throwable> typeOfFailure) {
         return upstream.onFailure(typeOfFailure);
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnEvent.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnEvent.java
@@ -37,7 +37,7 @@ public class UniOnEvent<T> {
      * @param consumer the callback, must not be {@code null}
      * @return a new {@link Uni}
      */
-    public Uni<T> subscription(Consumer<? super UniSubscription> consumer) {
+    public Uni<T> subscribed(Consumer<? super UniSubscription> consumer) {
         return Infrastructure.onUniCreation(new UniOnSubscription<>(upstream, nonNull(consumer, "consumer")));
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
@@ -36,6 +36,26 @@ public class UniOnEventTest {
     }
 
     @Test
+    public void testActionsOnItem2() {
+        AtomicInteger Item = new AtomicInteger();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<Subscription> subscription = new AtomicReference<>();
+        AtomicBoolean terminate = new AtomicBoolean();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
+                .onItem().invoke(Item::set)
+                .onFailure().invoke(failure::set)
+                .on().subscribed(subscription::set)
+                .on().termination(() -> terminate.set(true))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertItem(1);
+        assertThat(Item).hasValue(1);
+        assertThat(failure.get()).isNull();
+        assertThat(subscription.get()).isNotNull();
+        assertThat(terminate).isTrue();
+    }
+
+    @Test
     public void testActionsOnFailures() {
         AtomicInteger Item = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
@@ -53,6 +73,26 @@ public class UniOnEventTest {
         assertThat(failure.get()).isInstanceOf(IOException.class);
         assertThat(subscription.get()).isNotNull();
         assertThat(terminate.get()).isInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void testActionsOnFailures2() {
+        AtomicInteger Item = new AtomicInteger();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<Subscription> subscription = new AtomicReference<>();
+        AtomicBoolean terminate = new AtomicBoolean();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> failure(new IOException("boom"))
+                .onItem().invoke(Item::set)
+                .onFailure().invoke(failure::set)
+                .on().subscribed(subscription::set)
+                .on().termination(() -> terminate.set(true))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertCompletedWithFailure().assertFailure(IOException.class, "boom");
+        assertThat(Item).doesNotHaveValue(1);
+        assertThat(failure.get()).isInstanceOf(IOException.class);
+        assertThat(subscription.get()).isNotNull();
+        assertThat(terminate).isTrue();
     }
 
     @Test
@@ -85,6 +125,28 @@ public class UniOnEventTest {
     }
 
     @Test
+    public void testWhenOnItemThrowsAnException2() {
+        AtomicInteger Item = new AtomicInteger();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<Subscription> subscription = new AtomicReference<>();
+        AtomicBoolean terminated = new AtomicBoolean();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
+                .onItem().invoke(i -> {
+                    throw new IllegalStateException("boom");
+                })
+                .onFailure().invoke(failure::set)
+                .on().subscribed(subscription::set)
+                .on().termination(() -> terminated.set(true))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertCompletedWithFailure().assertFailure(IllegalStateException.class, "boom");
+        assertThat(Item).doesNotHaveValue(1);
+        assertThat(failure.get()).isInstanceOf(IllegalStateException.class);
+        assertThat(subscription.get()).isNotNull();
+        assertThat(terminated).isTrue();
+    }
+
+    @Test
     public void testWhenOnFailureThrowsAnException() {
         AtomicInteger Item = new AtomicInteger();
         AtomicReference<Subscription> subscription = new AtomicReference<>();
@@ -114,6 +176,28 @@ public class UniOnEventTest {
     }
 
     @Test
+    public void testWhenOnFailureThrowsAnException2() {
+        AtomicInteger Item = new AtomicInteger();
+        AtomicReference<Subscription> subscription = new AtomicReference<>();
+        AtomicBoolean terminated = new AtomicBoolean();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> failure(new IOException("kaboom"))
+                .onItem().invoke(Item::set)
+                .onFailure().invoke(e -> {
+                    throw new IllegalStateException("boom");
+                })
+                .on().subscribed(subscription::set)
+                .on().termination(() -> terminated.set(true))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertCompletedWithFailure()
+                .assertFailure(CompositeException.class, "boom")
+                .assertFailure(CompositeException.class, "kaboom");
+        assertThat(Item).doesNotHaveValue(1);
+        assertThat(subscription.get()).isNotNull();
+        assertThat(terminated).isTrue();
+    }
+
+    @Test
     public void testWhenOnSubscriptionThrowsAnException() {
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
                 .on().subscribed(s -> {
@@ -140,6 +224,20 @@ public class UniOnEventTest {
         AtomicBoolean terminated = new AtomicBoolean();
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
                 .on().termination((r, f, c) -> terminated.set(c))
+                .on().cancellation(() -> called.set(true))
+                .subscribe().withSubscriber(new UniAssertSubscriber<>(true));
+
+        subscriber.assertNotCompleted();
+        assertThat(called).isTrue();
+        assertThat(terminated).isTrue();
+    }
+
+    @Test
+    public void testOnTerminationWithCancellation2() {
+        AtomicBoolean called = new AtomicBoolean();
+        AtomicBoolean terminated = new AtomicBoolean();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
+                .on().termination(() -> terminated.set(true))
                 .on().cancellation(() -> called.set(true))
                 .subscribe().withSubscriber(new UniAssertSubscriber<>(true));
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
@@ -24,7 +24,7 @@ public class UniOnEventTest {
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
                 .onItem().invoke(Item::set)
                 .onFailure().invoke(failure::set)
-                .on().subscription(subscription::set)
+                .on().subscribed(subscription::set)
                 .on().termination((r, f, c) -> terminate.set(r))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
@@ -44,7 +44,7 @@ public class UniOnEventTest {
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> failure(new IOException("boom"))
                 .onItem().invoke(Item::set)
                 .onFailure().invoke(failure::set)
-                .on().subscription(subscription::set)
+                .on().subscribed(subscription::set)
                 .on().termination((r, f, c) -> terminate.set(f))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
@@ -67,7 +67,7 @@ public class UniOnEventTest {
                     throw new IllegalStateException("boom");
                 })
                 .onFailure().invoke(failure::set)
-                .on().subscription(subscription::set)
+                .on().subscribed(subscription::set)
                 .on().termination((r, f, c) -> {
                     if (r != null) {
                         ItemFromTerminate.set(r);
@@ -95,7 +95,7 @@ public class UniOnEventTest {
                 .onFailure().invoke(e -> {
                     throw new IllegalStateException("boom");
                 })
-                .on().subscription(subscription::set)
+                .on().subscribed(subscription::set)
                 .on().termination((r, f, c) -> {
                     if (r != null) {
                         ItemFromTerminate.set(r);
@@ -116,7 +116,7 @@ public class UniOnEventTest {
     @Test
     public void testWhenOnSubscriptionThrowsAnException() {
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
-                .on().subscription(s -> {
+                .on().subscribed(s -> {
                     throw new IllegalStateException("boom");
                 }).subscribe().withSubscriber(UniAssertSubscriber.create());
 

--- a/implementation/src/test/java/tck/MultiCollectTest.java
+++ b/implementation/src/test/java/tck/MultiCollectTest.java
@@ -104,7 +104,7 @@ public class MultiCollectTest extends AbstractTck {
     public void collectStageShouldPropagateErrorsFromAccumulator() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         CompletionStage<String> result = infiniteStream()
-                .on().termination((failed, cancel) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .collectItems().with(Collector.of(() -> "", (a, b) -> {
                     throw new QuietRuntimeException("failed");
                 }, (a, b) -> a + b, Function.identity()))

--- a/implementation/src/test/java/tck/MultiDistinctTckTest.java
+++ b/implementation/src/test/java/tck/MultiDistinctTckTest.java
@@ -59,7 +59,7 @@ public class MultiDistinctTckTest extends AbstractPublisherTck<Integer> {
         }
         CompletionStage<List<ObjectThatThrowsFromEquals>> result = Multi.createFrom().items(
                 new ObjectThatThrowsFromEquals(), new ObjectThatThrowsFromEquals())
-                .on().termination((e, c) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .transform().byDroppingDuplicates().collectItems().asList().subscribeAsCompletionStage();
         await(cancelled);
         await(result);
@@ -69,7 +69,7 @@ public class MultiDistinctTckTest extends AbstractPublisherTck<Integer> {
     public void distinctStageShouldPropagateCancel() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         infiniteStream()
-                .on().termination((e, c) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .transform().byDroppingDuplicates().subscribe().withSubscriber(new Subscriptions.CancelledSubscriber<>());
         await(cancelled);
     }

--- a/implementation/src/test/java/tck/MultiFirstTckTest.java
+++ b/implementation/src/test/java/tck/MultiFirstTckTest.java
@@ -37,7 +37,7 @@ public class MultiFirstTckTest extends AbstractTck {
     public void findFirstStageShouldCancelUpstream() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         int result = await(infiniteStream()
-                .on().termination((f, c) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .collectItems().first().subscribeAsCompletionStage());
         assertEquals(result, 1);
         await(cancelled);

--- a/implementation/src/test/java/tck/MultiFlatMapCompletionStageTckTest.java
+++ b/implementation/src/test/java/tck/MultiFlatMapCompletionStageTckTest.java
@@ -102,7 +102,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Int
     public void flatMapCsStageShouldHandleErrorsThrownByCallback() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         CompletionStage<List<Object>> result = this.infiniteStream()
-                .on().termination((fail, can) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .onItem().produceCompletionStage(i -> {
                     throw new QuietRuntimeException("failed");
                 }).merge()
@@ -116,7 +116,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Int
     public void flatMapCsStageShouldHandleFailedCompletionStages() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         CompletionStage<List<Object>> result = this.infiniteStream()
-                .on().termination((fail, can) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .onItem().produceCompletionStage(i -> {
                     CompletableFuture<Object> failed = new CompletableFuture<>();
                     failed.completeExceptionally(new QuietRuntimeException("failed"));
@@ -132,7 +132,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Int
     public void flatMapCsStageShouldFailIfNullIsReturned() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         CompletionStage<List<Object>> result = this.infiniteStream()
-                .on().termination((fail, can) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .onItem().produceCompletionStage(i -> CompletableFuture.completedFuture(null)).merge()
                 .collectItems().asList()
                 .subscribeAsCompletionStage();

--- a/implementation/src/test/java/tck/MultiFlatMapTckTest.java
+++ b/implementation/src/test/java/tck/MultiFlatMapTckTest.java
@@ -83,7 +83,7 @@ public class MultiFlatMapTckTest extends AbstractPublisherTck<Long> {
     public void flatMapStageShouldPropagateSubstreamExceptions() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         CompletionStage<List<Object>> result = infiniteStream()
-                .on().termination((fail, can) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .flatMap(f -> Multi.createFrom().failure(new QuietRuntimeException("failed")))
                 .collectItems().asList()
                 .subscribeAsCompletionStage();
@@ -110,8 +110,8 @@ public class MultiFlatMapTckTest extends AbstractPublisherTck<Long> {
         CompletableFuture<Void> outerCancelled = new CompletableFuture<>();
         CompletableFuture<Void> innerCancelled = new CompletableFuture<>();
         await(infiniteStream()
-                .on().termination((f, c) -> outerCancelled.complete(null))
-                .flatMap(i -> infiniteStream().on().termination((f, c) -> innerCancelled.complete(null)))
+                .on().termination(() -> outerCancelled.complete(null))
+                .flatMap(i -> infiniteStream().on().termination(() -> innerCancelled.complete(null)))
                 .transform().byTakingFirstItems(5)
                 .collectItems().asList()
                 .subscribeAsCompletionStage());

--- a/implementation/src/test/java/tck/MultiMapTckTest.java
+++ b/implementation/src/test/java/tck/MultiMapTckTest.java
@@ -29,7 +29,7 @@ public class MultiMapTckTest extends AbstractPublisherTck<Integer> {
     public void mapStageShouldHandleExceptions() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         CompletionStage<List<Object>> result = infiniteStream()
-                .on().termination((fail, can) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .map(foo -> {
                     throw new QuietRuntimeException("failed");
                 })
@@ -51,7 +51,7 @@ public class MultiMapTckTest extends AbstractPublisherTck<Integer> {
     public void mapStageShouldFailIfNullReturned() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         CompletionStage<List<Object>> result = infiniteStream()
-                .on().termination((fail, can) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .map(t -> null)
                 .collectItems().asList().subscribeAsCompletionStage();
         await(cancelled);

--- a/implementation/src/test/java/tck/MultiSkipItemsWhileTckTest.java
+++ b/implementation/src/test/java/tck/MultiSkipItemsWhileTckTest.java
@@ -30,7 +30,7 @@ public class MultiSkipItemsWhileTckTest extends AbstractPublisherTck<Long> {
     public void dropWhileStageShouldHandleErrors() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         CompletionStage<List<Integer>> result = infiniteStream()
-                .on().termination((f, c) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .transform().bySkippingItemsWhile(i -> {
                     throw new QuietRuntimeException("failed");
                 })
@@ -89,7 +89,7 @@ public class MultiSkipItemsWhileTckTest extends AbstractPublisherTck<Long> {
     public void dropWhileStageShouldPropagateCancel() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         infiniteStream()
-                .on().termination((f, c) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .transform().bySkippingItemsWhile(i -> i < 3)
                 .subscribe().withSubscriber(new MultiAssertSubscriber<>(10, true));
         await(cancelled);

--- a/implementation/src/test/java/tck/MultiTakeFirstItemsTckTest.java
+++ b/implementation/src/test/java/tck/MultiTakeFirstItemsTckTest.java
@@ -51,7 +51,7 @@ public class MultiTakeFirstItemsTckTest extends AbstractPublisherTck<Long> {
     public void limitStageShouldCancelUpStreamWhenDone() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         infiniteStream()
-                .on().termination((f, c) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .transform().byTakingFirstItems(1)
                 .collectItems().asList()
                 .subscribeAsCompletionStage();
@@ -80,7 +80,7 @@ public class MultiTakeFirstItemsTckTest extends AbstractPublisherTck<Long> {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         await(
                 infiniteStream()
-                        .on().termination((f, c) -> cancelled.complete(null))
+                        .on().termination(() -> cancelled.complete(null))
                         .onItem().invoke(i -> {
                             if (i == 100) {
                                 cancelled.completeExceptionally(new RuntimeException("Was not cancelled"));

--- a/implementation/src/test/java/tck/MultiTakeItemsWhileTckTest.java
+++ b/implementation/src/test/java/tck/MultiTakeItemsWhileTckTest.java
@@ -37,7 +37,7 @@ public class MultiTakeItemsWhileTckTest extends AbstractPublisherTck<Long> {
     public void takeWhileShouldCancelUpStreamWhenDone() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         infiniteStream()
-                .on().termination((f, c) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .transform().byTakingItemsWhile(t -> false)
                 .collectItems().asList()
                 .subscribeAsCompletionStage();
@@ -65,7 +65,7 @@ public class MultiTakeItemsWhileTckTest extends AbstractPublisherTck<Long> {
     public void takeWhileStageShouldHandleErrors() {
         CompletableFuture<Void> cancelled = new CompletableFuture<>();
         CompletionStage<List<Integer>> result = infiniteStream()
-                .on().termination((f, c) -> cancelled.complete(null))
+                .on().termination(() -> cancelled.complete(null))
                 .transform().byTakingItemsWhile(i -> {
                     throw new QuietRuntimeException("failed");
                 })

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/ConcatStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/ConcatStageFactory.java
@@ -44,7 +44,7 @@ public class ConcatStageFactory implements PublisherStageFactory<Stage.Concat> {
         public Multi<O> get() {
             CancellablePublisher<O> cancellable = new CancellablePublisher<>(engine.buildPublisher(second));
             return Multi.createBy().concatenating().streams(engine.buildPublisher(first), cancellable)
-                    .on().termination((err, cancelled) -> cancellable.cancelIfNotSubscribed());
+                    .on().termination(cancellable::cancelIfNotSubscribed);
         }
     }
 }

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/OnTerminateStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/OnTerminateStageFactory.java
@@ -21,6 +21,6 @@ public class OnTerminateStageFactory implements ProcessingStageFactory<Stage.OnT
     public <I, O> ProcessingStage<I, O> create(Engine engine, Stage.OnTerminate stage) {
         Runnable runnable = Objects.requireNonNull(stage).getAction();
         Objects.requireNonNull(runnable);
-        return source -> (Multi<O>) source.on().termination((t, e) -> runnable.run());
+        return source -> (Multi<O>) source.on().termination(runnable);
     }
 }


### PR DESCRIPTION
* Align the `subscribed` event name between Uni and Multi
* Provides `on().termination(...)` variant ignoring the event details (just getting a `Runnable`)