### PR TITLE
Fix asciidoctor config

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -120,15 +120,16 @@
                     </requires>
                     <preserveDirectories>true</preserveDirectories>
                     <backend>html</backend>
-                    <sourceHighlighter>highlightjs</sourceHighlighter>
                     <attributes>
                         <toc>left</toc>
                         <version>${project.version}</version>
                         <reactive.streams.version>${reactive-streams.version}</reactive.streams.version>
                         <icons>font</icons>
+                        <source-highlighter>highlightjs</source-highlighter>
+                        <imagesdir>assets/images</imagesdir>
+                        <attribute-missing>warn</attribute-missing>
                     </attributes>
                     <sourceDirectory>src/main/docs</sourceDirectory>
-                    <imagesDir>assets/images</imagesDir>
                     <outputDirectory>${site.dir}</outputDirectory>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The update to the asciidoctor-maven-plugin 2.0.0 broke the documentation.
This commit migrates to the new configuration format - see https://github.com/asciidoctor/asciidoctor-maven-plugin/blob/master/docs/v2-migration-guide.adoc for details.

Two issues were reported:

* The syntax highlighting was not working anymore
* The top image was missing

Once merged I will apply this hotfix on the web site.