### PR TITLE
Add support for repeat whilst

### DIFF
--- a/documentation/src/main/docs/faq.adoc
+++ b/documentation/src/main/docs/faq.adoc
@@ -547,7 +547,7 @@ include::../../../src/test/java/snippets/PollableSourceTest.java[tags=code2]
 
 === How do I handle pagination?
 
-There are many REST / HTTP API using pagination, _i.e._ return only a subset of the results and you need to request the next page to get the next batch.
+There are many REST / HTTP APIs using pagination, _i.e._ return only a subset of the results and you need to request the next _page_ to get the next batch.
 Each batch contains a list of item(s).
 To use this kind of API and generate a continuous stream of items, you need to use the `Multi.createBy().repeating()` function.
 However, we need to pass a cursor / state to advance and avoid requesting again and again the same page.
@@ -563,13 +563,31 @@ First, you create a `Multi` containing the items emitted by the `CompletionStage
 
 Then, use `until` to call the paginated API until we have all the items.
 At the point we have a stream of list of item such as `["a", "b", "c"], ["d", "e"], []`.
-However we want the following stream: `"a", "b", "c", "d", "e"`.
+However, we want the following stream: `"a", "b", "c", "d", "e"`.
 The `disjoint` method does exactly this.
 It gets the items from the lists and passes them downstream:
 
 [plantuml,align=center]
 ----
 include::plantuml/disjoint.puml[]
+----
+
+`Multi.createBy().repeating()` lets you choose the number of iterations using:
+
+* `atMost` - exact number of repetitions (or failure happens before reaching that number)
+* `until` - the repetition is stopped if the item emitted by the `Uni` **passes** a test (predicate).
+It does not propagate the item that did pass the check, and it stops the repetition.
+The check verifies if the current item does not contain valid data.
+* `whilst` - the repetition is stopped if the item emitted by the `Uni` **does not pass** a test (predicate).
+It does propagate the item downstream even if the check does not pass.
+However, it stops the repetition.
+The test verifies if there is a _next_ batch to be retrieved.
+
+The following code illustrates the usage of `whilst`:
+
+[source,java,indent=0]
+----
+include::../../../src/test/java/snippets/PaginationTest.java[tags=code2]
 ----
 
 === How do I delay _things_?

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRepeatWhilstOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRepeatWhilstOp.java
@@ -1,0 +1,106 @@
+package io.smallrye.mutiny.operators.multi;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.ParameterValidation;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+import io.smallrye.mutiny.subscription.SwitchableSubscriptionSubscriber;
+
+public class MultiRepeatWhilstOp<T> extends AbstractMultiOperator<T, T> implements Multi<T> {
+    private final Predicate<T> predicate;
+    private final long times;
+
+    public MultiRepeatWhilstOp(Multi<T> upstream, Predicate<T> predicate) {
+        super(upstream);
+        this.predicate = predicate;
+        this.times = Long.MAX_VALUE;
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super T> downstream) {
+        ParameterValidation.nonNullNpe(downstream, "downstream");
+        RepeatWhilstProcessor<T> processor = new RepeatWhilstProcessor<>(upstream, downstream,
+                times != Long.MAX_VALUE ? times - 1 : Long.MAX_VALUE,
+                predicate);
+        downstream.onSubscribe(processor);
+        upstream.subscribe(processor);
+    }
+
+    static final class RepeatWhilstProcessor<T> extends SwitchableSubscriptionSubscriber<T> {
+
+        private final Multi<? extends T> upstream;
+        private long remaining;
+        private final Predicate<T> predicate;
+
+        private boolean stop = false;
+
+        private long emitted;
+        private final AtomicInteger wip = new AtomicInteger();
+
+        public RepeatWhilstProcessor(Multi<? extends T> upstream, MultiSubscriber<? super T> downstream,
+                long times, Predicate<T> predicate) {
+            super(downstream);
+            this.upstream = upstream;
+            this.predicate = predicate;
+            this.remaining = times;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            setOrSwitchUpstream(s);
+        }
+
+        @Override
+        public void onItem(T t) {
+            stop = !predicate.test(t);
+            emitted++;
+            downstream.onNext(t);
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            downstream.onError(t);
+        }
+
+        @Override
+        public void onCompletion() {
+            long r = remaining;
+            if (r != Long.MAX_VALUE) {
+                remaining = r - 1;
+            }
+
+            if (r != 0L && !stop) {
+                subscribeNext();
+            } else {
+                downstream.onComplete();
+            }
+        }
+
+        /**
+         * Subscribes to the source again via trampolining.
+         */
+        void subscribeNext() {
+            if (wip.getAndIncrement() == 0) {
+                int missed = 1;
+                while (!isCancelled()) {
+                    long p = emitted;
+                    if (p != 0L) {
+                        emitted = 0L;
+                        emitted(p);
+                    }
+                    upstream.subscribe(this);
+
+                    missed = wip.addAndGet(-missed);
+                    if (missed == 0) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/implementation/src/test/java/tck/UniRepeatWhilstTckTest.java
+++ b/implementation/src/test/java/tck/UniRepeatWhilstTckTest.java
@@ -1,0 +1,19 @@
+package tck;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+public class UniRepeatWhilstTckTest extends AbstractPublisherTck<Integer> {
+    @Override
+    public Publisher<Integer> createPublisher(long elements) {
+        if (elements == 0) {
+            return Multi.createFrom().empty();
+        }
+        AtomicInteger count = new AtomicInteger();
+        return Uni.createFrom().item(1).repeat().whilst(x -> count.getAndIncrement() < elements - 1);
+    }
+}


### PR DESCRIPTION
Improve the support of paginated API:

```
 Multi<Page> stream = Multi.createBy().repeating()
       .uni(
          () -> new AtomicInteger(),
          state -> api.retrieve(state.getAndIncrement()))
      .whilst(page -> page.hasNext());
```

Fix #176 