### PR TITLE
Optimize Queue usages

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/Subscriptions.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/Subscriptions.java
@@ -130,7 +130,7 @@ public class Subscriptions {
         return prefetch == Integer.MAX_VALUE ? Integer.MAX_VALUE : (prefetch - (prefetch >> 2));
     }
 
-    public static long unboundedOrMaxConcurrency(int concurrency) {
+    public static long unboundedOrRequests(int concurrency) {
         return concurrency == Integer.MAX_VALUE ? Long.MAX_VALUE : concurrency;
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/EmptyQueue.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/EmptyQueue.java
@@ -1,0 +1,100 @@
+package io.smallrye.mutiny.helpers.queues;
+
+import java.util.*;
+
+final class EmptyQueue<T> implements Queue<T> {
+
+    @Override
+    public boolean add(T t) {
+        return false;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        return false;
+    }
+
+    @Override
+    public void clear() {
+        // Do nothing
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return false;
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return false;
+    }
+
+    @Override
+    public T element() {
+        throw new NoSuchElementException("This is an empty queue");
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public boolean offer(T t) {
+        return false;
+    }
+
+    @Override
+    public T peek() {
+        return null;
+    }
+
+    @Override
+    public T poll() {
+        return null;
+    }
+
+    @Override
+    public T remove() {
+        throw new NoSuchElementException("This is an empty queue");
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return false;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return false;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return false;
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public Object[] toArray() {
+        return new Object[0];
+    }
+
+    @Override
+    public <T1> T1[] toArray(T1[] a) {
+        if (a.length > 0) {
+            a[0] = null;
+        }
+        return a;
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/Queues.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/Queues.java
@@ -1,0 +1,100 @@
+package io.smallrye.mutiny.helpers.queues;
+
+import java.util.Queue;
+import java.util.function.Supplier;
+
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class Queues {
+
+    /**
+     * Queues with a requested with a capacity greater than this value are unbounded.
+     */
+    public static final int TO_LARGE_TO_BE_BOUNDED = 10_000_000;
+
+    private Queues() {
+        // avoid direct instantiation
+    }
+
+    public static final int BUFFER_XS = Math.max(8,
+            Integer.parseInt(System.getProperty("mutiny.buffer-size.xs", "32")));
+
+    public static final int BUFFER_S = Math.max(16,
+            Integer.parseInt(System.getProperty("mutiny.buffer-size.s", "256")));
+
+    static final Supplier EMPTY_QUEUE_SUPPLIER = EmptyQueue::new;
+    static final Supplier SINGLETON_QUEUE_SUPPLIER = SingletonQueue::new;
+
+    static final Supplier XS_QUEUE_SUPPLIER = () -> new SpscArrayQueue<>(BUFFER_XS);
+    static final Supplier S_QUEUE_SUPPLIER = () -> new SpscArrayQueue<>(BUFFER_S);
+
+    static final Supplier UNBOUNDED_QUEUE_SUPPLIER = () -> new SpscLinkedArrayQueue<>(BUFFER_S);
+    static final Supplier XS_UNBOUNDED_QUEUE_SUPPLIER = () -> new SpscLinkedArrayQueue<>(BUFFER_XS);
+
+    public static <T> Supplier<Queue<T>> getXsQueueSupplier() {
+        return (Supplier<Queue<T>>) XS_QUEUE_SUPPLIER;
+    }
+
+    /**
+     * Gets a supplier to create queues with the given buffer size (size of the array allocated as backend of the queue).
+     * <p>
+     * The type of the queue and configuration is computed based on the given buffer size.
+     *
+     * @param bufferSize the buffer size
+     * @param <T> the type of element
+     * @return the supplier.
+     */
+    public static <T> Supplier<Queue<T>> get(int bufferSize) {
+        if (bufferSize == BUFFER_XS) {
+            return XS_QUEUE_SUPPLIER;
+        }
+
+        if (bufferSize == BUFFER_S) {
+            return S_QUEUE_SUPPLIER;
+        }
+
+        if (bufferSize == 1) {
+            return SINGLETON_QUEUE_SUPPLIER;
+        }
+
+        if (bufferSize == 0) {
+            return EMPTY_QUEUE_SUPPLIER;
+        }
+
+        final int computedSize = Math.max(8, bufferSize);
+        if (computedSize > TO_LARGE_TO_BE_BOUNDED) {
+            return UNBOUNDED_QUEUE_SUPPLIER;
+        } else {
+            return () -> new SpscArrayQueue<>(computedSize);
+        }
+    }
+
+    /**
+     * Returns an unbounded Queue.
+     * The queue is array-backed. Each array has the given size. If the queue is full, new arrays can be allocated.
+     * 
+     * @param size the size of the array
+     * @param <T> the type of item
+     * @return the unbound queue supplier
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Supplier<Queue<T>> unbounded(int size) {
+        if (size == BUFFER_XS) {
+            return XS_UNBOUNDED_QUEUE_SUPPLIER;
+        } else if (size == Integer.MAX_VALUE || size == BUFFER_S) {
+            return UNBOUNDED_QUEUE_SUPPLIER;
+        } else {
+            return () -> new SpscLinkedArrayQueue<>(size);
+        }
+    }
+
+    /**
+     * Creates a new multi-producer single consumer unbounded queue.
+     * 
+     * @param <T> the type of item
+     * @return the queue
+     */
+    public static <T> Queue<T> createMpscQueue() {
+        return new MpscLinkedQueue<>();
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/SingletonQueue.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/SingletonQueue.java
@@ -1,0 +1,177 @@
+package io.smallrye.mutiny.helpers.queues;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+final class SingletonQueue<T> implements Queue<T> {
+
+    private final AtomicReference<T> element = new AtomicReference<>();
+
+    @Override
+    public boolean add(T t) {
+        return offer(t);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        if (c.isEmpty()) {
+            return true;
+        }
+        if (c.size() == 1) {
+            return offer(c.iterator().next());
+        }
+        return false;
+    }
+
+    @Override
+    public void clear() {
+        element.set(null);
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return Objects.equals(element.get(), o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        if (c.isEmpty()) {
+            return true;
+        }
+        if (c.size() == 1) {
+            return Objects.equals(c.iterator().next(), peek());
+        }
+        return false;
+    }
+
+    @Override
+    public T element() {
+        return element.get();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return element.get() == null;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new SingletonIterator<>(this);
+    }
+
+    @Override
+    public boolean offer(T t) {
+        if (element.get() != null) {
+            return false;
+        }
+        element.lazySet(t);
+        return true;
+    }
+
+    @Override
+    public T peek() {
+        return element.get();
+    }
+
+    @Override
+    public T poll() {
+        T v = element.get();
+        if (v != null) {
+            element.lazySet(null);
+        }
+        return v;
+    }
+
+    @Override
+    public T remove() {
+        return element.getAndSet(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean remove(Object o) {
+        try {
+            return element.compareAndSet((T) o, null);
+        } catch (ClassCastException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        // Not supported
+        return false;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        // Not supported
+        return false;
+    }
+
+    @Override
+    public int size() {
+        return element.get() == null ? 0 : 1;
+    }
+
+    @Override
+    public Object[] toArray() {
+        T t = element.get();
+        if (t == null) {
+            return new Object[0];
+        }
+        return new Object[] { t };
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T1> T1[] toArray(T1[] a) {
+        int size = size();
+        if (a.length < size) {
+            a = (T1[]) Array.newInstance(a.getClass().getComponentType(), size);
+        }
+        if (size == 1) {
+            a[0] = (T1) element.get();
+        }
+        if (a.length > size) {
+            a[size] = null;
+        }
+        return a;
+    }
+
+    private static final class SingletonIterator<T> implements Iterator<T> {
+
+        final SingletonQueue<T> queue;
+        final AtomicBoolean consumed = new AtomicBoolean();
+
+        public SingletonIterator(SingletonQueue<T> queue) {
+            this.queue = queue;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (queue.isEmpty()) {
+                return false;
+            }
+            return !consumed.get();
+        }
+
+        @Override
+        public T next() {
+            if (consumed.compareAndSet(false, true)) {
+                return queue.peek();
+            }
+            return null;
+        }
+
+        @Override
+        public void remove() {
+            queue.remove();
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiEmitOnOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiEmitOnOp.java
@@ -15,7 +15,7 @@ import org.reactivestreams.Subscription;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.helpers.Subscriptions;
-import io.smallrye.mutiny.helpers.queues.SpscArrayQueue;
+import io.smallrye.mutiny.helpers.queues.Queues;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 
@@ -27,7 +27,7 @@ import io.smallrye.mutiny.subscription.MultiSubscriber;
 public class MultiEmitOnOp<T> extends AbstractMultiOperator<T, T> {
 
     private final Executor executor;
-    private final Supplier<? extends Queue<T>> queueSupplier = () -> new SpscArrayQueue<>(16);
+    private final Supplier<? extends Queue<T>> queueSupplier = Queues.get(Queues.BUFFER_S);
 
     public MultiEmitOnOp(Multi<? extends T> upstream, Executor executor) {
         super(upstream);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOnDurationOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOnDurationOp.java
@@ -18,7 +18,7 @@ import org.reactivestreams.Subscription;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.helpers.Subscriptions;
-import io.smallrye.mutiny.helpers.queues.MpscLinkedQueue;
+import io.smallrye.mutiny.helpers.queues.Queues;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
@@ -58,7 +58,7 @@ public class MultiWindowOnDurationOp<T> extends AbstractMultiOperator<T, Multi<T
         WindowTimeoutSubscriber(MultiSubscriber<? super Multi<T>> downstream, Duration duration,
                 ScheduledExecutorService scheduler) {
             super(downstream);
-            this.queue = new MpscLinkedQueue<>();
+            this.queue = Queues.createMpscQueue();
             this.duration = duration;
             this.scheduler = scheduler;
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOp.java
@@ -17,8 +17,7 @@ import org.reactivestreams.Subscription;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.helpers.Subscriptions;
-import io.smallrye.mutiny.helpers.queues.SpscArrayQueue;
-import io.smallrye.mutiny.helpers.queues.SpscLinkedArrayQueue;
+import io.smallrye.mutiny.helpers.queues.Queues;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 
@@ -54,8 +53,8 @@ public class MultiWindowOp<T> extends AbstractMultiOperator<T, Multi<T>> {
         super(upstream);
         this.size = ParameterValidation.positive(size, "size");
         this.skip = ParameterValidation.positive(skip, "skip");
-        this.processorQueueSupplier = () -> new SpscArrayQueue<>(size);
-        this.overflowQueueSupplier = () -> new SpscLinkedArrayQueue<>(size);
+        this.processorQueueSupplier = Queues.unbounded(Queues.BUFFER_XS);
+        this.overflowQueueSupplier = Queues.unbounded(Queues.BUFFER_XS);
     }
 
     @Override
@@ -78,7 +77,7 @@ public class MultiWindowOp<T> extends AbstractMultiOperator<T, Multi<T>> {
 
         private final Supplier<? extends Queue<T>> supplier;
         private final int size;
-        private AtomicInteger count = new AtomicInteger();
+        private final AtomicInteger count = new AtomicInteger();
 
         int index;
         private UnicastProcessor<T> processor;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiZipOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiZipOp.java
@@ -13,7 +13,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.helpers.Subscriptions;
-import io.smallrye.mutiny.helpers.queues.SpscArrayQueue;
+import io.smallrye.mutiny.helpers.queues.Queues;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.AbstractMulti;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
@@ -276,7 +276,7 @@ public final class MultiZipOp<O> extends AbstractMulti<O> {
         @Override
         public void onSubscribe(Subscription s) {
             if (upstream.compareAndSet(null, s)) {
-                queue = new SpscArrayQueue<>(prefetch);
+                queue = Queues.get(prefetch).get();
                 s.request(prefetch);
             }
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BufferItemMultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BufferItemMultiEmitter.java
@@ -1,22 +1,23 @@
 package io.smallrye.mutiny.operators.multi.builders;
 
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.smallrye.mutiny.helpers.Subscriptions;
-import io.smallrye.mutiny.helpers.queues.SpscLinkedArrayQueue;
+import io.smallrye.mutiny.helpers.queues.Queues;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 
 public class BufferItemMultiEmitter<T> extends BaseMultiEmitter<T> {
 
-    private final SpscLinkedArrayQueue<T> queue;
+    private final Queue<T> queue;
     private Throwable failure;
     private volatile boolean done;
     private final AtomicInteger wip = new AtomicInteger();
 
     BufferItemMultiEmitter(MultiSubscriber<? super T> actual, int capacityHint) {
         super(actual);
-        this.queue = new SpscLinkedArrayQueue<>(capacityHint);
+        this.queue = Queues.<T> unbounded(capacityHint).get();
     }
 
     @Override
@@ -73,7 +74,7 @@ public class BufferItemMultiEmitter<T> extends BaseMultiEmitter<T> {
         }
 
         int missed = 1;
-        final SpscLinkedArrayQueue<T> q = queue;
+        final Queue<T> q = queue;
 
         do {
             long r = requested.get();

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/SerializedMultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/SerializedMultiEmitter.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.Subscription;
 
-import io.smallrye.mutiny.helpers.queues.SpscLinkedArrayQueue;
+import io.smallrye.mutiny.helpers.queues.Queues;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 
@@ -22,7 +22,7 @@ public class SerializedMultiEmitter<T> implements MultiEmitter<T>, MultiSubscrib
     private final AtomicInteger wip = new AtomicInteger();
     private final BaseMultiEmitter<T> downstream;
     private final AtomicReference<Throwable> failure = new AtomicReference<>();
-    private final SpscLinkedArrayQueue<T> queue = new SpscLinkedArrayQueue<>(16);
+    private final Queue<T> queue = Queues.createMpscQueue();
 
     private volatile boolean done;
 
@@ -50,7 +50,7 @@ public class SerializedMultiEmitter<T> implements MultiEmitter<T>, MultiSubscrib
                 return;
             }
         } else {
-            SpscLinkedArrayQueue<T> q = queue;
+            Queue<T> q = queue;
             synchronized (q) {
                 q.offer(item);
             }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiPublishOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiPublishOp.java
@@ -12,7 +12,7 @@ import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.Subscriptions;
-import io.smallrye.mutiny.helpers.queues.SpscArrayQueue;
+import io.smallrye.mutiny.helpers.queues.Queues;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
 import io.smallrye.mutiny.subscription.Cancellable;
@@ -137,7 +137,7 @@ public final class MultiPublishOp<T> extends ConnectableMulti<T> {
 
         private static final Throwable COMPLETED = new Exception();
 
-        private final SpscArrayQueue<T> queue;
+        private final Queue<T> queue;
 
         private final AtomicBoolean cancelled = new AtomicBoolean();
 
@@ -150,7 +150,7 @@ public final class MultiPublishOp<T> extends ConnectableMulti<T> {
             this.current = current;
             this.shouldConnect = new AtomicBoolean();
             this.bufferSize = bufferSize;
-            this.queue = new SpscArrayQueue<>(bufferSize);
+            this.queue = (Queue<T>) Queues.get(bufferSize).get();
         }
 
         @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowBufferOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowBufferOp.java
@@ -10,8 +10,7 @@ import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.Subscriptions;
-import io.smallrye.mutiny.helpers.queues.SpscArrayQueue;
-import io.smallrye.mutiny.helpers.queues.SpscLinkedArrayQueue;
+import io.smallrye.mutiny.helpers.queues.Queues;
 import io.smallrye.mutiny.operators.multi.AbstractMultiOperator;
 import io.smallrye.mutiny.operators.multi.MultiOperatorProcessor;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
@@ -61,7 +60,7 @@ public class MultiOnOverflowBufferOp<T> extends AbstractMultiOperator<T, T> {
             super(downstream);
             this.onOverflow = onOverflow;
             this.postponeFailurePropagation = postponeFailurePropagation;
-            this.queue = unbounded ? new SpscLinkedArrayQueue<>(bufferSize) : new SpscArrayQueue<>(bufferSize);
+            this.queue = unbounded ? Queues.<T> unbounded(bufferSize).get() : Queues.<T> get(bufferSize).get();
         }
 
         @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessor.java
@@ -12,7 +12,7 @@ import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.helpers.Subscriptions;
-import io.smallrye.mutiny.helpers.queues.SpscLinkedArrayQueue;
+import io.smallrye.mutiny.helpers.queues.Queues;
 import io.smallrye.mutiny.operators.AbstractMulti;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
@@ -45,7 +45,7 @@ public class UnicastProcessor<T> extends AbstractMulti<T> implements Processor<T
      * @return the unicast processor
      */
     public static <I> UnicastProcessor<I> create() {
-        return new UnicastProcessor<>(new SpscLinkedArrayQueue<>(16), null);
+        return new UnicastProcessor<>(Queues.<I> unbounded(Queues.BUFFER_S).get(), null);
     }
 
     /**

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/queues/QueuesTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/queues/QueuesTest.java
@@ -1,0 +1,221 @@
+package io.smallrye.mutiny.helpers.queues;
+
+import static io.smallrye.mutiny.helpers.queues.Queues.BUFFER_S;
+import static io.smallrye.mutiny.helpers.queues.Queues.BUFFER_XS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.*;
+
+import org.testng.annotations.Test;
+
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class QueuesTest {
+
+    @Test
+    public void testUnboundedQueueCreation() {
+        Queue q = Queues.unbounded(10).get();
+        assertThat(q).isInstanceOf(SpscLinkedArrayQueue.class);
+
+        q = Queues.unbounded(Queues.BUFFER_XS).get();
+        assertThat(q).isInstanceOf(SpscLinkedArrayQueue.class);
+
+        q = Queues.unbounded(Queues.BUFFER_S).get();
+        assertThat(q).isInstanceOf(SpscLinkedArrayQueue.class);
+
+        q = Queues.unbounded(Integer.MAX_VALUE).get();
+        assertThat(q).isInstanceOf(SpscLinkedArrayQueue.class);
+    }
+
+    @Test
+    public void testCreationOfBoundedQueues() {
+        //the bounded queue floors at 8 and rounds to the next power of 2
+        Queue queue = Queues.get(2).get();
+        // 8 is the minimum
+        assertThat(getCapacity(queue)).isEqualTo(8);
+        assertThat(queue).isInstanceOf(SpscArrayQueue.class);
+
+        queue = Queues.get(8).get();
+        // 8 is the minimum
+        assertThat(getCapacity(queue)).isEqualTo(8);
+        assertThat(queue).isInstanceOf(SpscArrayQueue.class);
+
+        queue = Queues.get(10).get();
+        // next power of 2 after 8
+        assertThat(getCapacity(queue)).isEqualTo(16);
+        assertThat(queue).isInstanceOf(SpscArrayQueue.class);
+
+        // Special BUFFER_XS case
+        queue = Queues.get(BUFFER_XS).get();
+        assertThat(getCapacity(queue)).isEqualTo(32);
+        assertThat(queue).isInstanceOf(SpscArrayQueue.class);
+
+        // Special BUFFER_S case
+        queue = Queues.get(BUFFER_S).get();
+        assertThat(getCapacity(queue)).isEqualTo(256);
+        assertThat(queue).isInstanceOf(SpscArrayQueue.class);
+
+        queue = Queues.get(1).get();
+        assertThat(getCapacity(queue)).isEqualTo(1);
+        assertThat(queue).isInstanceOf(SingletonQueue.class);
+
+        queue = Queues.get(0).get();
+        assertThat(getCapacity(queue)).isEqualTo(0);
+        assertThat(queue).isInstanceOf(EmptyQueue.class);
+
+        queue = Queues.get(4).get();
+        assertThat(getCapacity(queue)).isEqualTo(8);
+        assertThat(queue).isInstanceOf(SpscArrayQueue.class);
+    }
+
+    @Test
+    public void testCreationOfUnboundedQueues() {
+        Queue queue = Queues.get(Integer.MAX_VALUE).get();
+        assertThat(getCapacity(queue)).isEqualTo(Integer.MAX_VALUE);
+        assertThat(queue).isInstanceOf(SpscLinkedArrayQueue.class);
+
+        // Not large enough to be unbounded:
+        queue = Queues.get(1000).get();
+        // Next power of 2.
+        assertThat(getCapacity(queue)).isEqualTo(1024L);
+        assertThat(queue).isInstanceOf(SpscArrayQueue.class);
+
+        queue = Queues.get(Queues.TO_LARGE_TO_BE_BOUNDED + 1).get();
+        assertThat(getCapacity(queue)).isEqualTo(Integer.MAX_VALUE);
+        assertThat(queue).isInstanceOf(SpscLinkedArrayQueue.class);
+
+    }
+
+    private long getCapacity(Queue q) {
+        if (q instanceof EmptyQueue) {
+            return 0;
+        }
+        if (q instanceof SingletonQueue) {
+            return 1;
+        }
+        if (q instanceof SpscLinkedArrayQueue) {
+            return Integer.MAX_VALUE;
+        } else if (q instanceof SpscArrayQueue) {
+            return ((SpscArrayQueue) q).length();
+        }
+        return -1;
+    }
+
+    @Test
+    public void testEmptyQueue() {
+        Queue<Integer> queue = Queues.<Integer> get(0).get();
+        List<Integer> values = Arrays.asList(1, 2, 3);
+        assertThat(queue.add(1)).isFalse();
+        assertThat(queue.addAll(values)).isFalse();
+        assertThat(queue.offer(1)).isFalse();
+        assertThat(queue.peek()).isNull();
+        assertThat(queue.poll()).isNull();
+        assertThat(queue.contains(1)).isFalse();
+        assertThat(queue.iterator().hasNext()).isFalse();
+        assertThatThrownBy(queue::element).isInstanceOf(NoSuchElementException.class);
+        assertThatThrownBy(queue::remove).isInstanceOf(NoSuchElementException.class);
+        assertThat(queue.remove(1)).isFalse();
+        assertThat(queue.containsAll(values)).isFalse();
+        assertThat(queue.retainAll(values)).isFalse();
+        assertThat(queue.removeAll(values)).isFalse();
+        queue.clear();
+        assertThat(queue).hasSize(0);
+        assertThat(queue.toArray()).isEmpty();
+        assertThat(queue.toArray(new Integer[0])).isEmpty();
+        Integer[] array = new Integer[] { 4, 5, 6 };
+        assertThat(queue.toArray(array)).containsExactly(null, 5, 6);
+        assertThat(queue).isEmpty();
+    }
+
+    @SuppressWarnings({ "ConfusingArgumentToVarargsMethod", "ConstantConditions", "RedundantCollectionOperation",
+            "SuspiciousMethodCalls" })
+    @Test
+    public void testSingletonQueue() {
+        SingletonQueue<Integer> queue = new SingletonQueue<>();
+
+        // Keep queue empty for the first tests
+        assertThat(queue.isEmpty()).isTrue();
+        assertThat(queue.toArray()).isEmpty();
+        assertThat(queue.toArray(new Integer[0])).isEmpty();
+        Integer[] arr = new Integer[] { 23 };
+        assertThat(queue.toArray(arr))
+                .hasSize(1).isSameAs(arr);
+
+        arr = new Integer[] { 1, 2, 3 };
+        assertThat(queue.toArray(arr))
+                .containsExactly(null, 2, 3).isSameAs(arr);
+
+        // Now test when the queue contains one element
+        assertThat(queue.add(23)).isTrue();
+        assertThat(queue.toArray()).containsExactly(23);
+        assertThat(queue.toArray(new Integer[0])).containsExactly(23);
+        arr = new Integer[1];
+        assertThat(queue.toArray(arr)).containsExactly(23).isSameAs(arr);
+        arr = new Integer[] { 1, 2, 3 };
+        assertThat(queue.toArray(arr))
+                .containsExactly(23, null, 3).isSameAs(arr);
+
+        assertThat(queue.remove()).isEqualTo(23);
+        assertThat(queue.isEmpty()).isTrue();
+        assertThat(queue.offer(2)).isTrue();
+        assertThat(queue.offer(4)).isFalse();
+        assertThat(queue).containsExactly(2);
+        assertThat(queue.offer(3)).isFalse();
+        assertThat(queue).containsExactly(2);
+
+        assertThat(queue.peek()).isEqualTo(2);
+        assertThat(queue).containsExactly(2);
+        assertThat(queue.poll()).isEqualTo(2);
+        assertThat(queue).isEmpty();
+
+        assertThat(queue.add(23)).isTrue();
+        assertThat(queue.peek()).isEqualTo(23);
+        assertThat(queue.add(24)).isFalse();
+        assertThat(queue.peek()).isEqualTo(23);
+        assertThat(queue.element()).isEqualTo(23);
+        queue.clear();
+        assertThat(queue).isEmpty();
+        assertThat(queue.peek()).isNull();
+        assertThat(queue.poll()).isNull();
+        assertThat(queue.element()).isNull();
+
+        assertThat(queue.addAll(Collections.singletonList(2))).isTrue();
+        assertThat(queue.addAll(Collections.singletonList(3))).isFalse();
+        assertThat(queue.addAll(Arrays.asList(1, 2, 3))).isFalse();
+        assertThat(queue.addAll(Collections.emptyList())).isTrue();
+
+        assertThat(queue.remove()).isEqualTo(2);
+        queue.add(55);
+        assertThat(queue.contains(55)).isTrue();
+        assertThat(queue.contains(0)).isFalse();
+        assertThat(queue.containsAll(Collections.emptyList())).isTrue();
+        assertThat(queue.containsAll(Collections.singleton(55))).isTrue();
+        assertThat(queue.containsAll(Arrays.asList(1, 2, 55))).isFalse();
+
+        assertThat(queue.remove(44)).isFalse();
+        assertThat(queue.remove("hello")).isFalse();
+        assertThat(queue.remove(null)).isFalse();
+        assertThat(queue.remove(55)).isTrue();
+
+        // Not supported:
+        assertThat(queue.removeAll(Collections.emptyList())).isFalse();
+        assertThat(queue.retainAll(Collections.emptyList())).isFalse();
+
+        queue.add(23);
+        Iterator<Integer> iterator = queue.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+        Integer next = iterator.next();
+        assertThat(next).isEqualTo(23);
+        assertThat(iterator.hasNext()).isFalse();
+        assertThat(iterator.next()).isNull();
+
+        iterator = queue.iterator();
+        assertThat(iterator.next()).isEqualTo(23);
+        iterator.remove();
+
+        iterator = queue.iterator();
+        assertThat(iterator.hasNext()).isFalse();
+        assertThat(iterator.next()).isNull();
+    }
+
+}


### PR DESCRIPTION
This PR improves the sizing and the kind of the various queues we use.
It creates a central class to create the various type of queues and provide heuristics about the size.

The various operators have been updated to use the right type of queues.

It also fixes #215 as the requests parameter should be used and passed to the operator.