### PR TITLE
Automatic license headers verification and application

### DIFF
--- a/context-propagation/src/main/java/io/smallrye/mutiny/context/ContextPropagationMultiInterceptor.java
+++ b/context-propagation/src/main/java/io/smallrye/mutiny/context/ContextPropagationMultiInterceptor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.context;
 
 import java.util.concurrent.Executor;

--- a/context-propagation/src/main/java/io/smallrye/mutiny/context/ContextPropagationUniInterceptor.java
+++ b/context-propagation/src/main/java/io/smallrye/mutiny/context/ContextPropagationUniInterceptor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.context;
 
 import java.util.concurrent.Executor;

--- a/context-propagation/src/main/java/io/smallrye/mutiny/context/MutinyContextManagerExtension.java
+++ b/context-propagation/src/main/java/io/smallrye/mutiny/context/MutinyContextManagerExtension.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.context;
 
 import org.eclipse.microprofile.context.ThreadContext;

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/MultiContextPropagationTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/MultiContextPropagationTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.context;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/MyContext.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/MyContext.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.context;
 
 public class MyContext {

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/MyThreadContextProvider.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/MyThreadContextProvider.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.context;
 
 import java.util.Map;

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/UniContextPropagationTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/UniContextPropagationTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.context;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/BackPressureTest.java
+++ b/documentation/src/test/java/snippets/BackPressureTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/BroadcastProcessorTest.java
+++ b/documentation/src/test/java/snippets/BroadcastProcessorTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import io.smallrye.mutiny.Multi;

--- a/documentation/src/test/java/snippets/CollectTest.java
+++ b/documentation/src/test/java/snippets/CollectTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/CompletionStageTest.java
+++ b/documentation/src/test/java/snippets/CompletionStageTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/DelayTest.java
+++ b/documentation/src/test/java/snippets/DelayTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import io.smallrye.mutiny.Multi;

--- a/documentation/src/test/java/snippets/EmitOnTest.java
+++ b/documentation/src/test/java/snippets/EmitOnTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/EmitterTest.java
+++ b/documentation/src/test/java/snippets/EmitterTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import io.smallrye.mutiny.Multi;

--- a/documentation/src/test/java/snippets/EventsTest.java
+++ b/documentation/src/test/java/snippets/EventsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import io.smallrye.mutiny.Uni;

--- a/documentation/src/test/java/snippets/FlatMapTest.java
+++ b/documentation/src/test/java/snippets/FlatMapTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/GettingStarted.java
+++ b/documentation/src/test/java/snippets/GettingStarted.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 // tag::getting-started[]

--- a/documentation/src/test/java/snippets/GettingStartedTest.java
+++ b/documentation/src/test/java/snippets/GettingStartedTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import org.junit.Test;

--- a/documentation/src/test/java/snippets/HowToChainAsyncTest.java
+++ b/documentation/src/test/java/snippets/HowToChainAsyncTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/HowToFilterTest.java
+++ b/documentation/src/test/java/snippets/HowToFilterTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/HowToJoinAsyncTest.java
+++ b/documentation/src/test/java/snippets/HowToJoinAsyncTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/HowToTransformTest.java
+++ b/documentation/src/test/java/snippets/HowToTransformTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import io.smallrye.mutiny.Multi;

--- a/documentation/src/test/java/snippets/Intro.java
+++ b/documentation/src/test/java/snippets/Intro.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import org.junit.Test;

--- a/documentation/src/test/java/snippets/MergeTest.java
+++ b/documentation/src/test/java/snippets/MergeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/MergeVsConcatenateTest.java
+++ b/documentation/src/test/java/snippets/MergeVsConcatenateTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import io.smallrye.mutiny.Multi;

--- a/documentation/src/test/java/snippets/MultiCreationTest.java
+++ b/documentation/src/test/java/snippets/MultiCreationTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import java.time.Duration;

--- a/documentation/src/test/java/snippets/MultiFailureTest.java
+++ b/documentation/src/test/java/snippets/MultiFailureTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/PaginationTest.java
+++ b/documentation/src/test/java/snippets/PaginationTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import io.smallrye.mutiny.Multi;

--- a/documentation/src/test/java/snippets/PollableSourceTest.java
+++ b/documentation/src/test/java/snippets/PollableSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import io.smallrye.mutiny.Multi;

--- a/documentation/src/test/java/snippets/ReactorTest.java
+++ b/documentation/src/test/java/snippets/ReactorTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/RunSubscriptionOnTest.java
+++ b/documentation/src/test/java/snippets/RunSubscriptionOnTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import io.smallrye.mutiny.Multi;

--- a/documentation/src/test/java/snippets/RxJavaTest.java
+++ b/documentation/src/test/java/snippets/RxJavaTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/ThenTest.java
+++ b/documentation/src/test/java/snippets/ThenTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/UniBlockingTest.java
+++ b/documentation/src/test/java/snippets/UniBlockingTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/UniCreationTest.java
+++ b/documentation/src/test/java/snippets/UniCreationTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import java.time.Duration;

--- a/documentation/src/test/java/snippets/UniFailureTest.java
+++ b/documentation/src/test/java/snippets/UniFailureTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import io.smallrye.mutiny.Uni;

--- a/documentation/src/test/java/snippets/UniMultiComparisonTest.java
+++ b/documentation/src/test/java/snippets/UniMultiComparisonTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import org.junit.Test;

--- a/documentation/src/test/java/snippets/UniNullTest.java
+++ b/documentation/src/test/java/snippets/UniNullTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import io.smallrye.mutiny.Multi;

--- a/documentation/src/test/java/snippets/UniTimeoutTest.java
+++ b/documentation/src/test/java/snippets/UniTimeoutTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/snippets/UnicastProcessorTest.java
+++ b/documentation/src/test/java/snippets/UnicastProcessorTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/main/java/io/smallrye/mutiny/CompositeException.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/CompositeException.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny;
 
 import java.util.ArrayList;

--- a/implementation/src/main/java/io/smallrye/mutiny/GroupedMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/GroupedMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny;
 
 /**

--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/TimeoutException.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/TimeoutException.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny;
 
 /**

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/converters/MultiConverter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/converters/MultiConverter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import io.smallrye.mutiny.Multi;

--- a/implementation/src/main/java/io/smallrye/mutiny/converters/UniConverter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/converters/UniConverter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import io.smallrye.mutiny.Uni;

--- a/implementation/src/main/java/io/smallrye/mutiny/converters/multi/BuiltinConverters.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/converters/multi/BuiltinConverters.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 public class BuiltinConverters {

--- a/implementation/src/main/java/io/smallrye/mutiny/converters/multi/FromCompletionStage.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/converters/multi/FromCompletionStage.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import java.util.concurrent.CompletionStage;

--- a/implementation/src/main/java/io/smallrye/mutiny/converters/uni/BuiltinConverters.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/converters/uni/BuiltinConverters.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 public class BuiltinConverters {

--- a/implementation/src/main/java/io/smallrye/mutiny/converters/uni/FromCompletionStage.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/converters/uni/FromCompletionStage.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import java.util.concurrent.CompletionStage;

--- a/implementation/src/main/java/io/smallrye/mutiny/converters/uni/ToCompletableFuture.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/converters/uni/ToCompletableFuture.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import java.util.concurrent.CompletableFuture;

--- a/implementation/src/main/java/io/smallrye/mutiny/converters/uni/ToCompletionStage.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/converters/uni/ToCompletionStage.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import java.util.concurrent.CompletionStage;

--- a/implementation/src/main/java/io/smallrye/mutiny/converters/uni/ToPublisher.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/converters/uni/ToPublisher.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiBroadcast.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiBroadcast.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.positive;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCollect.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCollect.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiConcat.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiConcat.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.ArrayList;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiConvert.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiConvert.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.SUPPLIER_PRODUCED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreateBy.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreateBy.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import io.smallrye.mutiny.Multi;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiFlatten.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiFlatten.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.positive;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiGroup.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiGroup.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiGroupIntoLists.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiGroupIntoLists.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiGroupIntoMultis.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiGroupIntoMultis.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiIfEmpty.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiIfEmpty.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.SUPPLIER_PRODUCED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiItemCombination.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiItemCombination.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiMerge.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiMerge.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.ArrayList;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnCompletion.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnCompletion.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnEvent.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnEvent.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnFailure.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.SUPPLIER_PRODUCED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItem.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.*;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnSubscribe.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnSubscribe.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnTerminate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnTerminate.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOverflow.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOverflow.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiRepetition.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiRepetition.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.concurrent.CompletionStage;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiResource.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiResource.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.function.BiFunction;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiRetry.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiRetry.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiSubscribe.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiSubscribe.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiTimePeriod.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiTimePeriod.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiTransform.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiTransform.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup2.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup2.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.Collections;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup3.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup3.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup4.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup4.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup5.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup5.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup6.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup6.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup7.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup7.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup8.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup8.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup9.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup9.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroupIterable.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroupIterable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAny.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAny.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAwait.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAwait.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAwaitOptional.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAwaitOptional.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniCombine.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniCombine.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.concurrent.Executor;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniConvert.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniConvert.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniCreate.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.Optional;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniIfNoItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniIfNoItem.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnEvent.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnEvent.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItem.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItemDelay.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItemDelay.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItemIgnore.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItemIgnore.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItemOrFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItemOrFailure.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNotNull.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNotNull.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNull.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNull.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.SUPPLIER_PRODUCED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnSubscribe.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnSubscribe.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnTerminate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnTerminate.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnTimeout.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnTimeout.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOr.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOr.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniRepeat.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniRepeat.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.function.Predicate;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniRetry.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniRetry.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.validate;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniSubscribe.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniSubscribe.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.concurrent.CompletableFuture;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniZip.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniZip.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/BlockingIterable.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/BlockingIterable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.SUPPLIER_PRODUCED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/EmptyUniSubscription.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/EmptyUniSubscription.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import io.smallrye.mutiny.subscription.UniSubscriber;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/ExponentialBackoff.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/ExponentialBackoff.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import java.time.Duration;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/HalfSerializer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/HalfSerializer.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/MultiEmitterProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/MultiEmitterProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/ParameterValidation.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/ParameterValidation.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import java.time.Duration;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/Predicates.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/Predicates.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import java.util.function.Predicate;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/StrictMultiSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/StrictMultiSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/Subscriptions.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/Subscriptions.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import java.util.Objects;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/UniCallbackSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/UniCallbackSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/DrainUtils.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/DrainUtils.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers.queues;
 
 import java.util.Queue;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/MpscLinkedQueue.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/MpscLinkedQueue.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers.queues;
 
 import java.util.Collection;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/SpscArrayQueue.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/SpscArrayQueue.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers.queues;
 
 import java.util.Collection;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/SpscLinkedArrayQueue.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/SpscLinkedArrayQueue.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers.queues;
 
 import java.util.AbstractQueue;

--- a/implementation/src/main/java/io/smallrye/mutiny/infrastructure/ExecutorConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/infrastructure/ExecutorConfiguration.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.infrastructure;
 
 import java.util.concurrent.Executor;

--- a/implementation/src/main/java/io/smallrye/mutiny/infrastructure/Infrastructure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/infrastructure/Infrastructure.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.infrastructure;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/infrastructure/MultiInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/infrastructure/MultiInterceptor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.infrastructure;
 
 import org.reactivestreams.Publisher;

--- a/implementation/src/main/java/io/smallrye/mutiny/infrastructure/MutinyScheduler.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/infrastructure/MutinyScheduler.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.infrastructure;
 
 import java.util.concurrent.*;

--- a/implementation/src/main/java/io/smallrye/mutiny/infrastructure/UniInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/infrastructure/UniInterceptor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.infrastructure;
 
 import io.smallrye.mutiny.Uni;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.concurrent.Executor;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/DefaultUniEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/DefaultUniEmitter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiBroadcaster.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiBroadcaster.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.time.Duration;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiCollector.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiCollector.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.time.Duration;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiCombine.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiCombine.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.List;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiFlatMapOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiFlatMapOnFailure.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.MAPPER_RETURNED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine2.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine2.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine3.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine3.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine4.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine4.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine5.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine5.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine6.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine6.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine7.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine7.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine8.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine8.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine9.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombine9.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombineIterable.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiItemCombineIterable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiMapOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiMapOnFailure.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.MAPPER_RETURNED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiOperator.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiOperator.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import io.smallrye.mutiny.Multi;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiSwitchOnCompletion.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiSwitchOnCompletion.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.SUPPLIER_PRODUCED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiSwitchOnEmpty.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiSwitchOnEmpty.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.SUPPLIER_PRODUCED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiTransformation.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiTransformation.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.time.Duration;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniAndCombination.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniAndCombination.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.ArrayList;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniBlockingAwait.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniBlockingAwait.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCache.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCache.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCallSubscribeOn.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCallSubscribeOn.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromCompletionStage.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromCompletionStage.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.propagateFailureEvent;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplier.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplier.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromPublisher.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromPublisher.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateWithEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateWithEmitter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniDelayOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniDelayOnItem.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniDelayUntil.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniDelayUntil.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniDelegatingSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniDelegatingSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniEmitOn.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniEmitOn.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniFailOnTimeout.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniFailOnTimeout.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniNever.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniNever.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnCancellation.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnCancellation.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnFailureFlatMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnFailureFlatMap.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnFailureMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnFailureMap.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.SUPPLIER_PRODUCED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemConsume.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemConsume.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.function.Consumer;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureConsume.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureConsume.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.function.BiConsumer;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureFlatMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureFlatMap.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureMap.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.function.BiFunction;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemTransform.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemTransform.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.function.Function;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemTransformToMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemTransformToMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.MAPPER_RETURNED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemTransformToUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemTransformToUni.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.MAPPER_RETURNED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnSubscribeInvoke.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnSubscribeInvoke.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.function.Consumer;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnSubscribeInvokeUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnSubscribeInvokeUni.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.Objects;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnTermination.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnTermination.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnTerminationInvokeUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnTerminationInvokeUni.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOperator.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOperator.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import io.smallrye.mutiny.Uni;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOrCombination.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOrCombination.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniRetryAtMost.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniRetryAtMost.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniSerializedSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniSerializedSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniSubscribeToCompletionStage.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniSubscribeToCompletionStage.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/AbstractMultiOperator.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/AbstractMultiOperator.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import io.smallrye.mutiny.Multi;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/FlatMapManager.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/FlatMapManager.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOp.java
@@ -1,4 +1,20 @@
-
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.time.Duration;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCacheOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCacheOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.List;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCollectorOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCollectorOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCombineLatestOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCombineLatestOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import static io.smallrye.mutiny.helpers.Subscriptions.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiConcatOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiConcatOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDistinctOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDistinctOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.Collection;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDistinctUntilChangedOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDistinctUntilChangedOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import io.smallrye.mutiny.Multi;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiEmitOnOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiEmitOnOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import static io.smallrye.mutiny.helpers.Subscriptions.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiFilterOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiFilterOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.function.Predicate;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiFlatMapOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiFlatMapOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.Objects;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiGroupByOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiGroupByOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import static io.smallrye.mutiny.helpers.Subscriptions.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiIgnoreOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiIgnoreOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import org.reactivestreams.Subscription;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiLastItemOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiLastItemOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import static io.smallrye.mutiny.helpers.Subscriptions.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiMapOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiMapOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.MAPPER_RETURNED_NULL;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnFailureResumeOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnFailureResumeOp.java
@@ -1,4 +1,20 @@
-
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.function.Function;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnSubscribeInvokeOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnSubscribeInvokeOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.Objects;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnSubscribeInvokeUniOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnSubscribeInvokeUniOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.Objects;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnTerminationInvoke.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnTerminationInvoke.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnTerminationInvokeUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnTerminationInvokeUni.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOperatorProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOperatorProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import static io.smallrye.mutiny.helpers.Subscriptions.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRepeatUntilOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRepeatUntilOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRepeatWhilstOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRepeatWhilstOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.function.Predicate;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRetryOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRetryOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRetryWhenOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRetryWhenOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiScanOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiScanOp.java
@@ -1,4 +1,20 @@
-
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.function.BiFunction;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiScanWithSeedOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiScanWithSeedOp.java
@@ -1,4 +1,20 @@
-
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSignalConsumerOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSignalConsumerOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.function.Consumer;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipLastOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipLastOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.ArrayDeque;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipUntilOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipUntilOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.function.Predicate;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipUntilPublisherOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipUntilPublisherOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSwitchOnEmptyOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSwitchOnEmptyOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.Objects;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiTakeLastOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiTakeLastOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.ArrayDeque;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiTakeOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiTakeOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiTakeUntilOtherOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiTakeUntilOtherOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiTakeWhileOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiTakeWhileOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.function.Predicate;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOnDurationOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOnDurationOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 package io.smallrye.mutiny.operators.multi;
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import static io.smallrye.mutiny.helpers.Subscriptions.CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiZipOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiZipOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import java.util.ArrayList;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BaseMultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BaseMultiEmitter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BufferItemMultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BufferItemMultiEmitter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/CollectionBasedMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/CollectionBasedMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import java.util.ArrayList;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/DeferredMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/DeferredMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import java.util.function.Supplier;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/EmitterBasedMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/EmitterBasedMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/EmptyMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/EmptyMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import org.reactivestreams.Publisher;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/FailedMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/FailedMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import java.util.function.Supplier;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/IntervalMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/IntervalMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import java.time.Duration;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/IterableBasedMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/IterableBasedMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import java.util.Iterator;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/NeverMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/NeverMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import org.reactivestreams.Publisher;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/ResourceMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/ResourceMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/SerializedMultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/SerializedMultiEmitter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import static io.smallrye.mutiny.helpers.Subscriptions.TERMINATED;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/StreamBasedMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/StreamBasedMulti.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import java.util.Iterator;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/ConnectableMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/ConnectableMulti.java
@@ -1,4 +1,20 @@
-
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.multicast;
 
 import java.time.Duration;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/ConnectableMultiConnection.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/ConnectableMultiConnection.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.multicast;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiConnectAfter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiConnectAfter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.multicast;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiPublishOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiPublishOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.multicast;
 
 import java.util.Queue;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiReferenceCount.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiReferenceCount.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.multicast;
 
 import java.time.Duration;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiReferenceCountSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiReferenceCountSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.multicast;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowBufferOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowBufferOp.java
@@ -1,4 +1,20 @@
-
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.overflow;
 
 import java.util.Queue;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowDropItemsOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowDropItemsOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.overflow;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowKeepLastOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowKeepLastOp.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.overflow;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/processors/BroadcastProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/processors/BroadcastProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.processors;
 
 import java.util.ArrayList;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/processors/SerializedProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/processors/SerializedProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.processors;
 
 import java.util.ArrayList;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.processors;
 
 import java.util.Queue;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/KnownFailureUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/KnownFailureUni.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.uni.builders;
 
 import io.smallrye.mutiny.helpers.EmptyUniSubscription;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/KnownItemUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/KnownItemUni.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.uni.builders;
 
 import io.smallrye.mutiny.helpers.EmptyUniSubscription;

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/BackPressureFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/BackPressureFailure.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 public class BackPressureFailure extends RuntimeException {

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/BackPressureStrategy.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/BackPressureStrategy.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 /**

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/Cancellable.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/Cancellable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 public interface Cancellable {

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/CancellableSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/CancellableSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 public interface CancellableSubscriber<T> extends MultiSubscriber<T>, Cancellable {

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/MultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/MultiEmitter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 import org.reactivestreams.Subscription;

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/MultiSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/MultiSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 import org.reactivestreams.Publisher;

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/SafeSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/SafeSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 import java.util.Objects;

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/SerializedSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/SerializedSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/Subscribers.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/Subscribers.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/SwitchableSubscriptionSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/SwitchableSubscriptionSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/UniEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/UniEmitter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 import io.smallrye.mutiny.Uni;

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/UniSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/UniSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 import java.util.concurrent.Executor;

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/UniSubscription.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/UniSubscription.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 import org.reactivestreams.Subscription;

--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Functions.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Functions.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import java.util.List;

--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import java.util.Collections;

--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple2.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple2.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple3.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple3.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple4.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple4.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple5.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple5.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple6.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple6.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple7.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple7.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple8.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple8.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple9.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple9.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import java.util.Arrays;

--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuples.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuples.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import java.util.List;

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/Unchecked.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/Unchecked.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.unchecked;
 
 import java.util.function.*;

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedBiConsumer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedBiConsumer.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.unchecked;
 
 import java.util.Objects;

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedBiFunction.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedBiFunction.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.unchecked;
 
 import java.util.Objects;

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedConsumer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedConsumer.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.unchecked;
 
 import java.util.Objects;

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedFunction.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedFunction.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.unchecked;
 
 import java.util.Objects;

--- a/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedSupplier.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/unchecked/UncheckedSupplier.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.unchecked;
 
 import java.util.function.Supplier;

--- a/implementation/src/test/java/io/smallrye/mutiny/CompositeExceptionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/CompositeExceptionTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/MultiStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/MultiStageTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/UniStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/UniStageTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import java.util.concurrent.CompletableFuture;

--- a/implementation/src/test/java/io/smallrye/mutiny/converters/UniConvertToTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/converters/UniConvertToTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/converters/UniCreateFromTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/converters/UniCreateFromTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiBroadcastTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiBroadcastTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiConvertTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiConvertTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiFlattenTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiFlattenTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiRepetitionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiRepetitionTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/UniOnFailureRetryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/UniOnFailureRetryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/UniSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/UniSubscriberTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.groups;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/BlockingIterableTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/BlockingIterableTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/HalfSerializerTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/HalfSerializerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/StrictMultiSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/StrictMultiSubscriberTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/SubscriptionsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/SubscriptionsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/MultiInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/MultiInterceptorTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/MutinySchedulerTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/MutinySchedulerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/UniInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/UniInterceptorTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCacheTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCacheTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.io.IOException;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCastTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCastTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import org.testng.annotations.Test;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCollectTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCollectTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCombineTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCombineTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiConcatTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiConcatTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromCompletionStageTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromDeferredSupplierTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromDeferredSupplierTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromEmitterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromEmitterTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromFailureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromFailureTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromItemsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromItemsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromOptionalTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromOptionalTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromPublisherTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromPublisherTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromRangeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromRangeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import org.testng.annotations.Test;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiDistinctTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiDistinctTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.io.IOException;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmitOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmitOnTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.awaitility.Awaitility.await;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmptyAndNeverTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmptyAndNeverTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import org.testng.annotations.Test;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiFilterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiFilterTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIfEmptyTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIfEmptyTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.io.IOException;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIgnoreTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIgnoreTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiMergeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiMergeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnCompletionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnCompletionTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnEventTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnEventTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureInvokeUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureInvokeUniTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryUntilTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryUntilTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryWhenTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryWhenTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnOverflowTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnOverflowTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnSubscribeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnTerminationUniInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnTerminationUniInvokeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiReceiveItemOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiReceiveItemOnTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiScanTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiScanTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import org.testng.annotations.Test;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSubscribeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTakeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTakeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiToUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiToUniTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformByMergingTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformByMergingTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToMultiTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToUniTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAndTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAndTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAssertSubscriber.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAssertSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.concurrent.CompletableFuture;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCacheTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCacheTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.ArrayList;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromCompletionStageTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplierTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplierTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromEmitterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromEmitterTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromFailureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromFailureTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromItemTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniFromPublisherTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniFromPublisherTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniGenericHintTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniGenericHintTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniNeverTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniNeverTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import org.testng.annotations.Test;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureInvokeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureMapToTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureMapToTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRecoveryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRecoveryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRetryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRetryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRetryUntilTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRetryUntilTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayUntilTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayUntilTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemFailTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemFailTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import java.io.IOException;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemIgnoreTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemIgnoreTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemInvokeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureFlatMapTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureFlatMapTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureInvokeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureMapTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureMapTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemProduceCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemProduceCompletionStageTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToMultiTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToUniTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToUniWithEmitterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToUniWithEmitterTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNotNullItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNotNullItemTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.*;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNullContinueWithTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNullContinueWithTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNullFailTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNullFailTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNullSwitchToTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNullSwitchToTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnSubscribeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOrTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOrTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRepeatTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRepeatTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniSubscribeAsCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniSubscribeAsCompletionStageTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniToMultiTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniToPublisherTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniToPublisherTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiToHotStreamTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiToHotStreamTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/EmitterBasedMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/EmitterBasedMultiTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.builders;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/BroadcastProcessorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/BroadcastProcessorTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.processors;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/SerializedProcessorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/SerializedProcessorTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.processors;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessorTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.multi.processors;
 
 import static org.awaitility.Awaitility.await;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/builders/KnownFailureUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/builders/KnownFailureUniTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.uni.builders;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/builders/KnownItemUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/builders/KnownItemUniTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.operators.uni.builders;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/stack/StackTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/stack/StackTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.stack;
 
 import java.util.ArrayList;

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/SafeSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/SafeSubscriberTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/UniSubscriptionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/UniSubscriptionTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.subscription;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/FunctionsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/FunctionsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple2Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple2Test.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple3Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple3Test.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple4Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple4Test.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple5Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple5Test.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple6Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple6Test.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple7Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple7Test.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple8Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple8Test.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple9Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple9Test.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedBiFunctionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedBiFunctionTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.unchecked;
 
 import static io.smallrye.mutiny.unchecked.Unchecked.function;

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedConsumerTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedConsumerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.unchecked;
 
 import static io.smallrye.mutiny.unchecked.Unchecked.consumer;

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedFunctionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedFunctionTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.unchecked;
 
 import static io.smallrye.mutiny.unchecked.Unchecked.*;

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedSupplierTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedSupplierTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.unchecked;
 
 import static io.smallrye.mutiny.unchecked.Unchecked.supplier;

--- a/implementation/src/test/java/tck/AbstractPublisherTck.java
+++ b/implementation/src/test/java/tck/AbstractPublisherTck.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.Iterator;

--- a/implementation/src/test/java/tck/AbstractTck.java
+++ b/implementation/src/test/java/tck/AbstractTck.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/test/java/tck/Await.java
+++ b/implementation/src/test/java/tck/Await.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.concurrent.CompletionStage;

--- a/implementation/src/test/java/tck/MultiCollectTest.java
+++ b/implementation/src/test/java/tck/MultiCollectTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/MultiConcatTckTest.java
+++ b/implementation/src/test/java/tck/MultiConcatTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/MultiDisjointTckTest.java
+++ b/implementation/src/test/java/tck/MultiDisjointTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiDistinctTckTest.java
+++ b/implementation/src/test/java/tck/MultiDistinctTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/MultiEmitOnTckTest.java
+++ b/implementation/src/test/java/tck/MultiEmitOnTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.concurrent.ExecutorService;

--- a/implementation/src/test/java/tck/MultiFirstTckTest.java
+++ b/implementation/src/test/java/tck/MultiFirstTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/MultiFlatMapCompletionStageTckTest.java
+++ b/implementation/src/test/java/tck/MultiFlatMapCompletionStageTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static tck.Await.await;

--- a/implementation/src/test/java/tck/MultiFlatMapTckTest.java
+++ b/implementation/src/test/java/tck/MultiFlatMapTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/MultiFromCollectionTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromCollectionTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.ArrayList;

--- a/implementation/src/test/java/tck/MultiFromItemsTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromItemsTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiFromIterableTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromIterableTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.List;

--- a/implementation/src/test/java/tck/MultiFromResourceTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromResourceTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import org.reactivestreams.Publisher;

--- a/implementation/src/test/java/tck/MultiFromStreamTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromStreamTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiMapTckTest.java
+++ b/implementation/src/test/java/tck/MultiMapTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/MultiOnFailureInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureInvokeTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiOnFailureInvokeUniTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureInvokeUniTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiOnFailureRecoverWithFailureTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureRecoverWithFailureTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.function.Function;

--- a/implementation/src/test/java/tck/MultiOnFailureRecoverWithItemTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureRecoverWithItemTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiOnFailureRecoverWithMultiTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureRecoverWithMultiTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiOnFailureResumeTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureResumeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/MultiOnITemTransformToMultiAndConcatenateTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnITemTransformToMultiAndConcatenateTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/MultiOnITemTransformToMultiAndMergeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnITemTransformToMultiAndMergeTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/MultiOnItemInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnItemInvokeTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiOnItemInvokeUniTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnItemInvokeUniTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiOnItemTransformToUniAndConcatenateTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnItemTransformToUniAndConcatenateTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiOnItemTransformToUniAndMergeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnItemTransformToUniAndMergeTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiOnSubscribeInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnSubscribeInvokeTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiOnSubscribeInvokeUniTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnSubscribeInvokeUniTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiOnTerminationInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnTerminationInvokeTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiOnTerminationInvokeUniTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnTerminationInvokeUniTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.stream.LongStream;

--- a/implementation/src/test/java/tck/MultiRepeatTckTest.java
+++ b/implementation/src/test/java/tck/MultiRepeatTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import org.reactivestreams.Publisher;

--- a/implementation/src/test/java/tck/MultiSkipItemsWhileTckTest.java
+++ b/implementation/src/test/java/tck/MultiSkipItemsWhileTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/MultiTakeFirstItemsTckTest.java
+++ b/implementation/src/test/java/tck/MultiTakeFirstItemsTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/MultiTakeItemsWhileTckTest.java
+++ b/implementation/src/test/java/tck/MultiTakeItemsWhileTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/QuietRuntimeException.java
+++ b/implementation/src/test/java/tck/QuietRuntimeException.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 /**

--- a/implementation/src/test/java/tck/ScheduledPublisher.java
+++ b/implementation/src/test/java/tck/ScheduledPublisher.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import static org.testng.Assert.assertEquals;

--- a/implementation/src/test/java/tck/UniRepeatTckTest.java
+++ b/implementation/src/test/java/tck/UniRepeatTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import org.reactivestreams.Publisher;

--- a/implementation/src/test/java/tck/UniRepeatUntilTckTest.java
+++ b/implementation/src/test/java/tck/UniRepeatUntilTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/test/java/tck/UniRepeatWhilstTckTest.java
+++ b/implementation/src/test/java/tck/UniRepeatWhilstTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/implementation/src/test/java/tck/UniTransformToMultiTckTest.java
+++ b/implementation/src/test/java/tck/UniTransformToMultiTckTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import org.reactivestreams.Publisher;

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,0 +1,15 @@
+Copyright (c) ${license.git.copyrightYears} ${owner}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <smallrye-context-propagation.version>1.0.13</smallrye-context-propagation.version>
         <smallrye-config.version>1.8.4</smallrye-config.version>
+        <license-maven-plugin.version>4.0.rc1</license-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -244,6 +245,37 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${license-maven-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin-git</artifactId>
+                        <version>${license-maven-plugin.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <defaultBasedir>${project.basedir}</defaultBasedir>
+                    <aggregate>true</aggregate>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>license-header.txt</header>
+                            <excludes>
+                                <exclude>**/MultiSubscribeOnOp.java</exclude>
+                                <exclude>**/MultiBufferOp.java</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/*.java</include>
+                            </includes>
+                        </licenseSet>
+                    </licenseSets>
+                    <properties>
+                        <owner>Red Hat</owner>
+                    </properties>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -255,6 +287,25 @@
             </modules>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>apply-license</id>
+                                <goals>
+                                    <goal>format</goal>
+                                </goals>
+                                <phase>process-sources</phase>
+                            </execution>
+                            <execution>
+                                <id>check-license</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/Engine.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/Engine.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams;
 
 import java.util.concurrent.CompletionStage;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/Operator.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/Operator.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.operators;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/ProcessingStage.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/ProcessingStage.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.operators;
 
 import java.util.function.Function;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/ProcessingStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/ProcessingStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.operators;
 
 import org.eclipse.microprofile.reactive.streams.operators.spi.Stage;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/ProcessorOperator.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/ProcessorOperator.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.operators;
 
 import org.eclipse.microprofile.reactive.streams.operators.spi.Stage;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/PublisherOperator.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/PublisherOperator.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.operators;
 
 import org.eclipse.microprofile.reactive.streams.operators.spi.Stage;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/PublisherStage.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/PublisherStage.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.operators;
 
 import java.util.function.Supplier;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/PublisherStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/PublisherStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.operators;
 
 import org.eclipse.microprofile.reactive.streams.operators.spi.Stage;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/TerminalOperator.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/TerminalOperator.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.operators;
 
 import org.eclipse.microprofile.reactive.streams.operators.spi.Stage;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/TerminalStage.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/TerminalStage.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.operators;
 
 import java.util.concurrent.CompletionStage;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/TerminalStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/operators/TerminalStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.operators;
 
 import org.eclipse.microprofile.reactive.streams.operators.spi.Stage;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/spi/ExecutionModel.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/spi/ExecutionModel.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.spi;
 
 import java.util.function.UnaryOperator;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/spi/Transformer.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/spi/Transformer.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.spi;
 
 import java.util.Iterator;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/CancelStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/CancelStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/CollectStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/CollectStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/ConcatStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/ConcatStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/CoupledStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/CoupledStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/DistinctStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/DistinctStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/DropWhileStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/DropWhileStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FailedPublisherStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FailedPublisherStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FilterStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FilterStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FindFirstStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FindFirstStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FlatMapCompletionStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FlatMapCompletionStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FlatMapIterableStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FlatMapIterableStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FlatMapStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FlatMapStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FromCompletionStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FromCompletionStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FromCompletionStageNullableFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FromCompletionStageNullableFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FromIterableStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FromIterableStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FromPublisherStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/FromPublisherStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/LimitStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/LimitStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import org.eclipse.microprofile.reactive.streams.operators.spi.Stage;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/MapStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/MapStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/OnCompleteStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/OnCompleteStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/OnErrorResumeStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/OnErrorResumeStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/OnErrorResumeWithStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/OnErrorResumeWithStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/OnErrorStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/OnErrorStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/OnTerminateStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/OnTerminateStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/PeekStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/PeekStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/ProcessorStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/ProcessorStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/SkipStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/SkipStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import org.eclipse.microprofile.reactive.streams.operators.spi.Stage;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/Stages.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/Stages.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.ArrayList;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/SubscriberStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/SubscriberStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/TakeWhileStageFactory.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/stages/TakeWhileStageFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/CancellablePublisher.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/CancellablePublisher.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.utils;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/Casts.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/Casts.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.utils;
 
 import java.util.concurrent.CompletionStage;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/ConnectableProcessor.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/ConnectableProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.utils;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/CouplingProcessor.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/CouplingProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.utils;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/DefaultSubscriberWithCompletionStage.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/DefaultSubscriberWithCompletionStage.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.utils;
 
 import java.util.concurrent.CompletionStage;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/SubscriptionObserver.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/SubscriptionObserver.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.utils;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/WrappedProcessor.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/WrappedProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.utils;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/WrappedSubscriber.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/WrappedSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.utils;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/WrappedSubscription.java
+++ b/reactive-streams-operators/src/main/java/io/smallrye/mutiny/streams/utils/WrappedSubscription.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.utils;
 
 import java.util.Objects;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/APITest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/APITest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/EngineTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/EngineTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/CancelStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/CancelStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/CollectStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/CollectStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/ConcatStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/ConcatStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/CoupledStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/CoupledStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/DistinctStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/DistinctStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/DropWhileStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/DropWhileStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FailedPublisherStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FailedPublisherStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import org.junit.Test;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FilterStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FilterStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FindFirstStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FindFirstStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FlatMapCompletionStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FlatMapCompletionStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FlatMapIterableStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FlatMapIterableStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FlatMapStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FlatMapStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromCompletionStageFactoryNullableTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromCompletionStageFactoryNullableTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromCompletionStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromCompletionStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromIterableStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromIterableStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromPublisherStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromPublisherStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/LimitStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/LimitStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/MapStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/MapStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnCompleteStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnCompleteStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnErrorResumeWithStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnErrorResumeWithStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnErrorStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnErrorStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnTerminateStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnTerminateStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/PeekStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/PeekStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/ProcessorStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/ProcessorStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/SkipStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/SkipStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/StageTestBase.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/StageTestBase.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import java.util.concurrent.CompletionStage;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/SubscriberStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/SubscriberStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/TakeWhileStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/TakeWhileStageFactoryTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/utils/WrappedSubscriberTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/utils/WrappedSubscriberTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/utils/WrappedSubscriptionTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/utils/WrappedSubscriptionTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.streams.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactive-streams-operators/src/test/java/tck/ReactiveStreamsEngineImplTck.java
+++ b/reactive-streams-operators/src/test/java/tck/ReactiveStreamsEngineImplTck.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package tck;
 
 import org.eclipse.microprofile.reactive.streams.operators.tck.ReactiveStreamsTck;

--- a/reactor/src/main/java/io/smallrye/mutiny/converters/multi/FromFlux.java
+++ b/reactor/src/main/java/io/smallrye/mutiny/converters/multi/FromFlux.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import io.smallrye.mutiny.Multi;

--- a/reactor/src/main/java/io/smallrye/mutiny/converters/multi/FromMono.java
+++ b/reactor/src/main/java/io/smallrye/mutiny/converters/multi/FromMono.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import io.smallrye.mutiny.Multi;

--- a/reactor/src/main/java/io/smallrye/mutiny/converters/multi/MultiReactorConverters.java
+++ b/reactor/src/main/java/io/smallrye/mutiny/converters/multi/MultiReactorConverters.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 public class MultiReactorConverters {

--- a/reactor/src/main/java/io/smallrye/mutiny/converters/multi/ToFlux.java
+++ b/reactor/src/main/java/io/smallrye/mutiny/converters/multi/ToFlux.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import java.util.function.Function;

--- a/reactor/src/main/java/io/smallrye/mutiny/converters/multi/ToMono.java
+++ b/reactor/src/main/java/io/smallrye/mutiny/converters/multi/ToMono.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import java.util.function.Function;

--- a/reactor/src/main/java/io/smallrye/mutiny/converters/uni/FromFlux.java
+++ b/reactor/src/main/java/io/smallrye/mutiny/converters/uni/FromFlux.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import io.smallrye.mutiny.Uni;

--- a/reactor/src/main/java/io/smallrye/mutiny/converters/uni/FromMono.java
+++ b/reactor/src/main/java/io/smallrye/mutiny/converters/uni/FromMono.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import io.smallrye.mutiny.Uni;

--- a/reactor/src/main/java/io/smallrye/mutiny/converters/uni/ToFlux.java
+++ b/reactor/src/main/java/io/smallrye/mutiny/converters/uni/ToFlux.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import java.util.function.Function;

--- a/reactor/src/main/java/io/smallrye/mutiny/converters/uni/ToMono.java
+++ b/reactor/src/main/java/io/smallrye/mutiny/converters/uni/ToMono.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import java.util.function.Function;

--- a/reactor/src/main/java/io/smallrye/mutiny/converters/uni/UniReactorConverters.java
+++ b/reactor/src/main/java/io/smallrye/mutiny/converters/uni/UniReactorConverters.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 public class UniReactorConverters {

--- a/reactor/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
+++ b/reactor/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import java.io.IOException;

--- a/reactor/src/test/java/io/smallrye/mutiny/converters/MultiConvertToTest.java
+++ b/reactor/src/test/java/io/smallrye/mutiny/converters/MultiConvertToTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor/src/test/java/io/smallrye/mutiny/converters/UniConvertFromTest.java
+++ b/reactor/src/test/java/io/smallrye/mutiny/converters/UniConvertFromTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor/src/test/java/io/smallrye/mutiny/converters/UniConvertToTest.java
+++ b/reactor/src/test/java/io/smallrye/mutiny/converters/UniConvertToTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/FromCompletable.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/FromCompletable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import io.reactivex.Completable;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/FromFlowable.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/FromFlowable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import io.reactivex.Flowable;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/FromMaybe.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/FromMaybe.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import io.reactivex.Maybe;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/FromObservable.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/FromObservable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import io.reactivex.BackpressureStrategy;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/FromSingle.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/FromSingle.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import io.reactivex.Single;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/MultiRxConverters.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/MultiRxConverters.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 public class MultiRxConverters {

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/ToCompletable.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/ToCompletable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import java.util.function.Function;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/ToFlowable.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/ToFlowable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import java.util.function.Function;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/ToMaybe.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/ToMaybe.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import java.util.function.Function;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/ToObservable.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/ToObservable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import java.util.function.Function;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/ToSingle.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/ToSingle.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import java.util.Optional;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/ToSingleFailOnNull.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/multi/ToSingleFailOnNull.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.multi;
 
 import java.util.Optional;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/FromCompletable.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/FromCompletable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import io.reactivex.Completable;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/FromFlowable.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/FromFlowable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import io.reactivex.Flowable;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/FromMaybe.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/FromMaybe.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import io.reactivex.Maybe;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/FromObservable.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/FromObservable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import io.reactivex.BackpressureStrategy;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/FromSingle.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/FromSingle.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import io.reactivex.Single;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToCompletable.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToCompletable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import java.util.function.Function;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToFlowable.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToFlowable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import java.util.function.Function;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToMaybe.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToMaybe.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import java.util.concurrent.CompletableFuture;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToObservable.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToObservable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import java.util.function.Function;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToSingle.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToSingle.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import java.util.Optional;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToSingleFailOnNull.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToSingleFailOnNull.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import java.util.NoSuchElementException;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToSingleWithDefault.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/ToSingleWithDefault.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 import java.util.function.Function;

--- a/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/UniRxConverters.java
+++ b/rxjava/src/main/java/io/smallrye/mutiny/converters/uni/UniRxConverters.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters.uni;
 
 public class UniRxConverters {

--- a/rxjava/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
+++ b/rxjava/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import java.io.IOException;

--- a/rxjava/src/test/java/io/smallrye/mutiny/converters/MultiConvertToTest.java
+++ b/rxjava/src/test/java/io/smallrye/mutiny/converters/MultiConvertToTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/rxjava/src/test/java/io/smallrye/mutiny/converters/UniConvertFromTest.java
+++ b/rxjava/src/test/java/io/smallrye/mutiny/converters/UniConvertFromTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/rxjava/src/test/java/io/smallrye/mutiny/converters/UniConvertToTest.java
+++ b/rxjava/src/test/java/io/smallrye/mutiny/converters/UniConvertToTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.converters;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/test-utils/src/main/java/io/smallrye/mutiny/test/AbstractSubscriber.java
+++ b/test-utils/src/main/java/io/smallrye/mutiny/test/AbstractSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.test;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/test-utils/src/main/java/io/smallrye/mutiny/test/Mocks.java
+++ b/test-utils/src/main/java/io/smallrye/mutiny/test/Mocks.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.test;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/test-utils/src/main/java/io/smallrye/mutiny/test/MultiAssertSubscriber.java
+++ b/test-utils/src/main/java/io/smallrye/mutiny/test/MultiAssertSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/test-utils/src/test/java/io/smallrye/mutiny/test/AbstractSubscriberTest.java
+++ b/test-utils/src/test/java/io/smallrye/mutiny/test/AbstractSubscriberTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/test-utils/src/test/java/io/smallrye/mutiny/test/MocksTest.java
+++ b/test-utils/src/test/java/io/smallrye/mutiny/test/MocksTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.test;
 
 import static org.mockito.Mockito.mock;

--- a/test-utils/src/test/java/io/smallrye/mutiny/test/MultiAssertSubscriberTest.java
+++ b/test-utils/src/test/java/io/smallrye/mutiny/test/MultiAssertSubscriberTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.smallrye.mutiny.test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
The current code base lacks license headers and SPDX identifiers in files.

This change uses a Maven plugin to check that all Java files have a license header.

The plugin can be run manually: `mvn license:check` and `mvn license:format`.

The plugin is automatically triggered with the 'release' profile to check for missing headers and apply up-to-date headers.

Note that the plugin maintains copyright year ranges based on Git metadata, which does simplify maintenance.

Signed-off-by: Julien Ponge <jponge@redhat.com>