### PR TITLE
Implement Uni.onItem().ifNotNull()

### DIFF
--- a/documentation/src/main/docs/faq.adoc
+++ b/documentation/src/main/docs/faq.adoc
@@ -190,6 +190,13 @@ The `retry` operator lets you re-subscribe and continue the reception.
 include::../../../src/test/java/snippets/UniNullTest.java[tags=code]
 ----
 
+The symmetric operation is also available with `ifNotNull` which let you handle the case where the item is _not null_:
+
+[source,java,indent=0]
+----
+include::../../../src/test/java/snippets/UniNullTest.java[tags=code-not-null]
+----
+
 === How do I handle timeout?
 
 `Uni` are often used to represent asynchronous operations, like an HTTP call.

--- a/documentation/src/test/java/snippets/UniNullTest.java
+++ b/documentation/src/test/java/snippets/UniNullTest.java
@@ -1,11 +1,10 @@
 package snippets;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.Test;
-
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class UniNullTest {
 
@@ -19,6 +18,22 @@ public class UniNullTest {
         // end::code[]
 
         assertThat(uni.onItem().ifNull().continueWith("hello").await().indefinitely()).isEqualTo("hello");
+    }
+
+    @Test
+    public void uniNotNull() {
+        Uni<String> uni = Uni.createFrom().item(() -> null);
+        // tag::code-not-null[]
+        uni
+                .onItem().ifNotNull().apply(String::toUpperCase)
+                .onItem().ifNull().continueWith("yolo!");
+        // end::code-not-null[]
+
+        String r = uni
+                .onItem().ifNotNull().apply(String::toUpperCase)
+                .onItem().ifNull().continueWith("yolo!")
+                .await().indefinitely();
+        assertThat(r).isEqualTo("yolo!");
     }
 
     @Test

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup2.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup2.java
@@ -23,7 +23,7 @@ public class UniAndGroup2<T1, T2> extends UniAndGroupIterable<T1> {
     }
 
     /**
-     * Configure the processing to wait until all the {@link Uni unis} to fires an event (item or failure) before
+     * Configure the processing to wait until all the {@link Uni unis} to fire an event (item or failure) before
      * firing the failure. If several failures have been collected, a {@link CompositeException} is fired wrapping
      * the different failures.
      *

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItem.java
@@ -116,7 +116,7 @@ public class UniOnItem<T> {
      * Transforms the received item asynchronously, forwarding the events emitted an {@link UniEmitter} consumes by
      * the given consumer.
      * <p>
-     * The consumer is called with the item event of the current {@link Uni} and an emitter uses to fires events.
+     * The consumer is called with the item event of the current {@link Uni} and an emitter uses to fire events.
      * These events are these propagated by the produced {@link Uni}.
      *
      * @param consumer the function called with the item of the this {@link Uni} and an {@link UniEmitter}.
@@ -213,5 +213,15 @@ public class UniOnItem<T> {
      */
     public UniOnNull<T> ifNull() {
         return new UniOnNull<>(upstream);
+    }
+
+    /**
+     * Adds specific behavior when the observed {@link Uni} fies a {@code non-null} item. If the item is {@code null},
+     * default fallbacks are used.
+     *
+     * @return the object to configure the behavior when receiving a {@code non-null} item
+     */
+    public UniOnNotNull<T> ifNotNull() {
+        return new UniOnNotNull<>(upstream);
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNotNull.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNotNull.java
@@ -1,0 +1,170 @@
+package io.smallrye.mutiny.groups;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.UniEmitter;
+
+public class UniOnNotNull<T> {
+
+    private final Uni<T> upstream;
+
+    public UniOnNotNull(Uni<T> upstream) {
+        this.upstream = nonNull(upstream, "upstream");
+    }
+
+    /**
+     * Produces a new {@link Uni} invoking the given callback when the {@code item} event is fired. If the item is
+     * {@code null}, the callback is not invoked.
+     *
+     * @param callback the callback, must not be {@code null}
+     * @return the new {@link Uni}
+     */
+    public Uni<T> invoke(Consumer<? super T> callback) {
+        return upstream.onItem().invoke(item -> {
+            if (item != null) {
+                callback.accept(item);
+            }
+        });
+    }
+
+    /**
+     * Produces a new {@link Uni} invoking the given function when the current {@link Uni} fires the {@code item} event.
+     * The function receives the (non-null) item as parameter, and can transform it. The returned object is sent downstream
+     * as {@code item}.
+     * <p>
+     * If the item is `null`, the mapper is not called and it produces a {@code null} item.
+     * <p>
+     * For asynchronous composition, see {@link #produceUni(Function)}.
+     *
+     * @param mapper the mapper function, must not be {@code null}
+     * @param <R> the type of Uni item
+     * @return the new {@link Uni}
+     */
+    public <R> Uni<R> apply(Function<? super T, ? extends R> mapper) {
+        return upstream.onItem().apply(item -> {
+            if (item != null) {
+                return mapper.apply(item);
+            } else {
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Transforms the received item asynchronously, forwarding the events emitted by another {@link Uni} produced by
+     * the given {@code mapper}.
+     * <p>
+     * The mapper is called with the item event of the current {@link Uni} and produces an {@link Uni}, possibly
+     * using another type of item ({@code R}). The events fired by produced {@link Uni} are forwarded to the
+     * {@link Uni} returned by this method.
+     * <p>
+     * If the item is {@code null}, the mapper is not called, and {@code null} is propagated downstream.
+     * <p>
+     * This operation is generally named {@code flatMap}.
+     *
+     * @param mapper the function called with the item of this {@link Uni} and producing the {@link Uni},
+     *        must not be {@code null}, must not return {@code null}.
+     * @param <R> the type of item
+     * @return a new {@link Uni} that would fire events from the uni produced by the mapper function, possibly
+     *         in an asynchronous manner.
+     */
+    public <R> Uni<R> produceUni(Function<? super T, ? extends Uni<? extends R>> mapper) {
+        return upstream.onItem().produceUni(item -> {
+            if (item != null) {
+                return mapper.apply(item);
+            } else {
+                return Uni.createFrom().nullItem();
+            }
+        });
+    }
+
+    /**
+     * When this {@code Uni} produces its item (not {@code null}), call the given {@code mapper} to produce
+     * a {@link Publisher}. Continue the pipeline with this publisher (as a {@link Multi}).
+     * <p>
+     * The mapper is called with the item event of the current {@link Uni} and produces a {@link Publisher}, possibly
+     * using another type of item ({@code R}). Events fired by the produced {@link Publisher} are forwarded to the
+     * {@link Multi} returned by this method.
+     * <p>
+     * If the item is `null`, the mapper is not called and an empty {@link Multi} is produced.
+     * <p>
+     * This operation is generally named {@code flatMapPublisher}.
+     *
+     * @param mapper the mapper, must not be {@code null}, may expect to receive {@code null} as item.
+     * @param <R> the type of item produced by the resulting {@link Multi}
+     * @return the multi
+     */
+    public <R> Multi<R> produceMulti(Function<? super T, ? extends Publisher<? extends R>> mapper) {
+        return upstream.onItem().produceMulti(item -> {
+            if (item != null) {
+                return mapper.apply(item);
+            } else {
+                return Multi.createFrom().empty();
+            }
+        });
+    }
+
+    /**
+     * Transforms the received item asynchronously, forwarding the events emitted by another {@link CompletionStage}
+     * produced by the given {@code mapper}.
+     * <p>
+     * The mapper is called with the item event of the current {@link Uni} and produces an {@link CompletionStage},
+     * possibly using another type of item ({@code R}). The events fired by produced {@link CompletionStage} are
+     * forwarded to the {@link Uni} returned by this method.
+     * <p>
+     * If the incoming item is {@code null}, the mapper is not called, and a {@link CompletionStage} redeeming
+     * {@code null} is returned.
+     *
+     * @param mapper the function called with the item of this {@link Uni} and producing the {@link CompletionStage},
+     *        must not be {@code null}, must not return {@code null}.
+     * @param <R> the type of item
+     * @return a new {@link Uni} that would fire events from the uni produced by the mapper function, possibly
+     *         in an asynchronous manner.
+     */
+    public <R> Uni<R> produceCompletionStage(Function<? super T, ? extends CompletionStage<? extends R>> mapper) {
+        return upstream
+                .onItem().produceCompletionStage(item -> {
+                    if (item != null) {
+                        return mapper.apply(item);
+                    } else {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                });
+    }
+
+    /**
+     * Transforms the received item asynchronously, forwarding the events emitted an {@link UniEmitter} consumes by
+     * the given consumer.
+     * <p>
+     * The consumer is called with the item event of the current {@link Uni} and an emitter uses to fire events.
+     * These events are these propagated by the produced {@link Uni}.
+     * <p>
+     * If the incoming item is {@code null}, the {@code consumer} is not called and a {@code null} item is propagated
+     * downstream.
+     *
+     * @param consumer the function called with the item of the this {@link Uni} and an {@link UniEmitter}.
+     *        It must not be {@code null}.
+     * @param <R> the type of item emitted by the emitter
+     * @return a new {@link Uni} that would fire events from the emitter consumed by the mapper function, possibly
+     *         in an asynchronous manner.
+     */
+    public <R> Uni<R> produceUni(BiConsumer<? super T, UniEmitter<? super R>> consumer) {
+        return upstream.onItem().produceUni((item, emitter) -> {
+            if (item != null) {
+                consumer.accept(item, emitter);
+            } else {
+                emitter.complete(null);
+            }
+        });
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniZip.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniZip.java
@@ -154,6 +154,7 @@ public class UniZip {
      * collected failures.
      *
      * @param unis the list of unis, must not be {@code null}, must not contain {@code null}, must not be empty
+     * @param <O> the type of item
      * @return an {@link UniAndGroupIterable} to configure the combination
      */
     public <O> UniAndGroupIterable<O> unis(Iterable<? extends Uni<?>> unis) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine2.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine2.java
@@ -17,7 +17,7 @@ public class MultiItemCombine2<T1, T2> extends MultiItemCombineIterable {
     }
 
     /**
-     * Configures the combination to wait until all the {@link Publisher streams} to fires a completion or failure event
+     * Configures the combination to wait until all the {@link Publisher streams} to fire a completion or failure event
      * before propagating a failure downstream.
      *
      * @return the current {@link MultiItemCombine2}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine3.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine3.java
@@ -16,7 +16,7 @@ public class MultiItemCombine3<T1, T2, T3> extends MultiItemCombineIterable {
     }
 
     /**
-     * Configures the combination to wait until all the {@link Publisher streams} to fires a completion or failure event
+     * Configures the combination to wait until all the {@link Publisher streams} to fire a completion or failure event
      * before propagating a failure downstream.
      *
      * @return the current {@link MultiItemCombine3}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine4.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine4.java
@@ -16,7 +16,7 @@ public class MultiItemCombine4<T1, T2, T3, T4> extends MultiItemCombineIterable 
     }
 
     /**
-     * Configures the combination to wait until all the {@link Publisher streams} to fires a completion or failure event
+     * Configures the combination to wait until all the {@link Publisher streams} to fire a completion or failure event
      * before propagating a failure downstream.
      *
      * @return the current {@link MultiItemCombine4}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine5.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine5.java
@@ -16,7 +16,7 @@ public class MultiItemCombine5<T1, T2, T3, T4, T5> extends MultiItemCombineItera
     }
 
     /**
-     * Configures the combination to wait until all the {@link Publisher streams} to fires a completion or failure event
+     * Configures the combination to wait until all the {@link Publisher streams} to fire a completion or failure event
      * before propagating a failure downstream.
      *
      * @return the current {@link MultiItemCombine5}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombineIterable.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombineIterable.java
@@ -24,7 +24,7 @@ public class MultiItemCombineIterable {
     }
 
     /**
-     * Configures the combination to wait until all the {@link Publisher streams} to fires a completion or failure event
+     * Configures the combination to wait until all the {@link Publisher streams} to fire a completion or failure event
      * before propagating a failure downstream.
      *
      * @return the current {@link MultiItemCombineIterable}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/processors/SerializedProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/processors/SerializedProcessor.java
@@ -176,6 +176,7 @@ public class SerializedProcessor<I, O> implements Processor<I, O> {
     /**
      * Dispatches the events contained in the queue to the given subscriber.
      *
+     * @param queue the queue of event
      * @param subscriber the subscriber to emit the events to
      */
     @SuppressWarnings("unchecked")

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedBiFunction.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedBiFunction.java
@@ -52,6 +52,7 @@ public interface UncheckedBiFunction<T, U, R> {
      * @param t the first function argument
      * @param u the second function argument
      * @return the function result
+     * @throws Exception if anything wrong happen
      */
     R apply(T t, U u) throws Exception;
 

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedConsumer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedConsumer.java
@@ -29,6 +29,7 @@ public interface UncheckedConsumer<T> {
      * Performs this operation on the given argument.
      *
      * @param t the input argument
+     * @throws Exception if anything wrong happen
      */
     void accept(T t) throws Exception;
 

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedFunction.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedFunction.java
@@ -31,6 +31,7 @@ public interface UncheckedFunction<T, R> {
      *
      * @param t the function argument
      * @return the function result
+     * @throws Exception if anything wrong happen
      */
     R apply(T t) throws Exception;
 

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedSupplier.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedSupplier.java
@@ -27,6 +27,7 @@ public interface UncheckedSupplier<T> {
      * Gets an item.
      *
      * @return an item
+     * @throws Exception if anything wrong happen
      */
     T get() throws Exception;
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNotNullItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNotNullItemTest.java
@@ -1,0 +1,128 @@
+package io.smallrye.mutiny.operators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+public class UniOnNotNullItemTest {
+
+    @Test
+    public void testApply() {
+        assertThat(Uni.createFrom().item("hello")
+                .onItem().ifNotNull().apply(String::toUpperCase)
+                .await().indefinitely()).isEqualTo("HELLO");
+
+        assertThat(Uni.createFrom().item(() -> (String) null)
+                .onItem().ifNotNull().apply(String::toUpperCase)
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).isEqualTo("yolo");
+
+        assertThatThrownBy(() -> Uni.createFrom().<String> failure(new Exception("boom"))
+                .onItem().ifNotNull().apply(String::toUpperCase)
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).hasMessageContaining("boom");
+    }
+
+    @Test
+    public void testInvoke() {
+        AtomicBoolean invoked = new AtomicBoolean();
+        assertThat(Uni.createFrom().item("hello")
+                .onItem().ifNotNull().invoke(s -> {
+                    invoked.set(s.equals("hello"));
+                })
+                .await().indefinitely()).isEqualTo("hello");
+        assertThat(invoked).isTrue();
+
+        invoked.set(false);
+        assertThat(Uni.createFrom().item(() -> (String) null)
+                .onItem().ifNotNull().invoke(s -> invoked.set(true))
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).isEqualTo("yolo");
+        assertThat(invoked).isFalse();
+
+        assertThatThrownBy(() -> Uni.createFrom().<String> failure(new Exception("boom"))
+                .onItem().ifNotNull().invoke(s -> invoked.set(true))
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).hasMessageContaining("boom");
+
+        assertThat(invoked).isFalse();
+    }
+
+    @Test
+    public void testProduceUni() {
+        assertThat(Uni.createFrom().item("hello")
+                .onItem().ifNotNull().produceUni(s -> Uni.createFrom().item(s.toUpperCase()))
+                .await().indefinitely()).isEqualTo("HELLO");
+
+        assertThat(Uni.createFrom().item(() -> (String) null)
+                .onItem().ifNotNull().produceUni(s -> Uni.createFrom().item(s.toUpperCase()))
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).isEqualTo("yolo");
+
+        assertThatThrownBy(() -> Uni.createFrom().<String> failure(new Exception("boom"))
+                .onItem().ifNotNull().produceUni(s -> Uni.createFrom().item(s.toUpperCase()))
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).hasMessageContaining("boom");
+    }
+
+    @Test
+    public void testProduceUniWithEmitter() {
+        assertThat(Uni.createFrom().item("hello")
+                .onItem().ifNotNull().produceUni((s, e) -> e.complete(s.toUpperCase()))
+                .await().indefinitely()).isEqualTo("HELLO");
+
+        assertThat(Uni.createFrom().item(() -> (String) null)
+                .onItem().ifNotNull().produceUni((s, e) -> e.complete(s.toUpperCase()))
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).isEqualTo("yolo");
+
+        assertThatThrownBy(() -> Uni.createFrom().<String> failure(new Exception("boom"))
+                .onItem().ifNotNull().produceUni((s, e) -> e.complete(s.toUpperCase()))
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).hasMessageContaining("boom");
+    }
+
+    @Test
+    public void testProduceCompletionStage() {
+        assertThat(Uni.createFrom().item("hello")
+                .onItem().ifNotNull().produceCompletionStage(x -> CompletableFuture.completedFuture(x.toUpperCase()))
+                .await().indefinitely()).isEqualTo("HELLO");
+
+        assertThat(Uni.createFrom().item(() -> (String) null)
+                .onItem().ifNotNull().produceCompletionStage(x -> CompletableFuture.completedFuture(x.toUpperCase()))
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).isEqualTo("yolo");
+
+        assertThatThrownBy(() -> Uni.createFrom().<String> failure(new Exception("boom"))
+                .onItem().ifNotNull().produceCompletionStage(x -> CompletableFuture.completedFuture(x.toUpperCase()))
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).hasMessageContaining("boom");
+    }
+
+    @Test
+    public void testProduceMulti() {
+        assertThat(Uni.createFrom().item("hello")
+                .onItem().ifNotNull().produceMulti(x -> Multi.createFrom().item(x.toUpperCase()))
+                .collectItems().first()
+                .await().indefinitely()).isEqualTo("HELLO");
+
+        assertThat(Uni.createFrom().item(() -> (String) null)
+                .onItem().ifNotNull().produceMulti(x -> Multi.createFrom().item(x.toUpperCase()))
+                .collectItems().first()
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).isEqualTo("yolo");
+
+        assertThatThrownBy(() -> Uni.createFrom().<String> failure(new Exception("boom"))
+                .onItem().ifNotNull().produceMulti(x -> Multi.createFrom().item(x.toUpperCase()))
+                .collectItems().first()
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).hasMessageContaining("boom");
+    }
+}


### PR DESCRIPTION
This group checks if the item is not `null`. If the item is `null` default results are provided (`null`, empty `Multi`...)

This PR also contains various cosmetic fixes.

Related to #109 