### PR TITLE
Collector finisher can return `null`

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCollectorOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCollectorOp.java
@@ -95,7 +95,9 @@ public final class MultiCollectorOp<T, A, R> extends AbstractMultiOperator<T, R>
                 }
 
                 intermediate = null;
-                downstream.onItem(result);
+                if (result != null) {
+                    downstream.onItem(result);
+                }
                 downstream.onCompletion();
             }
         }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCollectTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCollectTest.java
@@ -4,11 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import org.testng.annotations.Test;
@@ -187,9 +189,20 @@ public class MultiCollectTest {
                 .subscribe().withSubscriber(new UniAssertSubscriber<>()).assertCompletedSuccessfully().assertItem(10);
     }
 
+    @Test
+    public void testWithFinisherReturningNull() {
+        List<String> list = new ArrayList<>();
+        Multi.createFrom().items("a", "b", "c")
+                .map(String::toUpperCase)
+                .collectItems().with(Collector.of(() -> null, (n, t) -> list.add(t), (X, y) -> null, x -> null))
+                .await().indefinitely();
+        assertThat(list).containsExactly("A", "B", "C");
+    }
+
     static class Person {
 
         private final String firstName;
+
         private final long id;
 
         Person(String firstName, long id) {
@@ -214,6 +227,7 @@ public class MultiCollectTest {
         public int hashCode() {
             return Objects.hash(firstName, id);
         }
+
     }
 
 }


### PR DESCRIPTION
In this case, `null` should be ignored and the stream completed.