### PR TITLE
Rename Uni/Multi apply to transform

### DIFF
--- a/documentation/src/main/docs/faq.adoc
+++ b/documentation/src/main/docs/faq.adoc
@@ -2,7 +2,7 @@
 
 === How do I transform items?
 
-To transform items synchronously use the `apply` operators:
+To transform items synchronously use the `transform` operators:
 
 [source,java,indent=0]
 ----

--- a/documentation/src/test/java/snippets/BroadcastProcessorTest.java
+++ b/documentation/src/test/java/snippets/BroadcastProcessorTest.java
@@ -12,7 +12,7 @@ public class BroadcastProcessorTest {
         // tag::code[]
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
         Multi<String> multi = processor
-                .onItem().apply(String::toUpperCase)
+                .onItem().transform(String::toUpperCase)
                 .onFailure().recoverWithItem("d'oh");
 
         new Thread(() -> {

--- a/documentation/src/test/java/snippets/FlatMapTest.java
+++ b/documentation/src/test/java/snippets/FlatMapTest.java
@@ -63,7 +63,7 @@ public class FlatMapTest {
                 .await().indefinitely();
 
         List<Integer> list = multi
-                .onItem().apply(i -> i + 1)
+                .onItem().transform(i -> i + 1)
                 .collectItems().asList()
                 .await().indefinitely();
 

--- a/documentation/src/test/java/snippets/GettingStarted.java
+++ b/documentation/src/test/java/snippets/GettingStarted.java
@@ -8,7 +8,7 @@ public class GettingStarted {
 
     public static void main(String[] args) {
         Multi.createFrom().items("hello", "world")
-                .onItem().apply(s -> s.toUpperCase() + " ")
+                .onItem().transform(s -> s.toUpperCase() + " ")
                 .onCompletion().continueWith("!")
                 .subscribe().with(System.out::print);
     }

--- a/documentation/src/test/java/snippets/HowToTransformTest.java
+++ b/documentation/src/test/java/snippets/HowToTransformTest.java
@@ -20,10 +20,10 @@ public class HowToTransformTest {
 
         // tag::sync[]
         String result1 = uni
-                .onItem().apply(s -> s.toUpperCase())
+                .onItem().transform(s -> s.toUpperCase())
                 .await().indefinitely();
         List<String> result2 = multi
-                .onItem().apply(s -> s.toUpperCase())
+                .onItem().transform(String::toUpperCase)
                 .collectItems().asList().await().indefinitely();
         // end::sync[]
 
@@ -42,10 +42,10 @@ public class HowToTransformTest {
 
         // tag::sync-unchecked[]
         String result1 = uni
-                .onItem().apply(function(this::operationThrowingException))
+                .onItem().transform(function(this::operationThrowingException))
                 .await().indefinitely();
         List<String> result2 = multi
-                .onItem().apply(function(this::operationThrowingException))
+                .onItem().transform(function(this::operationThrowingException))
                 .collectItems().asList().await().indefinitely();
         // end::sync-unchecked[]
 

--- a/documentation/src/test/java/snippets/MultiFailureTest.java
+++ b/documentation/src/test/java/snippets/MultiFailureTest.java
@@ -18,7 +18,7 @@ public class MultiFailureTest {
         Multi<String> multi = Multi.createFrom().failure(new IOException("boom"));
         // tag::code[]
 
-        CompletableFuture<String> res0 = multi.onFailure().apply(failure -> new MyBusinessException("oh no!"))
+        CompletableFuture<String> res0 = multi.onFailure().transform(failure -> new MyBusinessException("oh no!"))
                 .collectItems().first()
                 .subscribeAsCompletionStage();
 

--- a/documentation/src/test/java/snippets/RunSubscriptionOnTest.java
+++ b/documentation/src/test/java/snippets/RunSubscriptionOnTest.java
@@ -22,7 +22,7 @@ public class RunSubscriptionOnTest {
             // called on a thread from the executor
             return retrieveItemsFromSource();
         })
-                .onItem().apply(this::applySomeOperation)
+                .onItem().transform(this::applySomeOperation)
                 .runSubscriptionOn(executor)
                 .subscribe().with(
                 item -> System.out.println("Item: " + item),
@@ -41,7 +41,7 @@ public class RunSubscriptionOnTest {
         //tag::emitOn[]
         Multi.createFrom().items(this::retrieveItemsFromSource)
                 .emitOn(executor)
-                .onItem().apply(this::applySomeOperation)
+                .onItem().transform(this::applySomeOperation)
                 .subscribe().with(
                 item -> System.out.println("Item: " + item),
                 Throwable::printStackTrace,

--- a/documentation/src/test/java/snippets/ThenTest.java
+++ b/documentation/src/test/java/snippets/ThenTest.java
@@ -17,8 +17,8 @@ public class ThenTest {
                 .then(self -> {
                     // Transform each item into a string of the item +1
                     return self
-                            .onItem().apply(i -> i + 1)
-                            .onItem().apply(i -> Integer.toString(i));
+                            .onItem().transform(i -> i + 1)
+                            .onItem().transform(i -> Integer.toString(i));
                 })
                 .then(self -> self
                         .onItem().invoke(item -> System.out.println("The item is " + item))

--- a/documentation/src/test/java/snippets/UniBlockingTest.java
+++ b/documentation/src/test/java/snippets/UniBlockingTest.java
@@ -24,7 +24,7 @@ public class UniBlockingTest {
         // tag::code-emitOn[]
         Multi<String> multi = Multi.createFrom().items("john", "jack", "sue")
                 .emitOn(Infrastructure.getDefaultWorkerPool())
-                .onItem().apply(this::invokeRemoteServiceUsingBlockingIO);
+                .onItem().transform(this::invokeRemoteServiceUsingBlockingIO);
         // end::code-emitOn[]
         assertThat(multi.collectItems().asList().await().indefinitely()).containsExactly("JOHN", "JACK", "SUE");
     }

--- a/documentation/src/test/java/snippets/UniMultiComparisonTest.java
+++ b/documentation/src/test/java/snippets/UniMultiComparisonTest.java
@@ -11,13 +11,13 @@ public class UniMultiComparisonTest {
     public void comparison() {
         //tag::code[]
         Multi.createFrom().items("a", "b", "c")
-                .onItem().apply(i -> i.toUpperCase())
+                .onItem().transform(i -> i.toUpperCase())
                 .subscribe().with(
                         item -> System.out.println("Received: " + item),
                         failure -> System.out.println("Failed with " + failure.getMessage()));
 
         Uni.createFrom().item("a")
-                .onItem().apply(i -> i.toUpperCase())
+                .onItem().transform(i -> i.toUpperCase())
                 .subscribe().with(
                         item -> System.out.println("Received: " + item),
                         failure -> System.out.println("Failed with " + failure.getMessage()));
@@ -29,14 +29,14 @@ public class UniMultiComparisonTest {
     public void conversion() {
         //tag::conversion[]
         Multi.createFrom().items("a", "b", "c")
-                .onItem().apply(i -> i.toUpperCase())
+                .onItem().transform(i -> i.toUpperCase())
                 .toUni() // Convert the multi to uni, only "a" will be forwarded.
                 .subscribe().with(
                         item -> System.out.println("Received: " + item),
                         failure -> System.out.println("Failed with " + failure.getMessage()));
 
         Uni.createFrom().item("a")
-                .onItem().apply(i -> i.toUpperCase())
+                .onItem().transform(i -> i.toUpperCase())
                 .toMulti() // Convert the uni to a multi, the completion event will be fired after the emission of "a"
                 .subscribe().with(
                         item -> System.out.println("Received: " + item),

--- a/documentation/src/test/java/snippets/UniNullTest.java
+++ b/documentation/src/test/java/snippets/UniNullTest.java
@@ -25,12 +25,12 @@ public class UniNullTest {
         Uni<String> uni = Uni.createFrom().item(() -> null);
         // tag::code-not-null[]
         uni
-                .onItem().ifNotNull().apply(String::toUpperCase)
+                .onItem().ifNotNull().transform(String::toUpperCase)
                 .onItem().ifNull().continueWith("yolo!");
         // end::code-not-null[]
 
         String r = uni
-                .onItem().ifNotNull().apply(String::toUpperCase)
+                .onItem().ifNotNull().transform(String::toUpperCase)
                 .onItem().ifNull().continueWith("yolo!")
                 .await().indefinitely();
         assertThat(r).isEqualTo("yolo!");

--- a/documentation/src/test/java/snippets/UnicastProcessorTest.java
+++ b/documentation/src/test/java/snippets/UnicastProcessorTest.java
@@ -15,7 +15,7 @@ public class UnicastProcessorTest {
         // tag::code[]
         UnicastProcessor<String> processor = UnicastProcessor.create();
         Multi<String> multi = processor
-                .onItem().apply(String::toUpperCase)
+                .onItem().transform(String::toUpperCase)
                 .onFailure().recoverWithItem("d'oh");
 
         // Create a source of items that does not follow the request protocol

--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -285,7 +285,7 @@ public interface Multi<T> extends Publisher<T> {
      * @return the new {@link Multi}
      */
     default <O> Multi<O> map(Function<? super T, ? extends O> mapper) {
-        return onItem().apply(nonNull(mapper, "mapper"));
+        return onItem().transform(nonNull(mapper, "mapper"));
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnFailure.java
@@ -120,8 +120,21 @@ public class MultiOnFailure<T> {
      *
      * @param mapper the mapper function, must not be {@code null}, must not return {@code null}
      * @return the new {@link Multi}
+     * @deprecated use {@link #transform(Function)}
      */
+    @Deprecated
     public Multi<T> apply(Function<? super Throwable, ? extends Throwable> mapper) {
+        return transform(mapper);
+    }
+
+    /**
+     * Produces a new {@link Multi} invoking the given function when the current {@link Multi} propagates a failure. The
+     * function can transform the received failure into another exception that will be fired as failure downstream.
+     *
+     * @param mapper the mapper function, must not be {@code null}, must not return {@code null}
+     * @return the new {@link Multi}
+     */
+    public Multi<T> transform(Function<? super Throwable, ? extends Throwable> mapper) {
         return Infrastructure.onMultiCreation(new MultiMapOnFailure<>(upstream, predicate, mapper));
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItem.java
@@ -42,8 +42,25 @@ public class MultiOnItem<T> {
      * @param mapper the mapper function, must not be {@code null}
      * @param <R> the type of item produced by the mapper function
      * @return the new {@link Multi}
+     * @deprecated Use {@link #transform(Function)}
      */
+    @Deprecated
     public <R> Multi<R> apply(Function<? super T, ? extends R> mapper) {
+        return transform(mapper);
+    }
+
+    /**
+     * Produces a new {@link Multi} invoking the given function for each item emitted by the upstream {@link Multi}.
+     * <p>
+     * The function receives the received item as parameter, and can transform it. The returned object is sent
+     * downstream as {@code item} event.
+     * <p>
+     *
+     * @param mapper the mapper function, must not be {@code null}
+     * @param <R> the type of item produced by the mapper function
+     * @return the new {@link Multi}
+     */
+    public <R> Multi<R> transform(Function<? super T, ? extends R> mapper) {
         return Infrastructure.onMultiCreation(new MultiMapOp<>(upstream, nonNull(mapper, "mapper")));
     }
 
@@ -256,7 +273,7 @@ public class MultiOnItem<T> {
      */
     public <O> Multi<O> castTo(Class<O> target) {
         nonNull(target, "target");
-        return apply(target::cast);
+        return transform(target::cast);
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
@@ -93,8 +93,21 @@ public class UniOnFailure<T> {
      *
      * @param mapper the mapper function, must not be {@code null}, must not return {@code null}
      * @return the new {@link Uni}
+     * @deprecated use {@link #transform(Function)}
      */
+    @Deprecated
     public Uni<T> apply(Function<? super Throwable, ? extends Throwable> mapper) {
+        return transform(mapper);
+    }
+
+    /**
+     * Produces a new {@link Uni} invoking the given function when the current {@link Uni} propagates a failure. The
+     * function can transform the received failure into another exception that will be fired as failure downstream.
+     *
+     * @param mapper the mapper function, must not be {@code null}, must not return {@code null}
+     * @return the new {@link Uni}
+     */
+    public Uni<T> transform(Function<? super Throwable, ? extends Throwable> mapper) {
         return Infrastructure.onUniCreation(new UniOnFailureMap<>(upstream, predicate, mapper));
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItem.java
@@ -70,8 +70,25 @@ public class UniOnItem<T> {
      * @param mapper the mapper function, must not be {@code null}
      * @param <R> the type of Uni item
      * @return the new {@link Uni}
+     * @deprecated use {@link #transform(Function)}
      */
+    @Deprecated
     public <R> Uni<R> apply(Function<? super T, ? extends R> mapper) {
+        return transform(mapper);
+    }
+
+    /**
+     * Produces a new {@link Uni} invoking the given function when the current {@link Uni} fires the {@code item} event.
+     * The function receives the item as parameter, and can transform it. The returned object is sent downstream
+     * as {@code item}.
+     * <p>
+     * For asynchronous composition, see {@link #produceUni(Function)}.
+     *
+     * @param mapper the mapper function, must not be {@code null}
+     * @param <R> the type of Uni item
+     * @return the new {@link Uni}
+     */
+    public <R> Uni<R> transform(Function<? super T, ? extends R> mapper) {
         return Infrastructure.onUniCreation(new UniOnItemMap<>(upstream, mapper));
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItemOrFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItemOrFailure.java
@@ -79,8 +79,28 @@ public class UniOnItemOrFailure<T> {
      * @param mapper the mapper function, must not be {@code null}
      * @param <R> the type of Uni item
      * @return the new {@link Uni}
+     * @deprecated use {@link #transform(BiFunction)}
      */
+    @Deprecated
     public <R> Uni<R> apply(BiFunction<? super T, Throwable, ? extends R> mapper) {
+        return transform(mapper);
+    }
+
+    /**
+     * Produces a new {@link Uni} invoking the given function when the current {@link Uni} fires the {@code item} or
+     * {@code failure} event. Note that the item can be {@code null}, so detecting failures must be done by checking
+     * whether the {@code failure} parameter is {@code null}.
+     * <p>
+     * The function receives the item and failure as parameters, and can transform the item or recover from the failure.
+     * The returned object is sent downstream as {@code item}.
+     * <p>
+     * For asynchronous composition, see {@link #produceUni(BiFunction)}.
+     *
+     * @param mapper the mapper function, must not be {@code null}
+     * @param <R> the type of Uni item
+     * @return the new {@link Uni}
+     */
+    public <R> Uni<R> transform(BiFunction<? super T, Throwable, ? extends R> mapper) {
         return Infrastructure.onUniCreation(new UniOnItemOrFailureMap<>(upstream, mapper));
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNotNull.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNotNull.java
@@ -70,8 +70,27 @@ public class UniOnNotNull<T> {
      * @param mapper the mapper function, must not be {@code null}
      * @param <R> the type of Uni item
      * @return the new {@link Uni}
+     * @deprecated use {@link #transform(Function)}
      */
+    @Deprecated
     public <R> Uni<R> apply(Function<? super T, ? extends R> mapper) {
+        return transform(mapper);
+    }
+
+    /**
+     * Produces a new {@link Uni} invoking the given function when the current {@link Uni} fires the {@code item} event.
+     * The function receives the (non-null) item as parameter, and can transform it. The returned object is sent downstream
+     * as {@code item}.
+     * <p>
+     * If the item is `null`, the mapper is not called and it produces a {@code null} item.
+     * <p>
+     * For asynchronous composition, see {@link #produceUni(Function)}.
+     *
+     * @param mapper the mapper function, must not be {@code null}
+     * @param <R> the type of Uni item
+     * @return the new {@link Uni}
+     */
+    public <R> Uni<R> transform(Function<? super T, ? extends R> mapper) {
         return upstream.onItem().apply(item -> {
             if (item != null) {
                 return mapper.apply(item);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiConcatTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiConcatTest.java
@@ -18,7 +18,7 @@ public class MultiConcatTest {
         MultiAssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().streams(
                 Multi.createFrom().item(5),
                 Multi.createFrom().range(1, 3),
-                Multi.createFrom().items(8, 9, 10).onItem().apply(i -> i + 1)).subscribe()
+                Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)).subscribe()
                 .withSubscriber(new MultiAssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
@@ -27,6 +27,19 @@ public class MultiConcatTest {
 
     @Test
     public void testConcatenationOfSeveralMultisWithConcurrency() {
+        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().concatenating()
+                .streams(
+                        Multi.createFrom().item(5),
+                        Multi.createFrom().range(1, 3),
+                        Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1))
+                .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
+
+        subscriber.assertCompletedSuccessfully()
+                .assertReceived(5, 1, 2, 9, 10, 11);
+    }
+
+    @Test
+    public void testConcatenationOfSeveralMultisWithConcurrencyAndDeprecatedApply() {
         MultiAssertSubscriber<Integer> subscriber = Multi.createBy().concatenating()
                 .streams(
                         Multi.createFrom().item(5),
@@ -44,7 +57,7 @@ public class MultiConcatTest {
                 Arrays.asList(
                         Multi.createFrom().item(5),
                         Multi.createFrom().range(1, 3),
-                        Multi.createFrom().items(8, 9, 10).onItem().apply(i -> i + 1)))
+                        Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)))
                 .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
@@ -56,7 +69,7 @@ public class MultiConcatTest {
         MultiAssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().streams(
                 Flowable.just(5),
                 Multi.createFrom().range(1, 3),
-                Multi.createFrom().items(8, 9, 10).onItem().apply(i -> i + 1)).subscribe()
+                Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)).subscribe()
                 .withSubscriber(new MultiAssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
@@ -69,7 +82,7 @@ public class MultiConcatTest {
                 Arrays.asList(
                         Flowable.just(5),
                         Multi.createFrom().range(1, 3),
-                        Multi.createFrom().items(8, 9, 10).onItem().apply(i -> i + 1)))
+                        Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)))
                 .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
@@ -33,7 +33,7 @@ public class MultiCreateFromTimePeriodTest {
 
         Multi.createFrom().ticks()
                 .startingAfter(Duration.ofMillis(100)).onExecutor(executor).every(Duration.ofMillis(100))
-                .onItem().apply(l -> System.currentTimeMillis())
+                .onItem().transform(l -> System.currentTimeMillis())
                 .subscribe().withSubscriber(ts);
 
         await().until(() -> ts.items().size() == 10);
@@ -62,7 +62,7 @@ public class MultiCreateFromTimePeriodTest {
 
         Multi.createFrom().ticks()
                 .every(Duration.ofMillis(100))
-                .onItem().apply(l -> System.currentTimeMillis())
+                .onItem().transform(l -> System.currentTimeMillis())
                 .subscribe().withSubscriber(ts);
 
         await().until(() -> ts.items().size() == 10);
@@ -87,7 +87,7 @@ public class MultiCreateFromTimePeriodTest {
 
         Multi.createFrom().ticks()
                 .startingAfter(Duration.ofMillis(50)).onExecutor(executor).every(Duration.ofMillis(50))
-                .onItem().apply(l -> System.currentTimeMillis())
+                .onItem().transform(l -> System.currentTimeMillis())
                 .subscribe().withSubscriber(ts);
 
         ts

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIgnoreTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIgnoreTest.java
@@ -32,7 +32,7 @@ public class MultiIgnoreTest {
     @Test(expectedExceptions = CompletionException.class, expectedExceptionsMessageRegExp = ".*boom.*")
     public void testAsUniWithFailure() {
         CompletableFuture<Void> future = Multi.createFrom().items(1, 2, 3, 4)
-                .onItem().apply(i -> {
+                .onItem().transform(i -> {
                     if (i == 3) {
                         throw new RuntimeException("boom");
                     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiMergeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiMergeTest.java
@@ -18,6 +18,18 @@ public class MultiMergeTest {
         MultiAssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
                 Multi.createFrom().item(5),
                 Multi.createFrom().range(1, 3),
+                Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)).subscribe()
+                .withSubscriber(new MultiAssertSubscriber<>(100));
+
+        subscriber.assertCompletedSuccessfully()
+                .assertReceived(5, 1, 2, 9, 10, 11);
+    }
+
+    @Test
+    public void testMergeOfSeveralMultisWithDeprecatedApiApply() {
+        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
+                Multi.createFrom().item(5),
+                Multi.createFrom().range(1, 3),
                 Multi.createFrom().items(8, 9, 10).onItem().apply(i -> i + 1)).subscribe()
                 .withSubscriber(new MultiAssertSubscriber<>(100));
 
@@ -31,7 +43,7 @@ public class MultiMergeTest {
                 .streams(
                         Multi.createFrom().item(5),
                         Multi.createFrom().range(1, 3),
-                        Multi.createFrom().items(8, 9, 10).onItem().apply(i -> i + 1))
+                        Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1))
                 .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
@@ -44,7 +56,7 @@ public class MultiMergeTest {
                 Arrays.asList(
                         Multi.createFrom().item(5),
                         Multi.createFrom().range(1, 3),
-                        Multi.createFrom().items(8, 9, 10).onItem().apply(i -> i + 1)))
+                        Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)))
                 .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
@@ -56,7 +68,7 @@ public class MultiMergeTest {
         MultiAssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
                 Flowable.just(5),
                 Multi.createFrom().range(1, 3),
-                Multi.createFrom().items(8, 9, 10).onItem().apply(i -> i + 1)).subscribe()
+                Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)).subscribe()
                 .withSubscriber(new MultiAssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
@@ -69,7 +81,7 @@ public class MultiMergeTest {
                 Arrays.asList(
                         Flowable.just(5),
                         Multi.createFrom().range(1, 3),
-                        Multi.createFrom().items(8, 9, 10).onItem().apply(i -> i + 1)))
+                        Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)))
                 .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureTest.java
@@ -86,6 +86,19 @@ public class MultiOnFailureTest {
         MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create();
 
         Multi.createFrom().<Integer> failure(new IllegalStateException("boom"))
+                .onFailure().transform(f -> new IOException("kaboom!"))
+                .subscribe().withSubscriber(subscriber);
+
+        subscriber.assertHasNotReceivedAnyItem()
+                .assertTerminated()
+                .assertHasFailedWith(IOException.class, "kaboom!");
+    }
+
+    @Test
+    public void testOnFailureMapWithDeprecatedApiApply() {
+        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create();
+
+        Multi.createFrom().<Integer> failure(new IllegalStateException("boom"))
                 .onFailure().apply(f -> new IOException("kaboom!"))
                 .subscribe().withSubscriber(subscriber);
 
@@ -316,7 +329,7 @@ public class MultiOnFailureTest {
     public void testOnFailureMapWithPredicate() {
         Multi.createFrom().<Integer> failure(new IOException())
                 .onFailure(IOException.class::isInstance)
-                .apply(e -> new Exception("BOOM!!!"))
+                .transform(e -> new Exception("BOOM!!!"))
                 .subscribe().withSubscriber(MultiAssertSubscriber.create(0))
                 .assertHasFailedWith(Exception.class, "BOOM!!!");
     }
@@ -325,7 +338,7 @@ public class MultiOnFailureTest {
     public void testOnFailureMapWithNonPassingPredicate() {
         Multi.createFrom().<Integer> failure(new RuntimeException("first"))
                 .onFailure(IOException.class::isInstance)
-                .apply(e -> new Exception("BOOM!!!"))
+                .transform(e -> new Exception("BOOM!!!"))
                 .subscribe().withSubscriber(MultiAssertSubscriber.create(0))
                 .assertHasFailedWith(RuntimeException.class, "first");
     }
@@ -336,7 +349,7 @@ public class MultiOnFailureTest {
                 .onFailure(f -> {
                     throw new IllegalArgumentException("bad");
                 })
-                .apply(e -> new Exception("BOOM"))
+                .transform(e -> new Exception("BOOM"))
                 .subscribe().withSubscriber(MultiAssertSubscriber.create(0))
                 .assertHasFailedWith(CompositeException.class, "first")
                 .assertHasFailedWith(CompositeException.class, "bad");

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureInvokeTest.java
@@ -93,7 +93,7 @@ public class UniOnFailureInvokeTest {
         int res = Uni.createFrom().nullItem()
                 .onFailure().invoke(container::set)
                 .onFailure().recoverWithItem(1)
-                .onItem().apply(x -> 5)
+                .onItem().transform(x -> 5)
                 .await().indefinitely();
 
         assertThat(res).isEqualTo(5);
@@ -110,7 +110,7 @@ public class UniOnFailureInvokeTest {
                     return Uni.createFrom().item(22).onItem().invoke(called::set);
                 })
                 .onFailure().recoverWithItem(1)
-                .onItem().apply(x -> 4)
+                .onItem().transform(x -> 4)
                 .await().indefinitely();
 
         assertThat(res).isEqualTo(4);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureMapToTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureMapToTest.java
@@ -27,7 +27,7 @@ public class UniOnFailureMapToTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testThatMapperMustNotBeNull() {
-        Uni.createFrom().item(1).onFailure().apply(null);
+        Uni.createFrom().item(1).onFailure().transform(null);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -38,7 +38,7 @@ public class UniOnFailureMapToTest {
     @Test
     public void testSimpleMapping() {
         UniAssertSubscriber<Integer> subscriber = failure
-                .onFailure().apply(t -> new BoomException())
+                .onFailure().transform(t -> new BoomException())
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber.assertCompletedWithFailure()
                 .assertFailure(BoomException.class, "BoomException");
@@ -50,7 +50,7 @@ public class UniOnFailureMapToTest {
         UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
-        Uni<Integer> uni = failure.onFailure().apply(t -> new BoomException(count.incrementAndGet()));
+        Uni<Integer> uni = failure.onFailure().transform(t -> new BoomException(count.incrementAndGet()));
         uni.subscribe().withSubscriber(ts1);
         uni.subscribe().withSubscriber(ts2);
 
@@ -64,7 +64,7 @@ public class UniOnFailureMapToTest {
     public void testWhenTheMapperThrowsAnException() {
         UniAssertSubscriber<Object> ts = UniAssertSubscriber.create();
 
-        failure.onFailure().apply(t -> {
+        failure.onFailure().transform(t -> {
             throw new RuntimeException("failure");
         }).subscribe().withSubscriber(ts);
 
@@ -75,7 +75,7 @@ public class UniOnFailureMapToTest {
     public void testThatMapperCanNotReturnNull() {
         UniAssertSubscriber<Object> ts = UniAssertSubscriber.create();
 
-        failure.onFailure().apply(t -> null).subscribe().withSubscriber(ts);
+        failure.onFailure().transform(t -> null).subscribe().withSubscriber(ts);
 
         ts.assertFailure(NullPointerException.class, "null");
     }
@@ -88,7 +88,7 @@ public class UniOnFailureMapToTest {
             AtomicReference<String> threadName = new AtomicReference<>();
             failure
                     .emitOn(executor)
-                    .onFailure().apply(fail -> {
+                    .onFailure().transform(fail -> {
                         threadName.set(Thread.currentThread().getName());
                         return new BoomException();
                     })
@@ -107,7 +107,7 @@ public class UniOnFailureMapToTest {
         UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
         AtomicBoolean called = new AtomicBoolean();
         Uni.createFrom().item(1)
-                .onFailure().apply(f -> {
+                .onFailure().transform(f -> {
                     called.set(true);
                     return f;
                 })
@@ -121,7 +121,7 @@ public class UniOnFailureMapToTest {
         UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
         AtomicBoolean called = new AtomicBoolean();
         Uni.createFrom().<Integer> failure(new IllegalStateException("boom"))
-                .onFailure(IOException.class).apply(f -> {
+                .onFailure(IOException.class).transform(f -> {
                     called.set(true);
                     return new IllegalArgumentException("Karamba");
                 })
@@ -137,7 +137,7 @@ public class UniOnFailureMapToTest {
         Uni.createFrom().<Integer> failure(new IllegalStateException("boom"))
                 .onFailure(t -> {
                     throw new IllegalArgumentException("boomboom");
-                }).apply(f -> {
+                }).transform(f -> {
                     called.set(true);
                     return new RuntimeException("Karamba");
                 })

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRecoveryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRecoveryTest.java
@@ -206,7 +206,7 @@ public class UniOnFailureRecoveryTest {
     public void testWithMappingOfFailure() {
         UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
         Uni.createFrom().<Integer> failure(new Exception())
-                .onFailure().apply(f -> new RuntimeException("boom"))
+                .onFailure().transform(f -> new RuntimeException("boom"))
                 .subscribe().withSubscriber(ts);
         ts.assertCompletedWithFailure()
                 .assertFailure(RuntimeException.class, "boom");
@@ -216,7 +216,7 @@ public class UniOnFailureRecoveryTest {
     public void testWithMappingOfFailureAndPredicates() {
         UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
         Uni.createFrom().<Integer> failure(new IOException())
-                .onFailure().apply(t -> new IndexOutOfBoundsException())
+                .onFailure().transform(t -> new IndexOutOfBoundsException())
                 .onFailure(IOException.class).recoverWithUni(Uni.createFrom().item(1))
                 .onFailure(IndexOutOfBoundsException.class).recoverWithUni(Uni.createFrom().item(2))
                 .subscribe().withSubscriber(ts);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureMapTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureMapTest.java
@@ -21,7 +21,7 @@ public class UniOnItemOrFailureMapTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testThatMapperMustNotBeNull() {
-        Uni.createFrom().item(1).onItemOrFailure().apply(null);
+        Uni.createFrom().item(1).onItemOrFailure().transform(null);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -34,7 +34,7 @@ public class UniOnItemOrFailureMapTest {
         UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
-        one.onItemOrFailure().apply((i, f) -> {
+        one.onItemOrFailure().transform((i, f) -> {
             assertThat(f).isNull();
             count.incrementAndGet();
             return i + 1;
@@ -51,7 +51,7 @@ public class UniOnItemOrFailureMapTest {
         UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
-        none.onItemOrFailure().apply((i, f) -> {
+        none.onItemOrFailure().transform((i, f) -> {
             assertThat(f).isNull();
             count.incrementAndGet();
             return 2;
@@ -68,7 +68,7 @@ public class UniOnItemOrFailureMapTest {
         UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
-        failed.onItemOrFailure().apply((i, f) -> {
+        failed.onItemOrFailure().transform((i, f) -> {
             assertThat(i).isNull();
             assertThat(f).isNotNull().isInstanceOf(IOException.class).hasMessageContaining("boom");
             count.incrementAndGet();
@@ -86,7 +86,7 @@ public class UniOnItemOrFailureMapTest {
         UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
-        one.onItemOrFailure().<Integer> apply((i, f) -> {
+        one.onItemOrFailure().<Integer> transform((i, f) -> {
             assertThat(f).isNull();
             count.incrementAndGet();
             throw new IllegalStateException("kaboom");
@@ -101,7 +101,7 @@ public class UniOnItemOrFailureMapTest {
         UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
-        failed.onItemOrFailure().<Integer> apply((i, f) -> {
+        failed.onItemOrFailure().<Integer> transform((i, f) -> {
             assertThat(i).isNull();
             assertThat(f).isNotNull().isInstanceOf(IOException.class).hasMessageContaining("boom");
             count.incrementAndGet();
@@ -120,7 +120,7 @@ public class UniOnItemOrFailureMapTest {
         UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
-        Uni<Integer> uni = one.onItemOrFailure().apply((v, f) -> v + count.incrementAndGet());
+        Uni<Integer> uni = one.onItemOrFailure().transform((v, f) -> v + count.incrementAndGet());
         uni.subscribe().withSubscriber(ts1);
         uni.subscribe().withSubscriber(ts2);
 
@@ -134,7 +134,7 @@ public class UniOnItemOrFailureMapTest {
     public void testThatMapperCanReturnNull() {
         UniAssertSubscriber<Void> ts = UniAssertSubscriber.create();
 
-        one.onItemOrFailure().<Void> apply((v, f) -> null).subscribe().withSubscriber(ts);
+        one.onItemOrFailure().<Void> transform((v, f) -> null).subscribe().withSubscriber(ts);
 
         ts.assertCompletedSuccessfully().assertItem(null);
     }
@@ -147,7 +147,7 @@ public class UniOnItemOrFailureMapTest {
             AtomicReference<String> threadName = new AtomicReference<>();
             one
                     .emitOn(executor)
-                    .onItemOrFailure().apply((i, f) -> {
+                    .onItemOrFailure().transform((i, f) -> {
                         threadName.set(Thread.currentThread().getName());
                         return i + 1;
                     })
@@ -169,7 +169,7 @@ public class UniOnItemOrFailureMapTest {
             AtomicReference<String> threadName = new AtomicReference<>();
             failed
                     .emitOn(executor)
-                    .onItemOrFailure().apply((i, f) -> {
+                    .onItemOrFailure().transform((i, f) -> {
                         threadName.set(Thread.currentThread().getName());
                         assertThat(i).isNull();
                         assertThat(f).isNotNull();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNotNullItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNotNullItemTest.java
@@ -33,6 +33,23 @@ public class UniOnNotNullItemTest {
     }
 
     @Test
+    public void testTransform() {
+        assertThat(Uni.createFrom().item("hello")
+                .onItem().ifNotNull().transform(String::toUpperCase)
+                .await().indefinitely()).isEqualTo("HELLO");
+
+        assertThat(Uni.createFrom().item(() -> (String) null)
+                .onItem().ifNotNull().transform(String::toUpperCase)
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).isEqualTo("yolo");
+
+        assertThatThrownBy(() -> Uni.createFrom().<String> failure(new Exception("boom"))
+                .onItem().ifNotNull().transform(String::toUpperCase)
+                .onItem().ifNull().continueWith("yolo")
+                .await().indefinitely()).hasMessageContaining("boom");
+    }
+
+    @Test
     public void testInvoke() {
         AtomicBoolean invoked = new AtomicBoolean();
         assertThat(Uni.createFrom().item("hello")

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
@@ -717,7 +717,7 @@ public class MultiFromResourceTest {
 
         public Multi<String> infinite() {
             return Multi.createFrom().ticks().every(Duration.ofMillis(10))
-                    .onItem().apply(l -> Long.toString(l))
+                    .onItem().transform(l -> Long.toString(l))
                     .on().subscribed(s -> subscribed.set(true));
         }
 

--- a/implementation/src/test/java/tck/MultiFromResourceTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromResourceTckTest.java
@@ -14,6 +14,6 @@ public class MultiFromResourceTckTest extends AbstractPublisherTck<Long> {
         }).withFinalizer(x -> {
             return Uni.createFrom().item(() -> null);
         })
-                .onItem().apply(i -> (long) i);
+                .onItem().transform(i -> (long) i);
     }
 }


### PR DESCRIPTION
- A few tests have been duplicated and marked as using deprecated APIs.
- apply() has been deprecated.

Relates to https://github.com/smallrye/smallrye-mutiny/issues/178