### PR TITLE
Improve CompositeException to override getCause()

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/CompositeException.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/CompositeException.java
@@ -7,10 +7,14 @@ import java.util.List;
 import java.util.Optional;
 
 import io.smallrye.mutiny.groups.UniAndGroup;
+import io.smallrye.mutiny.helpers.ParameterValidation;
 
 /**
  * An implementation of {@link Exception} collecting several causes.
+ * This class is used to collect multiple failures.
+ *
  * Uses {@link #getCauses()} to retrieves the individual causes.
+ * {@link #getCause()} returns the first cause.
  *
  * @see UniAndGroup
  */
@@ -19,12 +23,26 @@ public class CompositeException extends RuntimeException {
     private final List<Throwable> causes;
 
     public CompositeException(List<Throwable> causes) {
-        super("Multiple exceptions caught:");
+        super("Multiple exceptions caught:", getFirstOrFail(causes));
         this.causes = Collections.unmodifiableList(causes);
     }
 
+    private static Throwable getFirstOrFail(List<Throwable> causes) {
+        if (causes == null || causes.isEmpty()) {
+            throw new IllegalArgumentException("Composite Exception must contains at least one cause");
+        }
+        return ParameterValidation.nonNull(causes.get(0), "cause");
+    }
+
+    private static Throwable getFirstOrFail(Throwable[] causes) {
+        if (causes == null || causes.length == 0) {
+            throw new IllegalArgumentException("Composite Exception must contains at least one cause");
+        }
+        return ParameterValidation.nonNull(causes[0], "cause");
+    }
+
     public CompositeException(Throwable... causes) {
-        super("Multiple exceptions caught:");
+        super("Multiple exceptions caught:", getFirstOrFail(causes));
         this.causes = Arrays.asList(causes);
     }
 
@@ -32,6 +50,7 @@ public class CompositeException extends RuntimeException {
         List<Throwable> c = new ArrayList<>(other.causes);
         c.add(toBeAppended);
         this.causes = Collections.unmodifiableList(c);
+        initCause(getFirstOrFail(this.causes));
     }
 
     @Override

--- a/implementation/src/test/java/io/smallrye/mutiny/CompositeExceptionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/CompositeExceptionTest.java
@@ -1,0 +1,87 @@
+package io.smallrye.mutiny;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+public class CompositeExceptionTest {
+
+    private final static IllegalArgumentException IAE = new IllegalArgumentException("iae");
+    private final static IOException IO = new IOException("io");
+    private final static UnsupportedOperationException OUPS = new UnsupportedOperationException("oups");
+
+    @Test
+    public void testCreationWithArrays() {
+        CompositeException ce1 = new CompositeException(IAE, IO, OUPS);
+        CompositeException ce2 = new CompositeException(IO, IAE, OUPS);
+        assertThat(ce1).hasMessageContaining("iae").hasMessageContaining("io").hasMessageContaining("oups");
+
+        assertThat(ce1).getCause().isEqualTo(IAE);
+        assertThat(ce2).getCause().isEqualTo(IO);
+
+        assertThat(ce1.getCauses()).containsExactly(IAE, IO, OUPS);
+        assertThat(ce2.getCauses()).containsExactly(IO, IAE, OUPS);
+
+        CompositeException ce3 = new CompositeException(OUPS);
+        assertThat(ce3).hasMessageContaining("oups");
+        assertThat(ce3.getCauses()).containsExactly(OUPS);
+        assertThat(ce3.getCause()).isEqualTo(OUPS);
+    }
+
+    @Test
+    public void testCreationWithList() {
+        CompositeException ce1 = new CompositeException(Arrays.asList(IAE, IO, OUPS));
+        CompositeException ce2 = new CompositeException(Arrays.asList(IO, IAE, OUPS));
+        assertThat(ce1).hasMessageContaining("iae").hasMessageContaining("io").hasMessageContaining("oups");
+
+        assertThat(ce1).getCause().isEqualTo(IAE);
+        assertThat(ce2).getCause().isEqualTo(IO);
+
+        assertThat(ce1.getCauses()).containsExactly(IAE, IO, OUPS);
+        assertThat(ce2.getCauses()).containsExactly(IO, IAE, OUPS);
+
+        CompositeException ce3 = new CompositeException(Collections.singletonList(OUPS));
+        assertThat(ce3).hasMessageContaining("oups");
+        assertThat(ce3.getCauses()).containsExactly(OUPS);
+        assertThat(ce3.getCause()).isEqualTo(OUPS);
+    }
+
+    @Test
+    public void testCreationFromAnExisting() {
+        CompositeException ce1 = new CompositeException(Arrays.asList(IAE, IO, OUPS));
+        Exception another = new Exception("another");
+        CompositeException ce2 = new CompositeException(ce1, another);
+
+        assertThat(ce2.getCauses()).containsExactly(IAE, IO, OUPS, another);
+        assertThat(ce2.getCause()).isEqualTo(IAE);
+    }
+
+    @SuppressWarnings("ThrowableNotThrown")
+    @Test
+    public void testCreationWithNull() {
+        assertThatThrownBy(() -> new CompositeException((Throwable[]) null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new CompositeException((Throwable) null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new CompositeException((List<Throwable>) null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new CompositeException(Collections.singletonList(null)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @SuppressWarnings("ThrowableNotThrown")
+    @Test
+    public void testCreationWithEmpty() {
+        assertThatThrownBy(() -> new CompositeException(new Throwable[0]))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new CompositeException(Collections.emptyList()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+}


### PR DESCRIPTION
Improve CompositeException to override getCause (which was null initially).
It also checks that at least one exception is passed.

It might be interested later to use suppressed exceptions.