### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -9,59 +9,51 @@ on:
       - '.github/workflows/deployment.yml'
 
 jobs:
-  build_java8:
+  build_java_${{ matrix.java }}:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [
+        {'version': '8', 'source': 'releases'},
+        {'version': '11', 'source': 'releases'},
+        {'version': '14', 'source': 'releases'},
+        {'version': '15', 'source': 'nightly'}
+        ]
+    name: Build with Java ${{ matrix.java.version }}
     steps:
-      - uses: actions/checkout@v1
-      - name: Install JDK 1.8
-        uses: joschi/setup-jdk@v1.0.0
+      - uses: actions/cache@v2
         with:
-          java-version: 'openjdk8'
-      - name: Build with Maven
-        run: mvn -B clean install --file pom.xml
-
-  build_java11:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install JDK 11
-        uses: joschi/setup-jdk@v1.0.0
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/**/*-SNAPSHOT/*
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - uses: actions/checkout@v2
+      - uses: AdoptOpenJDK/install-jdk@v1
         with:
-          java-version: 'openjdk11'
-      - name: Build with Maven
-        run: mvn -B clean install --file pom.xml
-
-  build_java12:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install JDK 12
-        uses: joschi/setup-jdk@v1.0.0
-        with:
-          java-version: 'openjdk12'
-      - name: Build with Maven
-        run: mvn -B clean install --file pom.xml
-
-  build_java14:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install JDK 14
-        uses: joschi/setup-jdk@v1.0.0
-        with:
-          java-version: 'openjdk14'
+          version: ${{ matrix.java.version }}
+          source: ${{ matrix.java.source }}
       - name: Build with Maven
         run: mvn -B clean install --file pom.xml
 
   quality:
-    needs: [build_java8, build_java11, build_java12, build_java14]
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Install JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/cache@v2
         with:
-          java-version: 1.8
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/**/*-SNAPSHOT/*
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - uses: actions/checkout@v2
+      - name: Install JDK 1.8
+        uses: AdoptOpenJDK/install-jdk@v1
+        with:
+          version: 8
       - name: Coverage and Sonar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-pull.yml
+++ b/.github/workflows/build-pull.yml
@@ -4,48 +4,31 @@ name: Pull Request Build
 on: pull_request
 
 jobs:
-  build_java8:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [
+          {'version': '8', 'source': 'releases'},
+          {'version': '11', 'source': 'releases'},
+          {'version': '14', 'source': 'releases'},
+          {'version': '15', 'source': 'nightly'}
+        ]
+    name: Build with Java ${{ matrix.java.version }}
     steps:
-      - uses: actions/checkout@v1
-      - name: Install JDK 1.8
-        uses: joschi/setup-jdk@v1.0.0
+      - uses: actions/cache@v2
         with:
-          java-version: 'openjdk8'
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/**/*-SNAPSHOT/*
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - uses: actions/checkout@v2
+      - name: Install JDK ${{ matrix.java.version }}
+        uses: AdoptOpenJDK/install-jdk@v1
+        with:
+          version: ${{ matrix.java.version }}
+          source: ${{ matrix.java.source }}
       - name: Build with Maven
         run: mvn -B clean install --file pom.xml
-
-  build_java11:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install JDK 11
-        uses: joschi/setup-jdk@v1.0.0
-        with:
-          java-version: 'openjdk11'
-      - name: Build with Maven
-        run: mvn -B clean install --file pom.xml
-
-  build_java12:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install JDK 12
-        uses: joschi/setup-jdk@v1.0.0
-        with:
-          java-version: 'openjdk12'
-      - name: Build with Maven
-        run: mvn -B clean install --file pom.xml
-
-  build_java14:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install JDK 14
-        uses: joschi/setup-jdk@v1.0.0
-        with:
-          java-version: 'openjdk14'
-      - name: Build with Maven
-        run: mvn -B clean install --file pom.xml
-
-

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -6,13 +6,22 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/**/*-SNAPSHOT/*
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - uses: actions/checkout@v1
         with:
           ref: 'master'
       - name: Install JDK 1.8
-        uses: joschi/setup-jdk@v1.0.0
+        uses: AdoptOpenJDK/install-jdk@v1
         with:
-          java-version: 'openjdk8'
+          version: 8
+
       - name: 'Run deployment for ${{ github.event.deployment.environment }}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -78,6 +78,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <groupId>org.asciidoctor</groupId>


### PR DESCRIPTION
* Enable cache - because I'm bored retrying build failing because it cannot download some artifact,
* Remove java 12 - not an LTS,
* Add java 15-ea 

It also uses a matrix build to configure the java version, and update the actions to the latest versions.

The setup-jdk actions have been replaced with the once provided by AdoptOpenJDK (https://github.com/AdoptOpenJDK/install-jdk).