### PR TITLE
Add requested and isCancelled method to the MultiEmitter.

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BaseMultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BaseMultiEmitter.java
@@ -26,6 +26,11 @@ abstract class BaseMultiEmitter<T>
     }
 
     @Override
+    public long requested() {
+        return requested.get();
+    }
+
+    @Override
     public void complete() {
         completion();
     }
@@ -42,7 +47,8 @@ abstract class BaseMultiEmitter<T>
         }
     }
 
-    protected boolean isCancelled() {
+    @Override
+    public boolean isCancelled() {
         return onTermination.get() == CLEARED;
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/SerializedMultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/SerializedMultiEmitter.java
@@ -150,4 +150,14 @@ public class SerializedMultiEmitter<T> implements MultiEmitter<T>, MultiSubscrib
         downstream.onTermination(onTermination);
         return this;
     }
+
+    @Override
+    public boolean isCancelled() {
+        return downstream.isCancelled();
+    }
+
+    @Override
+    public long requested() {
+        return downstream.requested();
+    }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/MultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/MultiEmitter.java
@@ -52,4 +52,15 @@ public interface MultiEmitter<T> {
      */
     MultiEmitter<T> onTermination(Runnable onTermination);
 
+    /**
+     * @return {@code true} if the downstream cancelled the stream or the emitter was terminated (with a completion
+     *         or failure events).
+     */
+    boolean isCancelled();
+
+    /**
+     * @return the current outstanding request amount.
+     */
+    long requested();
+
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiBroadcastTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiBroadcastTest.java
@@ -129,7 +129,7 @@ public class MultiBroadcastTest {
         assertThat(cancelled).isFalse();
         s1.cancel();
         assertThat(cancelled).isFalse();
-
+        assertThat(processor.isCancelled()).isFalse();
         MultiAssertSubscriber<Integer> s3 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
         processor.emit(23);
         processor.complete();
@@ -191,8 +191,10 @@ public class MultiBroadcastTest {
 
         s2.cancel();
         assertThat(cancelled).isFalse();
+        assertThat(processor.isCancelled()).isFalse();
         s1.cancel();
         assertThat(cancelled).isTrue();
+        assertThat(processor.isCancelled()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
These methods are required to implement the Reactive Messaging Emitter interface (same name, not the same purpose).