### PR TITLE
Unchecked functions/consumers/suppliers helpers

### DIFF
--- a/documentation/src/main/docs/faq.adoc
+++ b/documentation/src/main/docs/faq.adoc
@@ -9,6 +9,13 @@ To transform items synchronously use the `apply` operators:
 include::../../../src/test/java/snippets/HowToTransformTest.java[tags=sync]
 ----
 
+If your operation throws a _checked exception_, you can use the `io.smallrye.mutiny.unchecked.Unchecked` wrappers to avoid having to catch the exception in the _callback_.
+
+[source,java,indent=0]
+----
+include::../../../src/test/java/snippets/HowToTransformTest.java[tags=sync-unchecked]
+----
+
 You can also transform items asynchronously using the `produceUni` / `produceCompletionStage` operators:
 
 [source,java,indent=0]
@@ -22,6 +29,17 @@ If you need to generate a sequence of items use, `producePublisher`:
 ----
 include::../../../src/test/java/snippets/HowToTransformTest.java[tags=multi]
 ----
+
+[NOTE]
+.Unchecked
+====
+Mutiny provides a set of utility classes to handle functions / consumers / suppliers that throw _checked_ exceptions.
+`io.smallrye.mutiny.unchecked.Unchecked` wraps code throwing checked exceptions into Java functions/suppliers/consumers.
+The `try/catch` is done for you and if an exception occurs, it gets rethrown automatically.
+
+You can add the following import statement to simplify the usage of the provided methods:
+`import static io.smallrye.mutiny.unchecked.Unchecked.*;`
+====
 
 === How do I filter/select items?
 

--- a/documentation/src/test/java/snippets/HowToTransformTest.java
+++ b/documentation/src/test/java/snippets/HowToTransformTest.java
@@ -1,14 +1,15 @@
 package snippets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.junit.Test;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.Test;
