### PR TITLE
Grouping items into list from empty stream should produce an empty list

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiGroupIntoLists.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiGroupIntoLists.java
@@ -27,7 +27,8 @@ public class MultiGroupIntoLists<T> {
      * {@link Multi}, an empty list is emitted by the returned {@link Multi}.
      * <p>
      * When the upstream {@link Multi} sends the completion event, the resulting {@link Multi} emits the current list
-     * and propagates the completion event.
+     * and propagates the completion event. If the upstream {@link Multi} sends the completion event before having
+     * emitted any event, an empty list is propagated followed with the completion event.
      * <p>
      * If the upstream {@link Multi} sends a failure, the failure is propagated immediately.
      *
@@ -47,7 +48,8 @@ public class MultiGroupIntoLists<T> {
      * <p>
      * When the upstream {@link Multi} sends the completion event, the produced {@link Multi} emits the current list,
      * and sends the completion event. This last list may not contain {@code size} items. If the upstream {@link Multi}
-     * sends the completion event before having emitted any event, the completion event is propagated immediately.
+     * sends the completion event before having emitted any event, an empty list is propagated followed with the
+     * completion event.
      * <p>
      * If the upstream {@link Multi} sends a failure, the failure is propagated immediately.
      *
@@ -65,7 +67,8 @@ public class MultiGroupIntoLists<T> {
      * <p>
      * When the upstream {@link Multi} sends the completion event, the produced {@link Multi} emits the current list,
      * and sends the completion event. This last list may not contain {@code size} items. If the upstream {@link Multi}
-     * * sends the completion event before having emitted any event, the completion event is propagated immediately.
+     * sends the completion event before having emitted any event, an empty list is propagated followed with the
+     * completion event.
      * <p>
      * If the upstream {@link Multi} sends a failure, the failure is propagated immediately.
      *

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
@@ -121,8 +121,16 @@ public class MultiGroupTest {
     @Test
     public void testAsListsOnEmptyStream() {
         assertThat(
-                Multi.createFrom().empty().groupItems().intoLists().of(2).collectItems().last().await().indefinitely())
-                        .isNull();
+                Multi.createFrom().empty().groupItems().intoLists().of(2).collectItems().asList().await().indefinitely())
+                        .containsExactly(Collections.emptyList());
+
+        assertThat(
+                Multi.createFrom().empty().groupItems().intoLists().of(2, 2).collectItems().asList().await().indefinitely())
+                        .containsExactly(Collections.emptyList());
+
+        assertThat(
+                Multi.createFrom().empty().groupItems().intoLists().of(2, 3).collectItems().asList().await().indefinitely())
+                        .containsExactly(Collections.emptyList());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -283,6 +291,14 @@ public class MultiGroupTest {
 
         List<Integer> list = uni.await().atMost(Duration.ofSeconds(4));
         assertThat(list).contains(1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void testTimeWindowOnEmptyMulti() {
+        Uni<List<List<Integer>>> uni = Multi.createFrom().<Integer> empty()
+                .groupItems().intoLists().every(Duration.ofSeconds(5))
+                .collectItems().asList();
+        assertThat(uni.await().indefinitely()).hasSize(1).containsExactly(Collections.emptyList());
     }
 
     @Test


### PR DESCRIPTION
Fix #175 - When grouping items into lists from an empty stream, it should produce a stream containing a single empty list item.

This PR contains the necessary changes and updates the Javadoc.