### PR TITLE
Catch Throwable instead of Exception

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
@@ -105,7 +105,7 @@ public class MultiCreate {
             CompletionStage<? extends T> stage;
             try {
                 stage = supplier.get();
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 emitter.fail(e);
                 return;
             }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiIfEmpty.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiIfEmpty.java
@@ -52,7 +52,7 @@ public class MultiIfEmpty<T> {
             Throwable throwable;
             try {
                 throwable = supplier.get();
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 emitter.fail(e);
                 return;
             }
@@ -154,7 +154,7 @@ public class MultiIfEmpty<T> {
         Iterable<? extends T> iterable;
         try {
             iterable = supplier.get();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             return Multi.createFrom().failure(e);
         }
         if (iterable == null) {

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItem.java
@@ -159,7 +159,7 @@ public class MultiOnItem<T> {
             CompletionStage<? extends O> stage;
             try {
                 stage = mapper.apply(res);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 emitter.fail(e);
                 return;
             }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniCreate.java
@@ -109,7 +109,7 @@ public class UniCreate {
         return Uni.createFrom().deferred(() -> {
             try {
                 invokeOnce(once, state, stateSupplier);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 return Uni.createFrom().failure(e);
             }
 
@@ -231,7 +231,7 @@ public class UniCreate {
         return Uni.createFrom().deferred(() -> {
             try {
                 invokeOnce(once, state, stateSupplier);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 return Uni.createFrom().failure(e);
             }
 
@@ -348,7 +348,7 @@ public class UniCreate {
         return Uni.createFrom().deferred(() -> {
             try {
                 invokeOnce(once, state, stateSupplier);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 return Uni.createFrom().failure(e);
             }
             S sharedState = state.get();
@@ -435,7 +435,7 @@ public class UniCreate {
         return Uni.createFrom().deferred(() -> {
             try {
                 invokeOnce(once, state, stateSupplier);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 return Uni.createFrom().failure(e);
             }
 
@@ -479,7 +479,7 @@ public class UniCreate {
             Throwable throwable;
             try {
                 throwable = actual.get();
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 emitter.fail(e);
                 return;
             }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNull.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNull.java
@@ -46,7 +46,7 @@ public class UniOnNull<T> {
             Throwable throwable;
             try {
                 throwable = supplier.get();
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 emitter.fail(e);
                 return;
             }
@@ -96,7 +96,7 @@ public class UniOnNull<T> {
                 Uni<? extends T> produced;
                 try {
                     produced = supplier.get();
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     return Uni.createFrom().failure(e);
                 }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/Predicates.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/Predicates.java
@@ -16,7 +16,7 @@ public class Predicates {
             boolean pass;
             try {
                 pass = predicate.test(failure);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 subscriber.onFailure(e);
                 return false;
             }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
@@ -77,7 +77,7 @@ public abstract class AbstractMulti<T> implements Multi<T> {
                 }
                 try {
                     subscriber.onNext(item);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     Subscription subscription = reference.getAndSet(CANCELLED);
                     if (subscription != null) {
                         subscription.cancel();

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiSwitchOnCompletion.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiSwitchOnCompletion.java
@@ -28,7 +28,7 @@ public class MultiSwitchOnCompletion<T> extends MultiOperator<T, T> {
             Publisher<? extends T> publisher;
             try {
                 publisher = supplier.get();
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 return Multi.createFrom().failure(e);
             }
             if (publisher == null) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiSwitchOnEmpty.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiSwitchOnEmpty.java
@@ -29,7 +29,7 @@ public class MultiSwitchOnEmpty<T> extends MultiOperator<T, T> {
             Publisher<? extends T> publisher;
             try {
                 publisher = supplier.get();
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 return Infrastructure.onMultiCreation(new FailedMulti<>(e));
             }
             if (publisher == null) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniAndCombination.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniAndCombination.java
@@ -118,7 +118,7 @@ public class UniAndCombination<I, O> extends UniOperator<I, O> {
                 O aggregated;
                 try {
                     aggregated = combinator.apply(items);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     subscriber.onFailure(e);
                     return;
                 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCallSubscribeOn.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCallSubscribeOn.java
@@ -24,7 +24,7 @@ public class UniCallSubscribeOn<I> extends UniOperator<I, I> {
         SubscribeOnUniSubscriber downstream = new SubscribeOnUniSubscriber(subscriber);
         try {
             executor.execute(downstream);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             subscriber.onSubscribe(CANCELLED);
             subscriber.onFailure(e);
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromCompletionStage.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromCompletionStage.java
@@ -32,7 +32,7 @@ public class UniCreateFromCompletionStage<O> extends UniOperator<Void, O> {
         CompletionStage<? extends O> stage;
         try {
             stage = supplier.get();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             propagateFailureEvent(subscriber, e);
             return;
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplier.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplier.java
@@ -22,7 +22,7 @@ public class UniCreateFromDeferredSupplier<T> extends UniOperator<Void, T> {
         Uni<? extends T> uni;
         try {
             uni = supplier.get();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             subscriber.onSubscribe(CANCELLED);
             subscriber.onFailure(e);
             return;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniFailOnTimeout.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniFailOnTimeout.java
@@ -96,7 +96,7 @@ public class UniFailOnTimeout<I> extends UniOperator<I, I> {
         Throwable throwable;
         try {
             throwable = supplier.get();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             subscriber.onFailure(e);
             return;
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniFlatMapCompletionStageOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniFlatMapCompletionStageOnItem.java
@@ -27,7 +27,7 @@ public class UniFlatMapCompletionStageOnItem<I, O> extends UniOperator<I, O> {
         CompletionStage<? extends O> outcome;
         try {
             outcome = mapper.apply(input);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             subscriber.onFailure(e);
             return;
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniFlatMapOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniFlatMapOnItem.java
@@ -30,7 +30,7 @@ public class UniFlatMapOnItem<I, O> extends UniOperator<I, O> {
             outcome = mapper.apply(input);
             // We cannot call onItem here, as if onItem would throw an exception
             // it would be caught and onFailure would be called. This would be illegal.
-        } catch (Exception e) {
+        } catch (Throwable e) {
             subscriber.onFailure(e);
             return;
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniMapOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniMapOnFailure.java
@@ -47,7 +47,7 @@ public class UniMapOnFailure<I, O> extends UniOperator<I, O> {
                         outcome = mapper.apply(failure);
                         // We cannot call onFailure here, as if onFailure would throw an exception
                         // it would be caught and onFailure would be called. This would be illegal.
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         subscriber.onFailure(e);
                         return;
                     }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniMapOnResult.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniMapOnResult.java
@@ -31,7 +31,7 @@ public class UniMapOnResult<I, O> extends UniOperator<I, O> {
                     outcome = mapper.apply(item);
                     // We cannot call onItem here, as if onItem would throw an exception
                     // it would be caught and onFailure would be called. This would be illegal.
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     subscriber.onFailure(e);
                     return;
                 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnSubscription.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnSubscription.java
@@ -23,7 +23,7 @@ public class UniOnSubscription<T> extends UniOperator<T, T> {
             public void onSubscribe(UniSubscription subscription) {
                 try {
                     consumer.accept(subscription);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     subscriber.onSubscribe(CANCELLED);
                     subscriber.onFailure(e);
                     return;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnTermination.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnTermination.java
@@ -31,7 +31,7 @@ public class UniOnTermination<T> extends UniOperator<T, T> {
                     public void onItem(T item) {
                         try {
                             callback.accept(item, null, false);
-                        } catch (Exception e) {
+                        } catch (Throwable e) {
                             subscriber.onFailure(e);
                             return;
                         }
@@ -42,7 +42,7 @@ public class UniOnTermination<T> extends UniOperator<T, T> {
                     public void onFailure(Throwable failure) {
                         try {
                             callback.accept(null, failure, false);
-                        } catch (Exception e) {
+                        } catch (Throwable e) {
                             subscriber.onFailure(new CompositeException(failure, e));
                             return;
                         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCollectorOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCollectorOp.java
@@ -35,7 +35,7 @@ public final class MultiCollectorOp<T, A, R> extends AbstractMultiOperator<T, R>
             initialValue = collector.supplier().get();
             accumulator = collector.accumulator();
             finisher = collector.finisher();
-        } catch (Exception ex) {
+        } catch (Throwable ex) {
             Subscriptions.fail(downstream, ex, upstream);
             return;
         }
@@ -75,7 +75,7 @@ public final class MultiCollectorOp<T, A, R> extends AbstractMultiOperator<T, R>
             if (upstream.get() != CANCELLED) {
                 try {
                     accumulator.accept(intermediate, item);
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     failAndCancel(ex);
                 }
             }
@@ -89,7 +89,7 @@ public final class MultiCollectorOp<T, A, R> extends AbstractMultiOperator<T, R>
 
                 try {
                     result = finisher.apply(intermediate);
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     downstream.onFailure(ex);
                     return;
                 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOnDurationOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOnDurationOp.java
@@ -97,7 +97,7 @@ public class MultiWindowOnDurationOp<T> extends AbstractMultiOperator<T, Multi<T
                 return scheduler
                         .scheduleAtFixedRate(new Tick(this), duration.toMillis(), duration.toMillis(),
                                 TimeUnit.MILLISECONDS);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 downstream.onFailure(e);
                 return TaskHolder.NONE;
             }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BufferItemMultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BufferItemMultiEmitter.java
@@ -106,7 +106,7 @@ public class BufferItemMultiEmitter<T> extends BaseMultiEmitter<T> {
 
                 try {
                     downstream.onItem(o);
-                } catch (Exception x) {
+                } catch (Throwable x) {
                     cancel();
                 }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/FailedMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/FailedMulti.java
@@ -35,7 +35,7 @@ public class FailedMulti<T> extends AbstractMulti<T> {
             } else {
                 Subscriptions.fail(actual, throwable);
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             Subscriptions.fail(actual, e);
         }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/StreamBasedMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/StreamBasedMulti.java
@@ -28,7 +28,7 @@ public class StreamBasedMulti<T> extends AbstractMulti<T> {
 
         try {
             stream = supplier.get();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             Subscriptions.fail(downstream, e);
             return;
         }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnResultMapToItem.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnResultMapToItem.java
@@ -65,6 +65,17 @@ public class UniOnResultMapToItem {
     }
 
     @Test
+    public void testWhenTheMapperThrowsAnError() {
+        UniAssertSubscriber<Object> ts = UniAssertSubscriber.create();
+
+        one.map(v -> {
+            throw new AssertionError("OH NO!");
+        }).subscribe().withSubscriber(ts);
+
+        ts.assertFailure(AssertionError.class, "OH NO!");
+    }
+
+    @Test
     public void testThatMapperCanReturnNull() {
         UniAssertSubscriber<Object> ts = UniAssertSubscriber.create();
 


### PR DESCRIPTION
The user code may throw other types of throwable and it needs to be propagated downstream.
Typically, in a test, the user may use assertions that would throw AssertionError. This should be propagated downstream.