### PR TITLE
Improvement around Uni creation and subscription

### DIFF
--- a/context-propagation/src/main/java/io/smallrye/mutiny/context/ContextPropagationUniInterceptor.java
+++ b/context-propagation/src/main/java/io/smallrye/mutiny/context/ContextPropagationUniInterceptor.java
@@ -48,7 +48,7 @@ public class ContextPropagationUniInterceptor implements UniInterceptor {
         return new AbstractUni<T>() {
             @Override
             protected void subscribing(UniSerializedSubscriber<? super T> subscriber) {
-                executor.execute(() -> uni.subscribe().withSubscriber(subscriber));
+                executor.execute(() -> AbstractUni.subscribe(uni, subscriber));
             }
         };
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniCreate.java
@@ -22,6 +22,8 @@ import io.smallrye.mutiny.operators.UniCreateFromDeferredSupplier;
 import io.smallrye.mutiny.operators.UniCreateFromPublisher;
 import io.smallrye.mutiny.operators.UniCreateWithEmitter;
 import io.smallrye.mutiny.operators.UniNever;
+import io.smallrye.mutiny.operators.uni.builders.KnownFailureUni;
+import io.smallrye.mutiny.operators.uni.builders.KnownItemUni;
 import io.smallrye.mutiny.subscription.UniEmitter;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 
@@ -259,7 +261,7 @@ public class UniCreate {
      * @return the new {@link Uni}
      */
     public <T> Uni<T> item(T item) {
-        return item(() -> item);
+        return Infrastructure.onUniCreation(new KnownItemUni<>(item));
     }
 
     /**
@@ -483,8 +485,7 @@ public class UniCreate {
      * @return the produced {@link Uni}
      */
     public <T> Uni<T> failure(Throwable failure) {
-        Throwable exception = ParameterValidation.nonNull(failure, "failure");
-        return failure(() -> exception);
+        return Infrastructure.onUniCreation(new KnownFailureUni<>(ParameterValidation.nonNull(failure, "failure")));
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniAndCombination.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniAndCombination.java
@@ -195,7 +195,8 @@ public class UniAndCombination<I, O> extends UniOperator<I, O> {
         }
 
         public void subscribe() {
-            uni.subscribe().withSubscriber(this);
+            //noinspection unchecked
+            AbstractUni.subscribe(uni, this);
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniBlockingAwait.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniBlockingAwait.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.validate;
 
 import java.time.Duration;
 import java.util.concurrent.CompletionException;
@@ -44,8 +45,7 @@ public class UniBlockingAwait {
                 latch.countDown();
             }
         };
-        nonNull(upstream, "upstream").subscribe().withSubscriber(subscriber);
-
+        AbstractUni.subscribe(upstream, subscriber);
         try {
             if (duration != null) {
                 if (!latch.await(duration.toMillis(), TimeUnit.MILLISECONDS)) {
@@ -75,7 +75,7 @@ public class UniBlockingAwait {
             return;
         }
         if (duration.isZero() || duration.isNegative()) {
-            throw new IllegalArgumentException("`duration` must be greater than zero`");
+            throw new IllegalArgumentException("`duration` must be greater than zero");
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCache.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCache.java
@@ -34,7 +34,7 @@ public class UniCache<I> extends UniOperator<I, I> implements UniSubscriber<I> {
                 case NOT_INITIALIZED:
                     // First subscriber,
                     state = SUBSCRIBING;
-                    action = () -> upstream().subscribe().withSubscriber(this);
+                    action = () -> AbstractUni.subscribe(upstream(), this);
                     subscribers.add(subscriber);
                     break;
                 case SUBSCRIBING:

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCallSubscribeOn.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCallSubscribeOn.java
@@ -42,7 +42,7 @@ public class UniCallSubscribeOn<I> extends UniOperator<I, I> {
 
         @Override
         public void run() {
-            upstream().subscribe().withSubscriber(this);
+            AbstractUni.subscribe(upstream(), this);
         }
 
         @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplier.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplier.java
@@ -13,7 +13,7 @@ public class UniCreateFromDeferredSupplier<T> extends UniOperator<Void, T> {
 
     public UniCreateFromDeferredSupplier(Supplier<? extends Uni<? extends T>> supplier) {
         super(null);
-        this.supplier = nonNull(supplier, "supplier");
+        this.supplier = supplier; // Already checked
     }
 
     @Override
@@ -32,7 +32,7 @@ public class UniCreateFromDeferredSupplier<T> extends UniOperator<Void, T> {
             subscriber.onSubscribe(CANCELLED);
             subscriber.onFailure(new NullPointerException(ParameterValidation.SUPPLIER_PRODUCED_NULL));
         } else {
-            uni.subscribe().withSubscriber(subscriber);
+            AbstractUni.subscribe(uni, subscriber);
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniDelayOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniDelayOnItem.java
@@ -27,7 +27,7 @@ public class UniDelayOnItem<T> extends UniOperator<T, T> {
     protected void subscribing(UniSerializedSubscriber<? super T> subscriber) {
         AtomicReference<ScheduledFuture<?>> holder = new AtomicReference<>();
         AtomicReference<UniSubscription> reference = new AtomicReference<>();
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<T, T>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<T, T>(subscriber) {
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 if (reference.compareAndSet(null, subscription)) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniDelayUntil.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniDelayUntil.java
@@ -24,7 +24,7 @@ public class UniDelayUntil<T> extends UniOperator<T, T> {
     @Override
     protected void subscribing(UniSerializedSubscriber<? super T> subscriber) {
         AtomicReference<UniSubscription> reference = new AtomicReference<>();
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<T, T>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<T, T>(subscriber) {
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 if (reference.compareAndSet(null, subscription)) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniEmitOn.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniEmitOn.java
@@ -16,7 +16,7 @@ public class UniEmitOn<I> extends UniOperator<I, I> {
 
     @Override
     protected void subscribing(UniSerializedSubscriber<? super I> subscriber) {
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<I, I>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<I, I>(subscriber) {
             @Override
             public void onItem(I item) {
                 executor.execute(() -> subscriber.onItem(item));

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniFailOnTimeout.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniFailOnTimeout.java
@@ -36,7 +36,7 @@ public class UniFailOnTimeout<I> extends UniOperator<I, I> {
         AtomicBoolean doneOrCancelled = new AtomicBoolean();
         AtomicReference<ScheduledFuture<?>> task = new AtomicReference<>();
 
-        upstream().subscribe().withSubscriber(new UniSubscriber<I>() {
+        AbstractUni.subscribe(upstream(), new UniSubscriber<I>() {
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 // Configure the watch dog at subscription time.

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniFlatMapCompletionStageOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniFlatMapCompletionStageOnItem.java
@@ -41,8 +41,7 @@ public class UniFlatMapCompletionStageOnItem<I, O> extends UniOperator<I, O> {
                     flatMapSubscription.replace(secondSubscription);
                 }
             };
-
-            Uni.createFrom().completionStage(outcome).subscribe().withSubscriber(delegate);
+            AbstractUni.subscribe(Uni.createFrom().completionStage(outcome), delegate);
         }
     }
 
@@ -50,7 +49,7 @@ public class UniFlatMapCompletionStageOnItem<I, O> extends UniOperator<I, O> {
     protected void subscribing(UniSerializedSubscriber<? super O> subscriber) {
         UniOnItemFlatMap.FlatMapSubscription flatMapSubscription = new UniOnItemFlatMap.FlatMapSubscription();
         // Subscribe to the source.
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<I, O>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<I, O>(subscriber) {
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 flatMapSubscription.setInitialUpstream(subscription);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnCancellation.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnCancellation.java
@@ -15,7 +15,7 @@ public class UniOnCancellation<T> extends UniOperator<T, T> {
 
     @Override
     protected void subscribing(UniSerializedSubscriber<? super T> subscriber) {
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<T, T>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<T, T>(subscriber) {
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 super.onSubscribe(() -> {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnFailureFlatMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnFailureFlatMap.java
@@ -26,7 +26,7 @@ public class UniOnFailureFlatMap<I> extends UniOperator<I, I> {
     protected void subscribing(UniSerializedSubscriber<? super I> subscriber) {
         UniOnItemFlatMap.FlatMapSubscription flatMapSubscription = new UniOnItemFlatMap.FlatMapSubscription();
         // Subscribe to the source.
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<I, I>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<I, I>(subscriber) {
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 flatMapSubscription.setInitialUpstream(subscription);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnFailureMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnFailureMap.java
@@ -24,7 +24,7 @@ public class UniOnFailureMap<I, O> extends UniOperator<I, O> {
 
     @Override
     protected void subscribing(UniSerializedSubscriber<? super O> subscriber) {
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<I, O>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<I, O>(subscriber) {
 
             @Override
             public void onFailure(Throwable failure) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemConsume.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemConsume.java
@@ -23,7 +23,7 @@ public class UniOnItemConsume<T> extends UniOperator<T, T> {
 
     @Override
     protected void subscribing(UniSerializedSubscriber<? super T> subscriber) {
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<T, T>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<T, T>(subscriber) {
             @Override
             public void onItem(T item) {
                 if (invokeEventHandler(onItemCallback, item, false, subscriber)) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemFlatMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemFlatMap.java
@@ -54,8 +54,7 @@ public class UniOnItemFlatMap<I, O> extends UniOperator<I, O> {
                     flatMapSubscription.replace(secondSubscription);
                 }
             };
-
-            outcome.subscribe().withSubscriber(delegate);
+            AbstractUni.subscribe(outcome, delegate);
         }
     }
 
@@ -63,7 +62,7 @@ public class UniOnItemFlatMap<I, O> extends UniOperator<I, O> {
     protected void subscribing(UniSerializedSubscriber<? super O> subscriber) {
         FlatMapSubscription flatMapSubscription = new FlatMapSubscription();
         // Subscribe to the source.
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<I, O>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<I, O>(subscriber) {
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 flatMapSubscription.setInitialUpstream(subscription);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemMap.java
@@ -16,7 +16,7 @@ public class UniOnItemMap<I, O> extends UniOperator<I, O> {
 
     @Override
     protected void subscribing(UniSerializedSubscriber<? super O> subscriber) {
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<I, O>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<I, O>(subscriber) {
 
             @Override
             public void onItem(I item) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureConsume.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureConsume.java
@@ -17,7 +17,7 @@ public class UniOnItemOrFailureConsume<T> extends UniOperator<T, T> {
 
     @Override
     protected void subscribing(UniSerializedSubscriber<? super T> subscriber) {
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<T, T>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<T, T>(subscriber) {
             @Override
             public void onItem(T item) {
                 if (invokeCallback(item, null, subscriber)) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureFlatMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureFlatMap.java
@@ -45,7 +45,7 @@ public class UniOnItemOrFailureFlatMap<I, O> extends UniOperator<I, O> {
     protected void subscribing(UniSerializedSubscriber<? super O> subscriber) {
         UniOnItemFlatMap.FlatMapSubscription flatMapSubscription = new UniOnItemFlatMap.FlatMapSubscription();
         // Subscribe to the source.
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<I, O>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<I, O>(subscriber) {
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 flatMapSubscription.setInitialUpstream(subscription);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureMap.java
@@ -17,7 +17,7 @@ public class UniOnItemOrFailureMap<I, O> extends UniOperator<I, O> {
 
     @Override
     protected void subscribing(UniSerializedSubscriber<? super O> subscriber) {
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<I, O>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<I, O>(subscriber) {
 
             @Override
             public void onItem(I item) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnSubscription.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnSubscription.java
@@ -18,7 +18,7 @@ public class UniOnSubscription<T> extends UniOperator<T, T> {
 
     @Override
     protected void subscribing(UniSerializedSubscriber<? super T> subscriber) {
-        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<T, T>(subscriber) {
+        AbstractUni.subscribe(upstream(), new UniDelegatingSubscriber<T, T>(subscriber) {
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 try {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnTermination.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnTermination.java
@@ -17,7 +17,7 @@ public class UniOnTermination<T> extends UniOperator<T, T> {
 
     @Override
     protected void subscribing(UniSerializedSubscriber<? super T> subscriber) {
-        upstream().subscribe().withSubscriber(
+        AbstractUni.subscribe(upstream(),
                 new UniDelegatingSubscriber<T, T>(subscriber) {
                     @Override
                     public void onSubscribe(UniSubscription subscription) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOrCombination.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOrCombination.java
@@ -43,7 +43,7 @@ public class UniOrCombination<T> extends UniOperator<Void, T> {
         if (challengers.size() == 1) {
             // Just subscribe to the first and unique uni.
             Uni<? super T> uni = challengers.get(0);
-            uni.subscribe().withSubscriber((UniSubscriber) subscriber);
+            AbstractUni.subscribe(uni, (UniSubscriber) subscriber);
             return;
         }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniProduceMultiOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniProduceMultiOnItem.java
@@ -33,7 +33,7 @@ public class UniProduceMultiOnItem<I, O> extends AbstractMulti<O> {
         if (subscriber == null) {
             throw new NullPointerException("The subscriber must not be `null`");
         }
-        upstream.subscribe().withSubscriber(new FlatMapPublisherSubscriber<>(subscriber, mapper));
+        AbstractUni.subscribe(upstream, new FlatMapPublisherSubscriber<>(subscriber, mapper));
     }
 
     @SuppressWarnings("SubscriberImplementation")

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniRetryAtMost.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniRetryAtMost.java
@@ -72,10 +72,10 @@ public class UniRetryAtMost<T> extends UniOperator<T, T> {
             }
         };
 
-        upstream().subscribe().withSubscriber(retryingSubscriber);
+        AbstractUni.subscribe(upstream(), retryingSubscriber);
     }
 
     private void resubscribe(Uni<? extends T> upstream, UniSubscriber<T> subscriber) {
-        upstream.subscribe().withSubscriber(subscriber);
+        AbstractUni.subscribe(upstream, subscriber);
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniSubscribeToCompletionStage.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniSubscribeToCompletionStage.java
@@ -29,7 +29,7 @@ public class UniSubscribeToCompletionStage {
             }
         };
 
-        uni.subscribe().withSubscriber(new UniSubscriber<T>() {
+        AbstractUni.subscribe(uni, new UniSubscriber<T>() {
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 if (!ref.compareAndSet(null, subscription)) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/KnownFailureUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/KnownFailureUni.java
@@ -1,0 +1,26 @@
+package io.smallrye.mutiny.operators.uni.builders;
+
+import io.smallrye.mutiny.helpers.EmptyUniSubscription;
+import io.smallrye.mutiny.operators.AbstractUni;
+import io.smallrye.mutiny.operators.UniSerializedSubscriber;
+
+/**
+ * Specialized {@link io.smallrye.mutiny.Uni} implementation for the case where the failure is known.
+ * The failure cannot be {@code null}.
+ *
+ * @param <T> the type of the item
+ */
+public class KnownFailureUni<T> extends AbstractUni<T> {
+
+    private final Throwable failure;
+
+    public KnownFailureUni(Throwable failure) {
+        this.failure = failure;
+    }
+
+    @Override
+    protected void subscribing(UniSerializedSubscriber<? super T> subscriber) {
+        subscriber.onSubscribe(EmptyUniSubscription.CANCELLED);
+        subscriber.onFailure(failure);
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/KnownItemUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/KnownItemUni.java
@@ -1,0 +1,27 @@
+package io.smallrye.mutiny.operators.uni.builders;
+
+import io.smallrye.mutiny.helpers.EmptyUniSubscription;
+import io.smallrye.mutiny.operators.AbstractUni;
+import io.smallrye.mutiny.operators.UniSerializedSubscriber;
+
+/**
+ * Specialized {@link io.smallrye.mutiny.Uni} implementation for the case where the item is known.
+ * The item can be {@code null}.
+ *
+ * @param <T> the type of the item
+ */
+public class KnownItemUni<T> extends AbstractUni<T> {
+
+    private final T item;
+
+    public KnownItemUni(T item) {
+        this.item = item;
+    }
+
+    @Override
+    protected void subscribing(UniSerializedSubscriber<? super T> subscriber) {
+        // No need to track cancellation, it's done by the serialized subscriber downstream.
+        subscriber.onSubscribe(EmptyUniSubscription.CANCELLED);
+        subscriber.onItem(item);
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemFailTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemFailTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Uni;
 
-public class UniOnItemFail {
+public class UniOnItemFailTest {
 
     private Uni<Integer> one = Uni.createFrom().item(1);
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/builders/KnownFailureUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/builders/KnownFailureUniTest.java
@@ -1,0 +1,42 @@
+package io.smallrye.mutiny.operators.uni.builders;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.UniAssertSubscriber;
+
+public class KnownFailureUniTest {
+
+    @Test
+    public void testCreationWithFailure() {
+        assertThatThrownBy(() -> Uni.createFrom().failure(new IOException("io")).await().indefinitely())
+                .hasCauseInstanceOf(IOException.class).hasMessageContaining("io");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testCreationWithNull() {
+        Uni.createFrom().failure((Throwable) null);
+    }
+
+    @Test
+    public void testCancellationAfterEmission() {
+        UniAssertSubscriber<String> hello = Uni.createFrom().<String> failure(new IOException("boom"))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        hello.cancel();
+        hello.assertFailure(IOException.class, "boom");
+    }
+
+    @Test
+    public void testCancellationBeforeEmission() {
+        UniAssertSubscriber<String> subscriber = new UniAssertSubscriber<>(true);
+        Uni.createFrom().<String> failure(new IOException("boom"))
+                .subscribe().withSubscriber(subscriber);
+        subscriber.assertNotCompleted();
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/builders/KnownItemUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/builders/KnownItemUniTest.java
@@ -1,0 +1,39 @@
+package io.smallrye.mutiny.operators.uni.builders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.UniAssertSubscriber;
+
+public class KnownItemUniTest {
+
+    @Test
+    public void testCreationWithItem() {
+        assertThat(Uni.createFrom().item("hello").await().indefinitely()).isEqualTo("hello");
+    }
+
+    @Test
+    public void testCreationWithNull() {
+        assertThat(Uni.createFrom().item((String) null).await().indefinitely()).isNull();
+    }
+
+    @Test
+    public void testCancellationAfterEmission() {
+        UniAssertSubscriber<String> hello = Uni.createFrom().item("hello")
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        hello.cancel();
+        hello.assertCompletedSuccessfully().assertItem("hello");
+    }
+
+    @Test
+    public void testCancellationBeforeEmission() {
+        UniAssertSubscriber<String> subscriber = new UniAssertSubscriber<>(true);
+        Uni.createFrom().item("hello")
+                .subscribe().withSubscriber(subscriber);
+        subscriber.assertNotCompleted();
+    }
+
+}


### PR DESCRIPTION
Add specialized implementation of Uni when we know the item/failure. It avoids delegating to an emitter.
Optimized the subscription on a Uni, if this Uni is an AbstractUni. 