### PR TITLE
Mark functional interfaces in Functions

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Functions.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Functions.java
@@ -4,7 +4,10 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class Functions {
+public final class Functions {
+
+    private Functions() {
+    }
 
     private static final Consumer NOOP_CONSUMER = x -> {
     };
@@ -31,6 +34,7 @@ public class Functions {
         }
     }
 
+    @FunctionalInterface
     public interface Function4<T1, T2, T3, T4, R> extends Function<List<Object>, R> {
         R apply(T1 item1, T2 item2, T3 item3, T4 item4);
 
@@ -41,6 +45,7 @@ public class Functions {
         }
     }
 
+    @FunctionalInterface
     public interface Function5<T1, T2, T3, T4, T5, R> extends Function<List<Object>, R> {
         R apply(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5);
 
@@ -52,6 +57,7 @@ public class Functions {
         }
     }
 
+    @FunctionalInterface
     public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Function<List<Object>, R> {
         R apply(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6);
 
@@ -63,6 +69,7 @@ public class Functions {
         }
     }
 
+    @FunctionalInterface
     public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Function<List<Object>, R> {
         R apply(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7);
 
@@ -74,6 +81,7 @@ public class Functions {
         }
     }
 
+    @FunctionalInterface
     public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Function<List<Object>, R> {
         R apply(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8); // NOSONAR
 
@@ -86,6 +94,7 @@ public class Functions {
         }
     }
 
+    @FunctionalInterface
     public interface Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> extends Function<List<Object>, R> {
         R apply(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8, T9 item9); // NOSONAR
 
@@ -105,6 +114,7 @@ public class Functions {
      * @param <B> the type of the second parameter
      * @param <C> the type of the third parameter
      */
+    @FunctionalInterface
     public interface TriConsumer<A, B, C> {
         void accept(A a, B b, C c);
     }


### PR DESCRIPTION
This is cosmetic but aligns all interfaces since one was already marked with `@FunctionalInterface`.

Fixes #191