### PR TITLE
Document the difference between concatenate() and merge()

### DIFF
--- a/documentation/src/main/docs/faq.adoc
+++ b/documentation/src/main/docs/faq.adoc
@@ -99,6 +99,45 @@ To chain asynchronous calls, use `onItem().produceUni` or `onItem().produceCompl
 include::../../../src/test/java/snippets/HowToChainAsyncTest.java[tags=code]
 ----
 
+=== What's the difference between merge() and concatenate()
+
+Imagine you have a `Multi`, and for each item, you need to call a remote service or execute an asynchronous operation.
+To do this, you write the following code:
+
+[source,java]
+----
+List<String> list = multi
+    .onItem().produceUni(this::asyncService)
+    // .concatenate() or .merge() ?
+----
+
+`produceUni` lets you choose between two _merge_ methods: `merge()` and `concatenate()`:
+
+[source,java,indent=0]
+----
+include::../../../src/test/java/snippets/MergeVsConcatenateTest.java[tags=merge]
+----
+
+[source,java,indent=0]
+----
+include::../../../src/test/java/snippets/MergeVsConcatenateTest.java[tags=concatenate]
+----
+
+The difference between these alternatives is about the ordering.
+Let's imagine you have the following items: `a`, `b`, `c` and the `asyncService` is just producing the uppercase version (but asynchronously, and you don't know when the result is going to be produced).
+
+`concatenate()` preserves the ordering. So, the output will always be `A`, `B`, `C`.
+`merge()` emits the resulting items as soon as they are available, and so may interleave the items.
+The output could be `B`, `A`, `C` if the computation of `b` was faster than for `a`.
+
+`merge()` executes the asynchronous operation concurrently, while `concatenate()` executes them one by one to preserve the ordering.
+With `merge()`, you can also configure the degree of concurrency using: `merge(concurrency)`:
+
+[source,java,indent=0]
+----
+include::../../../src/test/java/snippets/MergeVsConcatenateTest.java[tags=merge-concurrency]
+----
+
 === How do I recover from failure?
 
 Failures are inherent to software.

--- a/documentation/src/test/java/snippets/MergeVsConcatenateTest.java
+++ b/documentation/src/test/java/snippets/MergeVsConcatenateTest.java
@@ -1,0 +1,58 @@
+package snippets;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MergeVsConcatenateTest {
+
+    Random random = new Random();
+
+    public Uni<String> asyncService(String input) {
+        int delay = random.nextInt(100) + 1;
+        return Uni.createFrom().item(input::toUpperCase)
+                .onItem().delayIt().by(Duration.ofMillis(delay));
+    }
+
+    Multi<String> multi = Multi.createFrom().items("a", "b", "c", "d", "e", "f", "g", "h");
+
+    @Test
+    public void testConcatenate() {
+        // tag::concatenate[]
+        List<String> list = multi
+                .onItem().produceUni(this::asyncService).concatenate()
+                .collectItems().asList()
+                .await().indefinitely();
+        // end::concatenate[]
+        assertThat(list).containsExactly("A", "B", "C", "D", "E", "F", "G", "H");
+    }
+
+    @Test
+    public void testMerge() {
+        // tag::merge[]
+        List<String> list = multi
+                .onItem().produceUni(this::asyncService).merge()
+                .collectItems().asList()
+                .await().indefinitely();
+        // end::merge[]
+        assertThat(list).containsExactlyInAnyOrder("A", "B", "C", "D", "E", "F", "G", "H");
+    }
+
+    @Test
+    public void testMergeWithConcurrency() {
+        // tag::merge-concurrency[]
+        List<String> list = multi
+                .onItem().produceUni(this::asyncService).merge(8)
+                .collectItems().asList()
+                .await().indefinitely();
+        // end::merge-concurrency[]
+        assertThat(list).containsExactlyInAnyOrder("A", "B", "C", "D", "E", "F", "G", "H");
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiFlatten.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiFlatten.java
@@ -74,7 +74,7 @@ public class MultiFlatten<I, O> {
      */
     public Multi<O> merge() {
         return Infrastructure.onMultiCreation(
-                new MultiFlatMapOp<>(upstream, mapper, collectFailureUntilCompletion, requests,
+                new MultiFlatMapOp<>(upstream, mapper, collectFailureUntilCompletion, 4,
                         () -> new SpscArrayQueue<>(256),
                         () -> new SpscArrayQueue<>(256)));
     }

--- a/implementation/src/test/java/tck/MultiFlatMapCompletionStageTckTest.java
+++ b/implementation/src/test/java/tck/MultiFlatMapCompletionStageTckTest.java
@@ -48,12 +48,12 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Int
     }
 
     @Test
-    public void flatMapCsStageShouldMaintainOrderOfFutures() throws Exception {
+    public void flatMapCsStageShouldMaintainOrderOfFuturesIfConcurrencyIs1() throws Exception {
         CompletableFuture<Integer> one = new CompletableFuture<>();
         CompletableFuture<Integer> two = new CompletableFuture<>();
         CompletableFuture<Integer> three = new CompletableFuture<>();
         CompletionStage<List<Integer>> result = Multi.createFrom().<CompletionStage<Integer>> items(one, two, three)
-                .onItem().produceCompletionStage(Function.identity()).merge()
+                .onItem().produceCompletionStage(Function.identity()).merge(1)
                 .collectItems().asList()
                 .subscribeAsCompletionStage();
         three.complete(3);
@@ -65,7 +65,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Int
     }
 
     @Test
-    public void flatMapCsStageShouldOnlyMapOneElementAtATime() throws Exception {
+    public void flatMapCsStageShouldOnlyMapOneElementAtATimeWithConcurrencyIs1() throws Exception {
         CompletableFuture<Integer> one = new CompletableFuture<>();
         CompletableFuture<Integer> two = new CompletableFuture<>();
         CompletableFuture<Integer> three = new CompletableFuture<>();
@@ -74,7 +74,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Int
                 .onItem().produceCompletionStage(cs -> {
                     Assert.assertEquals(1, concurrentMaps.incrementAndGet());
                     return cs;
-                }).merge()
+                }).merge(1)
                 .collectItems().asList()
                 .subscribeAsCompletionStage();
         Thread.sleep(100L); // NOSONAR

--- a/implementation/src/test/java/tck/MultiFlatMapTckTest.java
+++ b/implementation/src/test/java/tck/MultiFlatMapTckTest.java
@@ -96,11 +96,11 @@ public class MultiFlatMapTckTest extends AbstractPublisherTck<Long> {
     }
 
     @Test
-    public void flatMapStageShouldOnlySubscribeToOnePublisherAtATime() throws Exception {
+    public void concatMapStageShouldOnlySubscribeToOnePublisherAtATime() throws Exception {
         AtomicInteger activePublishers = new AtomicInteger();
 
         CompletionStage<List<Integer>> result = Multi.createFrom().items(1, 2, 3, 4, 5)
-                .flatMap(id -> Multi.createFrom()
+                .concatMap(id -> Multi.createFrom()
                         .publisher(new ScheduledPublisher(id, activePublishers, this::getExecutor)))
                 .collectItems().asList()
                 .subscribeAsCompletionStage();
@@ -110,7 +110,7 @@ public class MultiFlatMapTckTest extends AbstractPublisherTck<Long> {
     }
 
     @Test
-    public void flatMapStageShouldPropgateCancelToSubstreams() {
+    public void flatMapStageShouldPropagateCancelToSubstreams() {
         CompletableFuture<Void> outerCancelled = new CompletableFuture<>();
         CompletableFuture<Void> innerCancelled = new CompletableFuture<>();
         await(infiniteStream()


### PR DESCRIPTION
Also fix the default concurrency argument of the merge operation.

Fix #82 