### PR TITLE
Add Uni.onItem().disjoint() 

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItem.java
@@ -14,7 +14,10 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
-import io.smallrye.mutiny.operators.*;
+import io.smallrye.mutiny.operators.UniOnItemConsume;
+import io.smallrye.mutiny.operators.UniOnItemTransform;
+import io.smallrye.mutiny.operators.UniOnItemTransformToMulti;
+import io.smallrye.mutiny.operators.UniOnItemTransformToUni;
 import io.smallrye.mutiny.subscription.UniEmitter;
 
 public class UniOnItem<T> {
@@ -330,5 +333,27 @@ public class UniOnItem<T> {
      */
     public UniOnNotNull<T> ifNotNull() {
         return new UniOnNotNull<>(upstream);
+    }
+
+    /**
+     * Takes the items from the upstream {@link Uni} that is either a {@link Publisher Publisher&lt;O&gt;},
+     * an {@link java.lang.reflect.Array O[]}, an {@link Iterable Iterable&lt;O&gt;} or a {@link Multi Multi&lt;O&gt;} and
+     * disjoint the items to obtain a {@link Multi Multi&lt;O&gt;}.
+     * <p>
+     * For examples, {@code Uni<[A, B, C]>} is transformed into {@code Multi<A, B, C>}, {@code Uni<[]>} is transformed
+     * into an empty {@code Multi}.
+     * <p>
+     * If the item from the upstream are not instances of {@link Iterable}, {@link Publisher} or array, an
+     * {@link IllegalArgumentException} is propagated downstream.
+     * <p>
+     * If the item is {@code null}, an empty {@code Multi} is produced.
+     * If the upstream propagates a failure, the failure is propagated downstream.
+     *
+     * @param <O> the type of the upstream item.
+     * @return the resulting multi
+     */
+    public <O> Multi<O> disjoint() {
+        return upstream.toMulti()
+                .onItem().disjoint();
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDisjointTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDisjointTest.java
@@ -1,0 +1,159 @@
+package io.smallrye.mutiny.operators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.testng.annotations.Test;
+
+import io.reactivex.Flowable;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.test.MultiAssertSubscriber;
+
+public class UniOnItemDisjointTest {
+
+    private final Uni<String[]> array = Uni.createFrom().item(new String[] { "a", "b", "c" });
+    private final Uni<Integer> failed = Uni.createFrom().failure(new IOException("boom"));
+
+    @Test
+    public void testDisjointWithArray() {
+        List<String> r = array
+                .onItem().<String> disjoint()
+                .collectItems().asList()
+                .await().indefinitely();
+        assertThat(r).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    public void testDisjointWithEmptyArray() {
+        List<String> r = Uni.createFrom().item(new String[0])
+                .onItem().<String> disjoint()
+                .collectItems().asList()
+                .await().indefinitely();
+        assertThat(r).isEmpty();
+    }
+
+    @Test
+    public void testDisjointFromFailure() {
+        assertThatThrownBy(() -> failed
+                .onItem().<String> disjoint()
+                .collectItems().asList()
+                .await().indefinitely()).hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void testDisjointFromInvalidItemType() {
+        assertThatThrownBy(() -> Uni.createFrom().item("hello")
+                .onItem().<String> disjoint()
+                .collectItems().asList()
+                .await().indefinitely()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testDisjointFromNull() {
+        List<String> list = Uni.createFrom().nullItem()
+                .onItem().<String> disjoint()
+                .collectItems().asList()
+                .await().indefinitely();
+
+        assertThat(list).isEmpty();
+    }
+
+    @Test
+    public void testDisjointWithPublisher() {
+        List<String> r = Uni.createFrom().item(Flowable.just("a", "b", "c"))
+                .onItem().<String> disjoint()
+                .collectItems().asList()
+                .await().indefinitely();
+        assertThat(r).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    public void testDisjointWithEmptyPublisher() {
+        List<String> r = Uni.createFrom().item(Flowable.empty())
+                .onItem().<String> disjoint()
+                .collectItems().asList()
+                .await().indefinitely();
+        assertThat(r).isEmpty();
+    }
+
+    @Test
+    public void testDisjointWithMulti() {
+        List<String> r = Uni.createFrom().item(Multi.createFrom().items("a", "b", "c"))
+                .onItem().<String> disjoint()
+                .collectItems().asList()
+                .await().indefinitely();
+        assertThat(r).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    public void testDisjointWithEmptyMulti() {
+        List<String> r = Uni.createFrom().item(Multi.createFrom().empty())
+                .onItem().<String> disjoint()
+                .collectItems().asList()
+                .await().indefinitely();
+        assertThat(r).isEmpty();
+    }
+
+    @Test
+    public void testDisjointWithIterable() {
+        List<String> r = Uni.createFrom().item(Arrays.asList("a", "b", "c"))
+                .onItem().<String> disjoint()
+                .collectItems().asList()
+                .await().indefinitely();
+        assertThat(r).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    public void testDisjointWithEmptyIterable() {
+        List<String> r = Uni.createFrom().item(Collections.emptyList())
+                .onItem().<String> disjoint()
+                .collectItems().asList()
+                .await().indefinitely();
+        assertThat(r).isEmpty();
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void testDisjointWithNeverPublisher() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        MultiAssertSubscriber<String> subscriber = Uni.createFrom()
+                .item(Flowable.never().doOnCancel(() -> cancelled.set(true)))
+                .onItem().<String> disjoint()
+                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+
+        subscriber.assertSubscribed()
+                .assertNotTerminated();
+
+        assertThat(cancelled).isFalse();
+
+        subscriber.cancel();
+
+        assertThat(cancelled).isTrue();
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void testDisjointWithNothing() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        MultiAssertSubscriber<String> subscriber = Uni.createFrom()
+                .item(Multi.createFrom().nothing().on().cancellation(() -> cancelled.set(true)))
+                .onItem().<String> disjoint()
+                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+
+        subscriber.assertSubscribed()
+                .assertNotTerminated();
+
+        assertThat(cancelled).isFalse();
+
+        subscriber.cancel();
+
+        assertThat(cancelled).isTrue();
+    }
+}


### PR DESCRIPTION
The method was forgotten when the `Multi.onItem().disjoint()` method was added.