### PR TITLE
Use suppressed exception instead of explicit list in CompositeException

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/CompositeException.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/CompositeException.java
@@ -2,9 +2,7 @@ package io.smallrye.mutiny;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import io.smallrye.mutiny.groups.UniAndGroup;
 import io.smallrye.mutiny.helpers.ParameterValidation;
@@ -16,15 +14,17 @@ import io.smallrye.mutiny.helpers.ParameterValidation;
  * Uses {@link #getCauses()} to retrieves the individual causes.
  * {@link #getCause()} returns the first cause.
  *
+ * Causes, except the first one, are stored as suppressed exception.
+ *
  * @see UniAndGroup
  */
 public class CompositeException extends RuntimeException {
 
-    private final List<Throwable> causes;
-
     public CompositeException(List<Throwable> causes) {
         super("Multiple exceptions caught:", getFirstOrFail(causes));
-        this.causes = Collections.unmodifiableList(causes);
+        for (int i = 1; i < causes.size(); i++) {
+            addSuppressed(causes.get(i));
+        }
     }
 
     private static Throwable getFirstOrFail(List<Throwable> causes) {
@@ -43,28 +43,42 @@ public class CompositeException extends RuntimeException {
 
     public CompositeException(Throwable... causes) {
         super("Multiple exceptions caught:", getFirstOrFail(causes));
-        this.causes = Arrays.asList(causes);
+        for (int i = 1; i < causes.length; i++) {
+            addSuppressed(causes[i]);
+        }
     }
 
     public CompositeException(CompositeException other, Throwable toBeAppended) {
-        List<Throwable> c = new ArrayList<>(other.causes);
-        c.add(toBeAppended);
-        this.causes = Collections.unmodifiableList(c);
-        initCause(getFirstOrFail(this.causes));
+        Throwable[] suppressed = other.getSuppressed();
+        for (Throwable throwable : suppressed) {
+            addSuppressed(throwable);
+        }
+        addSuppressed(toBeAppended);
+        initCause(other.getCause());
     }
 
     @Override
     public String getMessage() {
-        StringBuilder message = Optional.ofNullable(super.getMessage()).map(StringBuilder::new).orElse(null);
-        for (int i = 0; i < causes.size(); i++) {
-            Throwable cause = causes.get(i);
-            message = (message == null ? new StringBuilder("null") : message).append("\n\t[Exception ").append(i)
-                    .append("] ").append(cause);
+        String messageFromSuper = super.getMessage();
+        StringBuilder message;
+        if (messageFromSuper != null) {
+            message = new StringBuilder(messageFromSuper);
+        } else {
+            message = new StringBuilder();
         }
-        return message == null ? null : message.toString();
+        message.append("\n\t[Exception 0] ").append(getCause());
+        Throwable[] suppressed = getSuppressed();
+        for (int i = 0; i < suppressed.length; i++) {
+            Throwable cause = suppressed[i];
+            message.append("\n\t[Exception ").append(i + 1).append("] ").append(cause);
+        }
+        return message.toString();
     }
 
     public List<Throwable> getCauses() {
+        List<Throwable> causes = new ArrayList<>();
+        causes.add(getCause());
+        causes.addAll(Arrays.asList(getSuppressed()));
         return causes;
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/CompositeExceptionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/CompositeExceptionTest.java
@@ -26,12 +26,15 @@ public class CompositeExceptionTest {
         assertThat(ce2).getCause().isEqualTo(IO);
 
         assertThat(ce1.getCauses()).containsExactly(IAE, IO, OUPS);
+        assertThat(ce1.getSuppressed()).containsExactly(IO, OUPS);
         assertThat(ce2.getCauses()).containsExactly(IO, IAE, OUPS);
+        assertThat(ce2.getSuppressed()).containsExactly(IAE, OUPS);
 
         CompositeException ce3 = new CompositeException(OUPS);
         assertThat(ce3).hasMessageContaining("oups");
         assertThat(ce3.getCauses()).containsExactly(OUPS);
         assertThat(ce3.getCause()).isEqualTo(OUPS);
+        assertThat(ce3.getSuppressed()).isEmpty();
     }
 
     @Test
@@ -44,12 +47,15 @@ public class CompositeExceptionTest {
         assertThat(ce2).getCause().isEqualTo(IO);
 
         assertThat(ce1.getCauses()).containsExactly(IAE, IO, OUPS);
+        assertThat(ce1.getSuppressed()).containsExactly(IO, OUPS);
         assertThat(ce2.getCauses()).containsExactly(IO, IAE, OUPS);
+        assertThat(ce2.getSuppressed()).containsExactly(IAE, OUPS);
 
         CompositeException ce3 = new CompositeException(Collections.singletonList(OUPS));
         assertThat(ce3).hasMessageContaining("oups");
         assertThat(ce3.getCauses()).containsExactly(OUPS);
         assertThat(ce3.getCause()).isEqualTo(OUPS);
+        assertThat(ce3.getSuppressed()).isEmpty();
     }
 
     @Test
@@ -82,6 +88,14 @@ public class CompositeExceptionTest {
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new CompositeException(Collections.emptyList()))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testWithASingleException() {
+        CompositeException ce = new CompositeException(IAE);
+        assertThat(ce.getCauses()).hasSize(1);
+        assertThat(ce.getCause()).isEqualTo(IAE);
+        assertThat(ce.getSuppressed()).isEmpty();
     }
 
 }


### PR DESCRIPTION
Refactor CompositeException to use suppressed exceptions instead of the explicit list.﻿
