### PR TITLE
Avoid leaking CompletionException coming from CompletionStage

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
@@ -5,6 +5,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
@@ -124,7 +125,11 @@ public class MultiCreate {
             emitter.onTermination(() -> stage.toCompletableFuture().cancel(false));
             stage.whenComplete((r, f) -> {
                 if (f != null) {
-                    emitter.fail(f);
+                    if (f instanceof CompletionException) {
+                        emitter.fail(f.getCause());
+                    } else {
+                        emitter.fail(f);
+                    }
                 } else if (r != null) {
                     emitter.emit(r);
                 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromCompletionStage.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromCompletionStage.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.propagateFailureEvent;
 
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
@@ -20,7 +21,11 @@ public class UniCreateFromCompletionStage<O> extends UniOperator<Void, O> {
         subscriber.onSubscribe(() -> stage.toCompletableFuture().cancel(false));
         stage.whenComplete((res, fail) -> {
             if (fail != null) {
-                subscriber.onFailure(fail);
+                if (fail instanceof CompletionException) {
+                    subscriber.onFailure(fail.getCause());
+                } else {
+                    subscriber.onFailure(fail);
+                }
             } else {
                 subscriber.onItem(res);
             }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiFlatMapToPublisherTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiFlatMapToPublisherTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.testng.annotations.Test;
@@ -138,7 +137,7 @@ public class MultiFlatMapToPublisherTest {
 
         subscriber
                 .await()
-                .assertHasFailedWith(CompletionException.class, "boom");
+                .assertHasFailedWith(IllegalArgumentException.class, "boom");
 
         assertThat(subscriber.items().size()).isEqualTo(99000 - 1);
         int current = 0;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemFlatMapToCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemFlatMapToCompletionStageTest.java
@@ -3,7 +3,6 @@ package io.smallrye.mutiny.operators;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.testng.annotations.Test;
@@ -49,7 +48,7 @@ public class UniOnItemFlatMapToCompletionStageTest {
                     throw new IllegalStateException("boom");
                 }));
         uni.subscribe().withSubscriber(test);
-        test.await().assertCompletedWithFailure().assertFailure(CompletionException.class, "boom");
+        test.await().assertCompletedWithFailure().assertFailure(IllegalStateException.class, "boom");
     }
 
     @Test


### PR DESCRIPTION
Fix #179 - Avoid leaking CompletionException when creating a Uni from a CompletionStage﻿