-
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
+import static io.smallrye.mutiny.unchecked.Unchecked.function;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HowToTransformTest {
 
@@ -25,6 +26,28 @@ public class HowToTransformTest {
                 .onItem().apply(s -> s.toUpperCase())
                 .collectItems().asList().await().indefinitely();
         // end::sync[]
+
+        assertThat(result1).isEqualTo("HELLO");
+        assertThat(result2).containsExactly("HELLO", "WORLD");
+    }
+
+    private String operationThrowingException(String s) throws IOException {
+        return s.toUpperCase();
+    }
+
+    @Test
+    public void transformSyncUnchecked() {
+        Uni<String> uni = Uni.createFrom().item("hello");
+        Multi<String> multi = Multi.createFrom().items("hello", "world");
+
+        // tag::sync-unchecked[]
+        String result1 = uni
+                .onItem().apply(function(this::operationThrowingException))
+                .await().indefinitely();
+        List<String> result2 = multi
+                .onItem().apply(function(this::operationThrowingException))
+                .collectItems().asList().await().indefinitely();
+        // end::sync-unchecked[]
 
         assertThat(result1).isEqualTo("HELLO");
         assertThat(result2).containsExactly("HELLO", "WORLD");

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/Unchecked.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/Unchecked.java
@@ -1,0 +1,147 @@
+package io.smallrye.mutiny.unchecked;
+
+import java.util.function.*;
+
+/**
+ * Provides wrapper to handle functions / consumers / suppliers that throw checked exceptions.
+ */
+public class Unchecked {
+
+    private Unchecked() {
+        // avoid direct instantiation.
+    }
+
+    /**
+     * Transforms the given bi-function into a version that can throw exceptions.
+     *
+     * @param function the function
+     * @param <T> the type of the first argument to the function
+     * @param <U> the type of the second argument to the function
+     * @param <R> the type of the result of the function
+     * @return the new {@link UncheckedBiFunction}
+     */
+    public static <T, U, R> UncheckedBiFunction<T, U, R> unchecked(BiFunction<T, U, R> function) {
+        return UncheckedBiFunction.from(function);
+    }
+
+    /**
+     * Transforms the given function into a version that can throw exceptions.
+     *
+     * @param function the function
+     * @param <T> the type of the argument to the function
+     * @param <R> the type of the result of the function
+     * @return the new {@link UncheckedFunction}
+     */
+    public static <T, R> UncheckedFunction<T, R> unchecked(Function<T, R> function) {
+        return UncheckedFunction.from(function);
+    }
+
+    /**
+     * Transforms the given consumer into a version that can throw exceptions.
+     *
+     * @param consumer the consumer
+     * @param <T> the type of the input to the operation
+     * @return the new {@link UncheckedConsumer}
+     */
+    public static <T> UncheckedConsumer<T> unchecked(Consumer<T> consumer) {
+        return UncheckedConsumer.from(consumer);
+    }
+
+    /**
+     * Transforms the given bi-consumer into a version that can throw exceptions.
+     *
+     * @param consumer the consumer
+     * @param <T> the type of the first argument to the operation
+     * @param <U> the type of the second argument to the operation
+     * @return the new {@link UncheckedBiConsumer}
+     */
+    public static <T, U> UncheckedBiConsumer<T, U> unchecked(BiConsumer<T, U> consumer) {
+        return UncheckedBiConsumer.from(consumer);
+    }
+
+    /**
+     * Transforms the given supplier into a version that can throw exceptions.
+     *
+     * @param supplier the supplier
+     * @param <T> the type of items supplied by this supplier
+     * @return the new {@link UncheckedSupplier}
+     */
+    public static <T> UncheckedSupplier<T> unchecked(Supplier<T> supplier) {
+        return UncheckedSupplier.from(supplier);
+    }
+
+    /**
+     * Transforms the given (unchecked) function into a regular function.
+     * If the operation throws an exception, this exception is rethrown, wrapped into a {@link RuntimeException} if
+     * needed.
+     *
+     * @param function the function
+     * @param <T> the type of the argument to the function
+     * @param <R> the type of the result of the function
+     * @return a {@link Function} executing the {@link UncheckedFunction}. If the operation throws an exception,
+     *         the exception is rethrown, wrapped in a {@link RuntimeException} if needed.
+     */
+    public static <T, R> Function<T, R> function(UncheckedFunction<T, R> function) {
+        return function.toFunction();
+    }
+
+    /**
+     * Transforms the given (unchecked) bi-function into a regular bi-function.
+     * If the operation throws an exception, this exception is rethrown, wrapped into a {@link RuntimeException} if
+     * needed.
+     *
+     * @param function the function
+     * @param <T> the type of the first argument to the function
+     * @param <U> the type of the second argument to the function
+     * @param <R> the type of the result of the function
+     * @return a {@link BiFunction} executing this {@link UncheckedBiFunction}. If the operation throws an exception,
+     *         the exception is rethrown, wrapped in a {@link RuntimeException} if needed.
+     */
+    public static <T, U, R> BiFunction<T, U, R> function(UncheckedBiFunction<T, U, R> function) {
+        return function.toBiFunction();
+    }
+
+    /**
+     * Transforms the given (unchecked) bi-consumer into a regular bi-consumer.
+     * If the operation throws an exception, this exception is rethrown, wrapped into a {@link RuntimeException} if
+     * needed.
+     *
+     * @param consumer the consumer
+     * @param <T> the type of the first argument to the operation
+     * @param <U> the type of the second argument to the operation
+     * @return a {@link BiConsumer} executing this {@link UncheckedBiConsumer}. If the operation throws an exception,
+     *         the exception is rethrown, wrapped in a {@link RuntimeException} if needed.
+     */
+    public static <T, U> BiConsumer<T, U> consumer(UncheckedBiConsumer<T, U> consumer) {
+        return consumer.toBiConsumer();
+    }
+
+    /**
+     * Transforms the given (unchecked) consumer into a regular consumer.
+     * If the operation throws an exception, this exception is rethrown, wrapped into a {@link RuntimeException} if
+     * needed.
+     *
+     * @param consumer the consumer
+     * @param <T> the type of the first argument to the operation
+     * @return a {@link Consumer} executing this {@link UncheckedConsumer}. If the operation throws an exception,
+     *         the exception is rethrown, wrapped in a {@link RuntimeException} if needed.
+     */
+    public static <T> Consumer<T> consumer(UncheckedConsumer<T> consumer) {
+        return consumer.toConsumer();
+    }
+
+    /**
+     * Transforms the given (unchecked) supplier into a regular supplier.
+     * If the operation throws an exception, this exception is rethrown, wrapped into a {@link RuntimeException} if
+     * needed.
+     *
+     * @param supplier the supplier
+     * @param <T> the type of items supplied by this supplier
+     * @return a {@link Supplier} executing this {@link UncheckedSupplier}. If the operation throws an exception,
+     *         the exception is rethrown, wrapped in a {@link RuntimeException} if needed.
+     */
+    public static <T> Supplier<T> supplier(UncheckedSupplier<T> supplier) {
+        return supplier.toSupplier();
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedBiConsumer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedBiConsumer.java
@@ -1,0 +1,75 @@
+package io.smallrye.mutiny.unchecked;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+/**
+ * Represents an operation that accepts two input arguments and returns no
+ * result. This is the two-arity specialization of {@link UncheckedConsumer}.
+ * <p>
+ * The operation can throw {@link Exception Exceptions}.
+ *
+ * @param <T> the type of the first argument to the operation
+ * @param <U> the type of the second argument to the operation
+ */
+@FunctionalInterface
+public interface UncheckedBiConsumer<T, U> {
+
+    /**
+     * Creates a {@link UncheckedBiConsumer} from an existing {@link BiConsumer}
+     *
+     * @param consumer the consumer
+     * @param <T> the type of the first argument to the operation
+     * @param <U> the type of the second argument to the operation
+     * @return the created {@link UncheckedBiConsumer}
+     */
+    static <T, U> UncheckedBiConsumer<T, U> from(BiConsumer<T, U> consumer) {
+        return consumer::accept;
+    }
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param t the first input argument
+     * @param u the second input argument
+     * @throws Exception if something <em>bad</em> happen during the execution
+     */
+    void accept(T t, U u) throws Exception;
+
+    /**
+     * Returns a composed {@code UncheckedBiConsumer} that performs, in sequence, this
+     * operation followed by the {@code after} operation. If performing either
+     * operation throws an exception, it is relayed to the caller of the
+     * composed operation. If performing this operation throws an exception,
+     * the {@code after} operation will not be performed.
+     *
+     * @param after the operation to perform after this operation
+     * @return a composed {@code UncheckedBiConsumer} that performs in sequence this
+     *         operation followed by the {@code after} operation
+     * @throws NullPointerException if {@code after} is null
+     */
+    default UncheckedBiConsumer<T, U> andThen(UncheckedBiConsumer<? super T, ? super U> after) {
+        Objects.requireNonNull(after);
+
+        return (l, r) -> {
+            accept(l, r);
+            after.accept(l, r);
+        };
+    }
+
+    /**
+     * @return the {@link BiConsumer} associated with this {@code UncheckedBiConsumer}. If the operation throws an
+     *         exception, the exception is rethrown, wrapped in a {@link RuntimeException} if needed.
+     */
+    default BiConsumer<T, U> toBiConsumer() {
+        return (x, y) -> {
+            try {
+                accept(x, y);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedBiFunction.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedBiFunction.java
@@ -1,0 +1,75 @@
+package io.smallrye.mutiny.unchecked;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Represents a function that accepts two arguments and produces a result.
+ * This is the two-arity specialization of {@link UncheckedFunction}.
+ * <p>
+ * The operation can throw {@link Exception Exceptions}.
+ *
+ * @param <T> the type of the first argument to the function
+ * @param <U> the type of the second argument to the function
+ * @param <R> the type of the result of the function
+ */
+@FunctionalInterface
+public interface UncheckedBiFunction<T, U, R> {
+
+    /**
+     * Creates a {@link UncheckedBiFunction} from an existing {@link BiFunction}.
+     *
+     * @param function the function
+     * @param <T> the type of the first argument to the function
+     * @param <U> the type of the second argument to the function
+     * @param <R> the type of the result of the function
+     * @return the created {@link UncheckedBiFunction}
+     */
+    static <T, U, R> UncheckedBiFunction<T, U, R> from(BiFunction<T, U, R> function) {
+        return function::apply;
+    }
+
+    /**
+     * @return a {@link Function} executing this {@code UncheckedFunction}.If the operation throws an exception, the
+     *         exception is rethrown, wrapped in a {@link RuntimeException} if needed.
+     */
+    default BiFunction<T, U, R> toBiFunction() {
+        return (t, u) -> {
+            try {
+                return apply(t, u);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t the first function argument
+     * @param u the second function argument
+     * @return the function result
+     */
+    R apply(T t, U u) throws Exception;
+
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V> the type of output of the {@code after} function, and of the
+     *        composed function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     *         applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V> UncheckedBiFunction<T, U, V> andThen(UncheckedFunction<? super R, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return (T t, U u) -> after.apply(apply(t, u));
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedConsumer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedConsumer.java
@@ -1,0 +1,70 @@
+package io.smallrye.mutiny.unchecked;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Represents an operation that accepts a single input argument and returns no
+ * result.
+ * <p>
+ * The operation can throw {@link Exception Exceptions}.
+ *
+ * @param <T> the type of the input to the operation
+ */
+@FunctionalInterface
+public interface UncheckedConsumer<T> {
+
+    /**
+     * Creates a new {@link UncheckedConsumer} from an existing {@link Consumer}
+     *
+     * @param consumer the consumer
+     * @param <T> the type of the input to the operation
+     * @return the created {@code UncheckedConsumer}
+     */
+    static <T> UncheckedConsumer<T> from(Consumer<T> consumer) {
+        return consumer::accept;
+    }
+
+    /**
+     * Performs this operation on the given argument.
+     *
+     * @param t the input argument
+     */
+    void accept(T t) throws Exception;
+
+    /**
+     * Returns a composed {@code UncheckedConsumer} that performs, in sequence, this
+     * operation followed by the {@code after} operation. If performing either
+     * operation throws an exception, it is relayed to the caller of the
+     * composed operation. If performing this operation throws an exception,
+     * the {@code after} operation will not be performed.
+     *
+     * @param after the operation to perform after this operation
+     * @return a composed {@code UncheckedConsumer} that performs in sequence this
+     *         operation followed by the {@code after} operation
+     * @throws NullPointerException if {@code after} is null
+     */
+    default UncheckedConsumer<T> andThen(UncheckedConsumer<? super T> after) {
+        Objects.requireNonNull(after);
+        return (T t) -> {
+            accept(t);
+            after.accept(t);
+        };
+    }
+
+    /**
+     * @return the {@link Consumer} executing the operation associated to this {@link UncheckedConsumer}. If the
+     *         operation throws an exception, the exception is rethrown, wrapped in a {@link RuntimeException} if needed.
+     */
+    default Consumer<T> toConsumer() {
+        return x -> {
+            try {
+                accept(x);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedFunction.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedFunction.java
@@ -1,0 +1,90 @@
+package io.smallrye.mutiny.unchecked;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Represents a function that accepts one argument and produces a result.
+ * <p>
+ * The operation can throw {@link Exception Exceptions}.
+ *
+ * @param <T> the type of the input to the function
+ * @param <R> the type of the result of the function
+ */
+@FunctionalInterface
+public interface UncheckedFunction<T, R> {
+
+    /**
+     * Creates a {@link UncheckedBiConsumer} from an existing {@link Function}
+     *
+     * @param function the function
+     * @param <T> the type of the input to the function
+     * @param <R> the type of the result of the function
+     * @return the created {@link UncheckedBiConsumer}
+     */
+    static <T, R> UncheckedFunction<T, R> from(Function<T, R> function) {
+        return function::apply;
+    }
+
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param t the function argument
+     * @return the function result
+     */
+    R apply(T t) throws Exception;
+
+    /**
+     * @return a {@link Function} executing this {@code UncheckedFunction}. If the operation throws an exception,
+     *         the exception is rethrown, wrapped in a {@link RuntimeException} if needed.
+     */
+    default Function<T, R> toFunction() {
+        return t -> {
+            try {
+                return apply(t);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    /**
+     * Returns a composed function that first applies the {@code before}
+     * function to its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V> the type of input to the {@code before} function, and to the
+     *        composed function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before}
+     *         function and then applies this function
+     * @throws NullPointerException if before is null
+     * @see #andThen(UncheckedFunction)
+     */
+    default <V> UncheckedFunction<V, R> compose(UncheckedFunction<? super V, ? extends T> before) {
+        Objects.requireNonNull(before);
+        return (V v) -> apply(before.apply(v));
+    }
+
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V> the type of output of the {@code after} function, and of the
+     *        composed function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     *         applies the {@code after} function
+     * @throws NullPointerException if after is null
+     * @see #compose(UncheckedFunction)
+     */
+    default <V> UncheckedFunction<T, V> andThen(UncheckedFunction<? super R, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return (T t) -> after.apply(apply(t));
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedSupplier.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedSupplier.java
@@ -1,0 +1,49 @@
+package io.smallrye.mutiny.unchecked;
+
+import java.util.function.Supplier;
+
+/**
+ * Represents a supplier of items.
+ * <p>
+ * The supplier can throw {@link Exception Exceptions}.
+ *
+ * @param <T> the type of items supplied by this supplier
+ */
+@FunctionalInterface
+public interface UncheckedSupplier<T> {
+
+    /**
+     * Creates a new {@link UncheckedSupplier} from an existing {@link Supplier}
+     *
+     * @param supplier the supplier
+     * @param <T> the type of items supplied by this supplier
+     * @return the new {@link UncheckedSupplier}
+     */
+    static <T> UncheckedSupplier<T> from(Supplier<T> supplier) {
+        return supplier::get;
+    }
+
+    /**
+     * Gets an item.
+     *
+     * @return an item
+     */
+    T get() throws Exception;
+
+    /**
+     * @return the {@link Supplier} getting the item produced by this {@link UncheckedSupplier}. If an exception is
+     *         thrown during the production, this exception is rethrown, wrapped into a {@link RuntimeException} if needed.
+     */
+    default Supplier<T> toSupplier() {
+        return () -> {
+            try {
+                return get();
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedBiFunctionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedBiFunctionTest.java
@@ -1,0 +1,52 @@
+package io.smallrye.mutiny.unchecked;
+
+import static io.smallrye.mutiny.unchecked.Unchecked.function;
+import static io.smallrye.mutiny.unchecked.Unchecked.unchecked;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.function.BiFunction;
+
+import org.testng.annotations.Test;
+
+public class UncheckedBiFunctionTest {
+
+    @Test
+    public void testUncheckedBiFunction() throws Exception {
+        BiFunction<Integer, Integer, Integer> sum = function(Integer::sum);
+        BiFunction<Integer, Integer, Integer> failIo = function((i, j) -> {
+            throw new IOException("boom");
+        });
+        BiFunction<Integer, Integer, Integer> failArithmetic = function((i, j) -> {
+            throw new ArithmeticException("boom");
+        });
+
+        assertThat(sum.apply(1, 1)).isEqualTo(2);
+
+        assertThatThrownBy(() -> failIo.apply(1, 2))
+                .isInstanceOf(RuntimeException.class).hasCauseInstanceOf(IOException.class)
+                .hasMessageContaining("boom");
+
+        assertThatThrownBy(() -> failArithmetic.apply(1, 2))
+                .isInstanceOf(ArithmeticException.class).hasMessageContaining("boom");
+
+        assertThat(unchecked(sum).andThen(i -> i * 2).apply(1, 2)).isEqualTo(6);
+        assertThat(unchecked(sum).andThen(this::validate).apply(1, 2)).isEqualTo(3);
+
+        assertThatThrownBy(() -> unchecked(sum).andThen(this::validate).apply(0, 0)).isInstanceOf(IOException.class)
+                .hasMessageContaining("boom");
+
+        assertThatThrownBy(() -> unchecked(sum).andThen(this::validate).toBiFunction().apply(0, 0))
+                .hasCauseInstanceOf(IOException.class).hasMessageContaining("boom");
+    }
+
+    private int validate(int i) throws IOException {
+        if (i != 0) {
+            return i;
+        } else {
+            throw new IOException("boom");
+        }
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedConsumerTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedConsumerTest.java
@@ -1,0 +1,91 @@
+package io.smallrye.mutiny.unchecked;
+
+import static io.smallrye.mutiny.unchecked.Unchecked.consumer;
+import static io.smallrye.mutiny.unchecked.Unchecked.unchecked;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.Multi;
+
+public class UncheckedConsumerTest {
+
+    @Test
+    public void testUncheckedConsumer() {
+        AtomicInteger result = new AtomicInteger(-1);
+        Consumer<Integer> consumer = consumer(result::set);
+        Consumer<Integer> consumerFailingWithIo = consumer(x -> {
+            throw new IOException("boom");
+        });
+        Consumer<Integer> consumerFailingWithArithmetic = consumer(x -> {
+            throw new ArithmeticException("boom");
+        });
+        consumer.accept(1);
+        assertThat(result).hasValue(1);
+        assertThatThrownBy(() -> consumerFailingWithIo.accept(2))
+                .hasCauseInstanceOf(IOException.class).hasMessageContaining("boom");
+        assertThatThrownBy(() -> consumerFailingWithArithmetic.accept(3))
+                .isInstanceOf(ArithmeticException.class).hasMessageContaining("boom");
+    }
+
+    @Test
+    public void testUncheckedBiConsumer() {
+        AtomicInteger result = new AtomicInteger(-1);
+        BiConsumer<Integer, Integer> consumer = consumer((i, j) -> result.set(i + j));
+        BiConsumer<Integer, Integer> consumerFailingWithIo = consumer((x, y) -> {
+            throw new IOException("boom");
+        });
+        BiConsumer<Integer, Integer> consumerFailingWithArithmetic = consumer((x, y) -> {
+            throw new ArithmeticException("boom");
+        });
+        consumer.accept(1, 1);
+        assertThat(result).hasValue(2);
+        assertThatThrownBy(() -> consumerFailingWithIo.accept(2, 2))
+                .hasCauseInstanceOf(IOException.class).hasMessageContaining("boom");
+        assertThatThrownBy(() -> consumerFailingWithArithmetic.accept(3, 3))
+                .isInstanceOf(ArithmeticException.class).hasMessageContaining("boom");
+    }
+
+    @Test
+    public void testChaining() throws Exception {
+        unchecked(x -> {
+        }).andThen(i -> {
+        }).accept(1);
+        unchecked((x, y) -> {
+        }).andThen((i, j) -> {
+        }).accept(1, 2);
+
+        assertThatThrownBy(() -> unchecked(x -> {
+        }).andThen(i -> {
+            throw new IllegalStateException("boom");
+        }).accept(1)).isInstanceOf(IllegalStateException.class).hasMessageContaining("boom");
+
+        assertThatThrownBy(() -> unchecked((x, y) -> {
+        }).andThen((i, j) -> {
+            throw new IllegalStateException("boom");
+        }).accept(1, 2)).isInstanceOf(IllegalStateException.class).hasMessageContaining("boom");
+
+    }
+
+    @Test
+    public void testSubscription() {
+        AtomicReference<String> reference = new AtomicReference<>();
+        Multi.createFrom().item("hey").subscribe().with(consumer(s -> {
+            TimeUnit.MILLISECONDS.sleep(100);
+            reference.set(s);
+        }));
+
+        await().until(() -> reference.get() != null);
+        assertThat(reference).hasValue("hey");
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedFunctionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedFunctionTest.java
@@ -1,0 +1,95 @@
+package io.smallrye.mutiny.unchecked;
+
+import static io.smallrye.mutiny.unchecked.Unchecked.function;
+import static io.smallrye.mutiny.unchecked.Unchecked.unchecked;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.Uni;
+
+public class UncheckedFunctionTest {
+
+    @Test
+    public void testWithMap() {
+        Integer res = Uni.createFrom().item(1)
+                .map(function(i -> {
+                    if (i == 0) {
+                        throw new IOException("boom");
+                    }
+                    return i;
+                })).await().indefinitely();
+
+        assertThat(res).isEqualTo(1);
+
+        assertThatThrownBy(() -> Uni.createFrom().item(0)
+                .map(function(i -> {
+                    if (i == 0) {
+                        throw new IOException("boom");
+                    }
+                    return i;
+                })).await().indefinitely()).isInstanceOf(RuntimeException.class).hasCauseInstanceOf(IOException.class)
+                        .hasMessageContaining("boom");
+
+        assertThatThrownBy(() -> Uni.createFrom().item(0)
+                .map(function(i -> {
+                    if (i == 0) {
+                        throw new ArithmeticException("boom");
+                    }
+                    return i;
+                })).await().indefinitely()).isInstanceOf(ArithmeticException.class).hasMessageContaining("boom");
+    }
+
+    interface Reader {
+        int read(int i) throws IOException;
+    }
+
+    interface UniReader {
+        Uni<Integer> read(int i) throws IOException;
+    }
+
+    @Test
+    public void testWithInterfaceMap() {
+        Reader reader = i -> i;
+        int res = Uni.createFrom().item(1)
+                .map(function(reader::read))
+                .await().indefinitely();
+        assertThat(res).isEqualTo(1);
+    }
+
+    @Test
+    public void testWithFlatMap() {
+        UniReader reader = i -> Uni.createFrom().item(i);
+        int res = Uni.createFrom().item(1)
+                .flatMap(function(reader::read))
+                .await().indefinitely();
+        assertThat(res).isEqualTo(1);
+    }
+
+    private int validate(int i) throws IOException {
+        if (i != 0) {
+            return i;
+        } else {
+            throw new IOException("boom");
+        }
+    }
+
+    @Test
+    public void testChaining() {
+        UncheckedFunction<Integer, String> function = unchecked(i -> (String) i)
+                .andThen(Integer::valueOf)
+                .andThen(this::validate)
+                .andThen(i -> Integer.toString(i))
+                .compose(x -> x.toString() + x.toString());
+
+        String res = function.toFunction().apply(1);
+        assertThat(res).isEqualTo("11");
+
+        assertThatThrownBy(() -> function.toFunction().apply(0))
+                .hasCauseInstanceOf(IOException.class);
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedSupplierTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedSupplierTest.java
@@ -1,0 +1,41 @@
+package io.smallrye.mutiny.unchecked;
+
+import static io.smallrye.mutiny.unchecked.Unchecked.supplier;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.Uni;
+
+public class UncheckedSupplierTest {
+
+    @Test
+    public void testUncheckedSupplier() {
+        Supplier<Integer> supplier = supplier(() -> 1);
+        Supplier<Integer> supplierFailingWithIo = supplier(() -> {
+            throw new IOException("boom");
+        });
+        Supplier<Integer> supplierFailingWithArithmetic = supplier(() -> {
+            throw new ArithmeticException("boom");
+        });
+
+        assertThat(supplier.get()).isEqualTo(1);
+        assertThatThrownBy(supplierFailingWithIo::get)
+                .hasCauseInstanceOf(IOException.class).hasMessageContaining("boom");
+        assertThatThrownBy(supplierFailingWithArithmetic::get)
+                .isInstanceOf(ArithmeticException.class).hasMessageContaining("boom");
+    }
+
+    @Test
+    public void testCreatingAUni() {
+        assertThat(Uni.createFrom().item(supplier(() -> 1)).await().indefinitely()).isEqualTo(1);
+        assertThatThrownBy(() -> Uni.createFrom().item(supplier(() -> {
+            throw new IOException("boom");
+        })).await().indefinitely()).hasCauseInstanceOf(IOException.class).hasMessageContaining("boom");
+    }
+
+}


### PR DESCRIPTION
This PR provides a set of helper classes to ease the integration of operation throwing checked exceptions. `java.util.functions` classes require the code to not throw checked exception. So it can be inconvenient to wrap the code in a try/catch construct. These helpers avoid that by doing the wrapping automatically.

Fix #99. 