### PR TITLE
Rename subscribeOn to runSubscriptionOn

### DIFF
--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/MultiContextPropagationTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/MultiContextPropagationTest.java
@@ -52,7 +52,7 @@ public class MultiContextPropagationTest {
                     assertThat(ctx).isEqualTo(MyContext.get());
                     return 2;
                 })
-                .subscribeOn(executor)
+                .runSubscriptionOn(executor)
                 .map(r -> {
                     assertThat(ctx).isEqualTo(MyContext.get());
                     return r;
@@ -81,7 +81,7 @@ public class MultiContextPropagationTest {
                     assertThat(ctx).isEqualTo(MyContext.get());
                     return 2;
                 })
-                .subscribeOn(executor)
+                .runSubscriptionOn(executor)
                 .map(r -> {
                     assertThat(ctx).isEqualTo(MyContext.get());
                     return r;
@@ -109,7 +109,7 @@ public class MultiContextPropagationTest {
                     assertThat(ctx).isEqualTo(MyContext.get());
                     return 2;
                 })
-                .subscribeOn(executor)
+                .runSubscriptionOn(executor)
                 .map(r -> {
                     assertThat(ctx).isEqualTo(MyContext.get());
                     return r;

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/UniContextPropagationTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/UniContextPropagationTest.java
@@ -48,7 +48,7 @@ public class UniContextPropagationTest {
                     assertThat(ctx).isEqualTo(MyContext.get());
                     return 2;
                 })
-                .subscribeOn(executor)
+                .runSubscriptionOn(executor)
                 .map(r -> {
                     assertThat(ctx).isEqualTo(MyContext.get());
                     return r;

--- a/documentation/src/main/docs/faq.adoc
+++ b/documentation/src/main/docs/faq.adoc
@@ -311,20 +311,55 @@ include::../../../src/test/java/snippets/UniBlockingTest.java[tags=code]
 ----
 
 Create an `Uni` that will supply the item using a blocking call, here the `invokeRemoteServiceUsingBlockingIO` method.
-To avoid blocking the subscriber, use `subscribeOn` which switch the thread and so call `invokeRemoteServiceUsingBlockingIO` on another thread.
+To avoid blocking the subscriber, use `runSubscriptionOn` which switch the thread and so call `invokeRemoteServiceUsingBlockingIO` on another thread.
 Here we pass the default worker thread pool, but you can use your own executor.
 
-Note that `subscribeOn` does not subscribe to the `Uni`.
+Note that `runSubscriptionOn` does not subscribe to the `Uni`.
 It specifies the `executor` to use when a subscribe call happens.
 
-Using `subscribeOn` works when the blocking operation happens at subscription time.
+Using `runSubscriptionOn` works when the blocking operation happens at subscription time.
 But, when you are dealing with `Multi` and need to execute a blocking operation for each item, you need `emitOn`.
 
-While `subscribeOn` runs the subscription on the given executor, `emitOn` configures the executor used to propagate downstream the `item`, `failure` and `completion` events:
+While `runSubscriptionOn` runs the subscription on the given executor, `emitOn` configures the executor used to propagate downstream the `item`, `failure` and `completion` events:
 
 [source,java,indent=0]
 ----
 include::../../../src/test/java/snippets/UniBlockingTest.java[tags=code-emitOn]
+----
+
+=== emitOn vs. runSubscriptionOn
+
+The `emitOn` and `runSubscriptionOn` are 2 operators influencing on which threads the event are dispatched.
+However, they target different types of events and different directions.
+
+`emitOn` takes events coming from upstream (items, completion, failure) and replays them downstream on a thread from the given executor.
+Consequently, it affects where the subsequent operators execute (until another `emitOn` is used):
+
+[source,java,indent=0]
+----
+include::../../../src/test/java/snippets/RunSubscriptionOnTest.java[tags=emitOn]
+----
+
+The previous code produces the following sequence:
+
+[plantuml,align=center]
+----
+include::plantuml/emitOn-sequence.puml[]
+----
+
+`runSubscriptionOn` applies to the subscription process.
+It requests the upstream to run its subscription (call of the `subscribe` method on its own upstream) on a thread from the given executor:
+
+[source,java,indent=0]
+----
+include::../../../src/test/java/snippets/RunSubscriptionOnTest.java[tags=runSubscriptionOn]
+----
+
+So, if we consider the previous code snippet, it produces the following sequence:
+
+[plantuml,align=center]
+----
+include::plantuml/runSubscriptionOn-sequence.puml[]
 ----
 
 === How can I use a Unicast Processor

--- a/documentation/src/main/docs/plantuml/emitOn-sequence.puml
+++ b/documentation/src/main/docs/plantuml/emitOn-sequence.puml
@@ -1,0 +1,17 @@
+@startuml
+
+skinparam dpi 300
+skinparam useBetaStyle true
+skinparam handwritten true
+skinparam StereotypeFontSize 0
+
+participant Source as m1 #D2B4DE
+participant "emitOn(executor)" as m2 #FAE5D3
+participant "some operation" as m3 #FAE5D3
+participant "Subscriber" as subscriber #D2B4DE
+
+m1 -> m2 : onItem("a") (called thread)
+m2 -[#EFBFCC]> m3 : onItem("a") (executor thread)
+m3 -[#EFBFCC]> subscriber: onItem("A") (executor thread)
+
+@enduml

--- a/documentation/src/main/docs/plantuml/runSubscriptionOn-sequence.puml
+++ b/documentation/src/main/docs/plantuml/runSubscriptionOn-sequence.puml
@@ -1,0 +1,17 @@
+@startuml
+
+skinparam dpi 300
+skinparam useBetaStyle true
+skinparam handwritten true
+skinparam StereotypeFontSize 0
+
+participant Source as m1 #D2B4DE
+participant "Some Operation" as m2 #FAE5D3
+participant "runSubscriptionOn(executor)" as m3 #FAE5D3
+participant "Subscriber" as subscriber #D2B4DE
+
+subscriber -> m3 : subscribe (subscriber thread)
+m3 -[#EFBFCC]> m2 : subscribe (executor thread)
+m2 -[#EFBFCC]> m1 : subscribe (executor thread)
+
+@enduml

--- a/documentation/src/test/java/snippets/PollableSourceTest.java
+++ b/documentation/src/test/java/snippets/PollableSourceTest.java
@@ -16,11 +16,11 @@ public class PollableSourceTest {
     private ExecutorService executor = Executors.newSingleThreadExecutor();
 
     @Test
-    public void test() {
+    public void test() { // NOSONAR
         // tag::code[]
         PollableDataSource source = new PollableDataSource();
         // First creates a uni that emit the polled item. Because `poll` blocks, let's use a specific executor
-        Uni<String> pollItemFromSource = Uni.createFrom().item(source::poll).subscribeOn(executor);
+        Uni<String> pollItemFromSource = Uni.createFrom().item(source::poll).runSubscriptionOn(executor);
         // To get the stream of items, just repeat the uni indefinitely
         Multi<String> stream = pollItemFromSource.repeat().indefinitely();
 
@@ -37,20 +37,20 @@ public class PollableSourceTest {
 
     @SuppressWarnings("Convert2MethodRef")
     @Test
-    public void test2() {
+    public void test2() { // NOSONAR
         // tag::code2[]
         PollableDataSource source = new PollableDataSource();
         Multi<String> stream = Multi.createBy().repeating()
                     .supplier(source::poll)
                     .until(s -> s == null)
-                .subscribeOn(executor);
+                .runSubscriptionOn(executor);
 
         stream.subscribe().with(item -> System.out.println("Polled item: " + item));
         // end::code2[]
         await().until(() -> source.counter.get() >= 5);
     }
 
-    private class PollableDataSource {
+    private static class PollableDataSource {
 
         private final AtomicInteger counter = new AtomicInteger();
 
@@ -64,7 +64,7 @@ public class PollableSourceTest {
 
         private void block() {
             try {
-                Thread.sleep(100);
+                Thread.sleep(100);  // NOSONAR
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/documentation/src/test/java/snippets/RunSubscriptionOnTest.java
+++ b/documentation/src/test/java/snippets/RunSubscriptionOnTest.java
@@ -1,0 +1,62 @@
+package snippets;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import org.junit.Test;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+
+public class RunSubscriptionOnTest {
+
+    @Test
+    public void testRunSubscriptionOn() {
+        Executor executor = Infrastructure.getDefaultExecutor();
+        AtomicBoolean completed = new AtomicBoolean();
+        //tag::runSubscriptionOn[]
+        Multi.createFrom().items(() -> {
+            // called on a thread from the executor
+            return retrieveItemsFromSource();
+        })
+                .onItem().apply(this::applySomeOperation)
+                .runSubscriptionOn(executor)
+                .subscribe().with(
+                item -> System.out.println("Item: " + item),
+                Throwable::printStackTrace,
+                () -> completed.set(true)
+        );
+        //end::runSubscriptionOn[]
+
+        await().untilAtomic(completed, is(true));
+    }
+
+    @Test
+    public void testEmitOn() {
+        Executor executor = Infrastructure.getDefaultExecutor();
+        AtomicBoolean completed = new AtomicBoolean();
+        //tag::emitOn[]
+        Multi.createFrom().items(this::retrieveItemsFromSource)
+                .emitOn(executor)
+                .onItem().apply(this::applySomeOperation)
+                .subscribe().with(
+                item -> System.out.println("Item: " + item),
+                Throwable::printStackTrace,
+                () -> completed.set(true)
+        );
+        //end::emitOn[]
+
+        await().untilAtomic(completed, is(true));
+    }
+
+    public String applySomeOperation(String s) {
+        return s.toUpperCase();
+    }
+
+    public Stream<String> retrieveItemsFromSource() {
+        return Stream.of("a", "b", "c");
+    }
+}

--- a/documentation/src/test/java/snippets/UniBlockingTest.java
+++ b/documentation/src/test/java/snippets/UniBlockingTest.java
@@ -14,7 +14,7 @@ public class UniBlockingTest {
     public void test() {
         // tag::code[]
         Uni<String> blocking = Uni.createFrom().item(this::invokeRemoteServiceUsingBlockingIO)
-                .subscribeOn(Infrastructure.getDefaultWorkerPool());
+                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
         // end::code[]
         assertThat(blocking.await().indefinitely()).isEqualTo("hello");
     }
@@ -31,7 +31,7 @@ public class UniBlockingTest {
 
     private String invokeRemoteServiceUsingBlockingIO() {
         try {
-            Thread.sleep(300);
+            Thread.sleep(300);  // NOSONAR
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
@@ -40,7 +40,7 @@ public class UniBlockingTest {
 
     private String invokeRemoteServiceUsingBlockingIO(String s) {
         try {
-            Thread.sleep(300);
+            Thread.sleep(300); // NOSONAR
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -193,8 +193,22 @@ public interface Multi<T> extends Publisher<T> {
      *
      * @param executor the executor to use, must not be {@code null}
      * @return a new {@link Multi}
+     * @deprecated Use {@link #runSubscriptionOn(Executor)} instead.
      */
-    Multi<T> subscribeOn(Executor executor);
+    @Deprecated
+    default Multi<T> subscribeOn(Executor executor) {
+        return runSubscriptionOn(executor);
+    }
+
+    /**
+     * When a subscriber subscribes to this {@link Multi}, execute the subscription to the upstream {@link Multi} on a
+     * thread from the given executor. As a result, the {@link Subscriber#onSubscribe(Subscription)} method will be called
+     * on this thread (except mentioned otherwise)
+     *
+     * @param executor the executor to use, must not be {@code null}
+     * @return a new {@link Multi}
+     */
+    Multi<T> runSubscriptionOn(Executor executor);
 
     /**
      * Allows configures the actions or continuation to execute when this {@link Multi} fires the completion event.

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -316,8 +316,22 @@ public interface Uni<T> {
      *
      * @param executor the executor to use, must not be {@code null}
      * @return a new {@link Uni}
+     * @deprecated Use {@link #runSubscriptionOn(Executor)} instead
      */
-    Uni<T> subscribeOn(Executor executor);
+    @Deprecated
+    default Uni<T> subscribeOn(Executor executor) {
+        return runSubscriptionOn(executor);
+    }
+
+    /**
+     * When a subscriber subscribes to this {@link Uni}, executes the subscription to the upstream {@link Uni} on a thread
+     * from the given executor. As a result, the {@link UniSubscriber#onSubscribe(UniSubscription)} method will be called
+     * on this thread (except mentioned otherwise)
+     *
+     * @param executor the executor to use, must not be {@code null}
+     * @return a new {@link Uni}
+     */
+    Uni<T> runSubscriptionOn(Executor executor);
 
     /**
      * Caches the events (item or failure) of this {@link Uni} and replays it for all further {@link UniSubscriber}.

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
@@ -175,7 +175,7 @@ public abstract class AbstractMulti<T> implements Multi<T> {
     }
 
     @Override
-    public Multi<T> subscribeOn(Executor executor) {
+    public Multi<T> runSubscriptionOn(Executor executor) {
         return Infrastructure.onMultiCreation(new MultiSubscribeOnOp<>(this, executor));
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
@@ -81,9 +81,9 @@ public abstract class AbstractUni<T> implements Uni<T> {
     }
 
     @Override
-    public Uni<T> subscribeOn(Executor executor) {
+    public Uni<T> runSubscriptionOn(Executor executor) {
         return Infrastructure.onUniCreation(
-                new UniCallSubscribeOn<>(this, ParameterValidation.nonNull(executor, "executor")));
+                new UniCallSubscribeOn<>(this, executor));
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/UniSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/UniSubscriber.java
@@ -1,5 +1,7 @@
 package io.smallrye.mutiny.subscription;
 
+import java.util.concurrent.Executor;
+
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniSubscribe;
 
@@ -30,7 +32,8 @@ public interface UniSubscriber<T> {
      * before the invocation of this method.
      *
      * <ul>
-     * <li>Executor: Operate on no particular executor, except if {@link Uni#subscribeOn} has been called</li>
+     * <li>Executor: Operate on no particular executor, except if {@link Uni#runSubscriptionOn(Executor)} has been
+     * called</li>
      * <li>Exception: Throwing an exception cancels the subscription, {@link #onItem(Object)} and
      * {@link #onFailure(Throwable)} won't be called</li>
      * </ul>

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiReceiveItemOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiReceiveItemOnTest.java
@@ -52,6 +52,11 @@ public class MultiReceiveItemOnTest {
         Multi.createFrom().item(1).subscribeOn(null);
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testThatRunSubscriptionOnExecutorCannotBeNull() {
+        Multi.createFrom().item(1).runSubscriptionOn(null);
+    }
+
     @Test
     public void testThatItemsAreDispatchedOnTheRightThread() {
         Set<String> itemThread = ConcurrentHashMap.newKeySet();
@@ -114,6 +119,15 @@ public class MultiReceiveItemOnTest {
     public void testSubscribeOn() {
         Multi.createFrom().items(1, 2, 3, 4)
                 .subscribeOn(executor)
+                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .await()
+                .assertReceived(1, 2, 3, 4);
+    }
+
+    @Test
+    public void testRunSubscriptionOn() {
+        Multi.createFrom().items(1, 2, 3, 4)
+                .runSubscriptionOn(executor)
                 .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
                 .await()
                 .assertReceived(1, 2, 3, 4);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRepeatTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRepeatTest.java
@@ -103,7 +103,7 @@ public class UniRepeatTest {
         final AtomicInteger count = new AtomicInteger();
         int value = Uni.createFrom().item(count::incrementAndGet)
                 .repeat().indefinitely()
-                .subscribeOn(Infrastructure.getDefaultWorkerPool())
+                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
                 .transform().byTakingFirstItems(num)
                 .collectItems().last()
                 .await().indefinitely();
@@ -121,7 +121,7 @@ public class UniRepeatTest {
                     invocations.incrementAndGet();
                     return false;
                 })
-                .subscribeOn(Infrastructure.getDefaultWorkerPool())
+                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
                 .transform().byTakingFirstItems(num)
                 .collectItems().last()
                 .await().indefinitely();
@@ -133,7 +133,7 @@ public class UniRepeatTest {
     @Test
     public void testNoStackOverflow() {
         int value = Uni.createFrom().item(1).repeat().indefinitely()
-                .subscribeOn(Infrastructure.getDefaultWorkerPool())
+                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
                 .transform().byTakingFirstItems(100000L)
                 .collectItems().last()
                 .await().indefinitely();
@@ -144,7 +144,7 @@ public class UniRepeatTest {
     public void testNoStackOverflowWithRepeatUntil() {
         AtomicInteger count = new AtomicInteger();
         int value = Uni.createFrom().item(1).repeat().until(x -> count.incrementAndGet() > 100000000L)
-                .subscribeOn(Infrastructure.getDefaultWorkerPool())
+                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
                 .transform().byTakingFirstItems(100000L)
                 .collectItems().last()
                 .await().indefinitely();
@@ -195,7 +195,7 @@ public class UniRepeatTest {
         final AtomicInteger count = new AtomicInteger();
         MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
                 .repeat().indefinitely()
-                .subscribeOn(Infrastructure.getDefaultWorkerPool())
+                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
                 .subscribe().withSubscriber(MultiAssertSubscriber.create());
 
         subscriber.assertSubscribed().assertHasNotReceivedAnyItem();
@@ -231,7 +231,7 @@ public class UniRepeatTest {
         final AtomicInteger count = new AtomicInteger();
         MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
                 .repeat().until(x -> false)
-                .subscribeOn(Infrastructure.getDefaultWorkerPool())
+                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
                 .subscribe().withSubscriber(MultiAssertSubscriber.create());
 
         subscriber.assertSubscribed().assertHasNotReceivedAnyItem();
@@ -267,7 +267,7 @@ public class UniRepeatTest {
         final AtomicInteger count = new AtomicInteger();
         MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
                 .repeat().atMost(3)
-                .subscribeOn(Infrastructure.getDefaultWorkerPool())
+                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
                 .subscribe().withSubscriber(MultiAssertSubscriber.create());
 
         subscriber.assertSubscribed().assertHasNotReceivedAnyItem();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
@@ -16,10 +16,10 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
 public class UniRunSubscriptionOnTest {
 
     @Test
-    public void testSubscribeOnWithSupplier() {
+    public void testRunSubscriptionOnWithSupplier() {
         UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
         Uni.createFrom().item(() -> 1)
-                .subscribeOn(ForkJoinPool.commonPool())
+                .runSubscriptionOn(ForkJoinPool.commonPool())
                 .subscribe().withSubscriber(ts);
         ts.await().assertItem(1);
         assertThat(ts.getOnSubscribeThreadName()).isNotEqualTo(Thread.currentThread().getName());
@@ -30,7 +30,7 @@ public class UniRunSubscriptionOnTest {
         UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
 
         Uni.createFrom().item(1)
-                .subscribeOn(ForkJoinPool.commonPool())
+                .runSubscriptionOn(ForkJoinPool.commonPool())
                 .subscribe().withSubscriber(ts);
 
         ts.await().assertItem(1);
@@ -50,7 +50,7 @@ public class UniRunSubscriptionOnTest {
             return 0;
         })
                 .ifNoItem().after(Duration.ofMillis(100)).recoverWithUni(Uni.createFrom().item(() -> 1))
-                .subscribeOn(Infrastructure.getDefaultExecutor())
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
                 .subscribe().withSubscriber(ts);
 
         ts.await().assertItem(1);
@@ -61,7 +61,7 @@ public class UniRunSubscriptionOnTest {
         AtomicInteger count = new AtomicInteger();
 
         Uni<Integer> uni = Uni.createFrom().item(count::incrementAndGet)
-                .subscribeOn(ForkJoinPool.commonPool());
+                .runSubscriptionOn(ForkJoinPool.commonPool());
 
         assertThat(count).hasValue(0);
         uni.subscribe().withSubscriber(UniAssertSubscriber.create()).await();
@@ -71,7 +71,7 @@ public class UniRunSubscriptionOnTest {
     @Test
     public void testWithFailure() {
         Uni.createFrom().<Void> failure(new IOException("boom"))
-                .subscribeOn(Infrastructure.getDefaultExecutor())
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
                 .await()
                 .assertFailure(IOException.class, "boom");

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
@@ -142,7 +142,7 @@ public class MultiFromIterableTest {
         final int expectedCount = 4;
         CountDownLatch latch = new CountDownLatch(expectedCount);
 
-        f.subscribeOn(Infrastructure.getDefaultExecutor())
+        f.runSubscriptionOn(Infrastructure.getDefaultExecutor())
                 .subscribe(new Subscriber<Integer>() {
                     Subscription upstream;
 


### PR DESCRIPTION
Fix #98

Also add a section in the doc clarifying `emitOn` vs. `runSubscriptionOn`