### PR TITLE
Create onCancellation() groups for Uni and Multi

### DIFF
--- a/documentation/src/test/java/snippets/EventsTest.java
+++ b/documentation/src/test/java/snippets/EventsTest.java
@@ -17,8 +17,7 @@ public class EventsTest {
                 .onFailure().invoke(failure -> System.out.println("Failed with " + failure.getMessage()))
                 .onCompletion().invoke(() -> System.out.println("Completed"))
                 .onSubscribe().invoke(subscription -> System.out.println("We are subscribed!"))
-
-                .on().cancellation(() -> System.out.println("Downstream has cancelled the interaction"))
+                .onCancellation().invoke(() -> System.out.println("Downstream has cancelled the interaction"))
                 .on().request(n -> System.out.println("Downstream requested " + n + " items"))
                 .subscribe().with(item -> {
                 });

--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -407,4 +407,11 @@ public interface Multi<T> extends Publisher<T> {
      * @return the object to configure the termination actions.
      */
     MultiOnTerminate<T> onTermination();
+
+    /**
+     * Configures actions when the subscriber cancels the subscription.
+     * 
+     * @return the object to configure the cancellation actions.
+     */
+    MultiOnCancel<T> onCancellation();
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -641,4 +641,11 @@ public interface Uni<T> {
      * @return the object to configure the termination actions.
      */
     UniOnTerminate<T> onTermination();
+
+    /**
+     * Configures actions to be performed when the subscriber cancels the subscription.
+     * 
+     * @return the object to configure the cancellation actions.
+     */
+    UniOnCancel<T> onCancellation();
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnCancel.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnCancel.java
@@ -21,6 +21,7 @@ public class MultiOnCancel<T> {
     /**
      * Attaches an action executed when the subscription is cancelled.
      * The upstream is not cancelled yet, but will be cancelled when the callback completes.
+     * Note that if the callback throws an exception then it will be discarded.
      *
      * @param action the action, must not be {@code null}
      * @return a new {@link Multi}
@@ -33,6 +34,7 @@ public class MultiOnCancel<T> {
      * Attaches an action executed when the subscription is cancelled.
      * The upstream is not cancelled yet, but will be cancelled when the returned {@link Uni} completes.
      * The supplier must not return {@code null}.
+     * Note that the result or the failure of the {@link Uni} will be discarded.
      * 
      * @param supplier the {@link Uni} supplier, must not return {@code null}.
      * @return a new {@link Multi}

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnCancel.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnCancel.java
@@ -1,0 +1,43 @@
+package io.smallrye.mutiny.groups;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.multi.MultiOnCancellationInvoke;
+import io.smallrye.mutiny.operators.multi.MultiOnCancellationInvokeUni;
+
+public class MultiOnCancel<T> {
+
+    private final Multi<T> upstream;
+
+    public MultiOnCancel(Multi<T> upstream) {
+        this.upstream = nonNull(upstream, "upstream");
+    }
+
+    /**
+     * Attaches an action executed when the subscription is cancelled.
+     * The upstream is not cancelled yet, but will be cancelled when the callback completes.
+     *
+     * @param action the action, must not be {@code null}
+     * @return a new {@link Multi}
+     */
+    public Multi<T> invoke(Runnable action) {
+        return Infrastructure.onMultiCreation(new MultiOnCancellationInvoke<>(upstream, nonNull(action, "action")));
+    }
+
+    /**
+     * Attaches an action executed when the subscription is cancelled.
+     * The upstream is not cancelled yet, but will be cancelled when the returned {@link Uni} completes.
+     * The supplier must not return {@code null}.
+     * 
+     * @param supplier the {@link Uni} supplier, must not return {@code null}.
+     * @return a new {@link Multi}
+     */
+    public Multi<T> invokeUni(Supplier<Uni<?>> supplier) {
+        return Infrastructure.onMultiCreation(new MultiOnCancellationInvokeUni<>(upstream, nonNull(supplier, "supplier")));
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnEvent.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnEvent.java
@@ -49,15 +49,11 @@ public class MultiOnEvent<T> {
      *
      * @param callback the callback, must not be {@code null}
      * @return a new {@link Multi}
+     * @deprecated Use {@link Multi#onCancellation()} instead.
      */
+    @Deprecated
     public Multi<T> cancellation(Runnable callback) {
-        return Infrastructure.onMultiCreation(new MultiSignalConsumerOp<>(
-                upstream,
-                null,
-                null,
-                null,
-                null,
-                nonNull(callback, "callback")));
+        return upstream.onCancellation().invoke(callback);
     }
 
     public Multi<T> request(LongConsumer callback) {

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnCancel.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnCancel.java
@@ -18,10 +18,27 @@ public class UniOnCancel<T> {
         this.upstream = ParameterValidation.nonNull(upstream, "upstream");
     }
 
+    /**
+     * Attaches an action executed when the subscription is cancelled.
+     * The upstream is not cancelled yet, but will be cancelled when the callback completes.
+     * Note that if the callback throws an exception then it will be discarded.
+     *
+     * @param action the action, must not be {@code null}
+     * @return a new {@link Uni}
+     */
     public Uni<T> invoke(Runnable action) {
         return Infrastructure.onUniCreation(new UniOnCancellation<>(upstream, nonNull(action, "action")));
     }
 
+    /**
+     * Attaches an action executed when the subscription is cancelled.
+     * The upstream is not cancelled yet, but will be cancelled when the returned {@link Uni} completes.
+     * The supplier must not return {@code null}.
+     * Note that the result or the failure of the {@link Uni} will be discarded.
+     *
+     * @param supplier the {@link Uni} supplier, must not return {@code null}.
+     * @return a new {@link Uni}
+     */
     public Uni<T> invokeUni(Supplier<Uni<?>> supplier) {
         return Infrastructure.onUniCreation(new UniOnCancellationInvokeUni<>(upstream, nonNull(supplier, "supplier")));
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnCancel.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnCancel.java
@@ -1,14 +1,14 @@
 package io.smallrye.mutiny.groups;
 
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.util.function.Supplier;
+
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.UniOnCancellation;
 import io.smallrye.mutiny.operators.UniOnCancellationInvokeUni;
-
-import java.util.function.Supplier;
-
-import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
 public class UniOnCancel<T> {
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnCancel.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnCancel.java
@@ -1,0 +1,28 @@
+package io.smallrye.mutiny.groups;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.ParameterValidation;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.UniOnCancellation;
+import io.smallrye.mutiny.operators.UniOnCancellationInvokeUni;
+
+import java.util.function.Supplier;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+public class UniOnCancel<T> {
+
+    private final Uni<T> upstream;
+
+    public UniOnCancel(Uni<T> upstream) {
+        this.upstream = ParameterValidation.nonNull(upstream, "upstream");
+    }
+
+    public Uni<T> invoke(Runnable action) {
+        return Infrastructure.onUniCreation(new UniOnCancellation<>(upstream, nonNull(action, "action")));
+    }
+
+    public Uni<T> invokeUni(Supplier<Uni<?>> supplier) {
+        return Infrastructure.onUniCreation(new UniOnCancellationInvokeUni<>(upstream, nonNull(supplier, "supplier")));
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnEvent.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnEvent.java
@@ -47,9 +47,11 @@ public class UniOnEvent<T> {
      *
      * @param runnable the callback, must not be {@code null}
      * @return a new {@link Uni}
+     * @deprecated Use {@link Uni#onCancellation()} instead.
      */
+    @Deprecated
     public Uni<T> cancellation(Runnable runnable) {
-        return Infrastructure.onUniCreation(new UniOnCancellation<>(upstream, nonNull(runnable, "runnable")));
+        return upstream.onCancellation().invoke(runnable);
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnEvent.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnEvent.java
@@ -6,8 +6,6 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
-import io.smallrye.mutiny.operators.UniOnCancellation;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
 import io.smallrye.mutiny.tuples.Functions;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
@@ -128,4 +128,9 @@ public abstract class AbstractMulti<T> implements Multi<T> {
         return new MultiOnTerminate<>(this);
     }
 
+    @Override
+    public MultiOnCancel<T> onCancellation() {
+        return new MultiOnCancel<>(this);
+    }
+
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
@@ -135,4 +135,9 @@ public abstract class AbstractUni<T> implements Uni<T> {
     public UniOnTerminate<T> onTermination() {
         return new UniOnTerminate<>(this);
     }
+
+    @Override
+    public UniOnCancel<T> onCancellation() {
+        return new UniOnCancel<>(this);
+    }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnCancellationInvokeUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnCancellationInvokeUni.java
@@ -1,0 +1,53 @@
+package io.smallrye.mutiny.operators;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.UniSubscription;
+
+public class UniOnCancellationInvokeUni<I> extends UniOperator<I, I> {
+
+    private final Supplier<Uni<?>> supplier;
+
+    public UniOnCancellationInvokeUni(Uni<? extends I> upstream, Supplier<Uni<?>> supplier) {
+        super(nonNull(upstream, "upstream"));
+        this.supplier = nonNull(supplier, "supplier");
+    }
+
+    @Override
+    protected void subscribing(UniSerializedSubscriber<? super I> subscriber) {
+        upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<I, I>(subscriber) {
+
+            // Guard to invoke the supplier only once
+            private final AtomicBoolean invoked = new AtomicBoolean();
+
+            @Override
+            public void onSubscribe(UniSubscription subscription) {
+                subscriber.onSubscribe(new UniSubscription() {
+
+                    @Override
+                    public void cancel() {
+                        execute().subscribe().with(
+                                ignoredItem -> subscription.cancel(),
+                                ignoredException -> subscription.cancel()); // TODO avoid swallowing this exception
+                    }
+
+                    private Uni<?> execute() {
+                        if (invoked.compareAndSet(false, true)) {
+                            try {
+                                return nonNull(supplier.get(), "uni");
+                            } catch (Throwable err) {
+                                return Uni.createFrom().failure(err);
+                            }
+                        } else {
+                            return Uni.createFrom().nullItem();
+                        }
+                    }
+                });
+            }
+        });
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnCancellationInvoke.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnCancellationInvoke.java
@@ -1,0 +1,44 @@
+package io.smallrye.mutiny.operators.multi;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+public class MultiOnCancellationInvoke<T> extends AbstractMultiOperator<T, T> {
+
+    private final Runnable action;
+
+    public MultiOnCancellationInvoke(Multi<? extends T> upstream, Runnable action) {
+        super(nonNull(upstream, "upstream"));
+        this.action = nonNull(action, "action");
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super T> downstream) {
+        upstream.subscribe().withSubscriber(new MultiOnCancellationInvokeProcessor(downstream));
+    }
+
+    class MultiOnCancellationInvokeProcessor extends MultiOperatorProcessor<T, T> {
+
+        private final AtomicBoolean actionInvoked = new AtomicBoolean();
+
+        public MultiOnCancellationInvokeProcessor(MultiSubscriber<? super T> downstream) {
+            super(downstream);
+        }
+
+        @Override
+        public void cancel() {
+            if (actionInvoked.compareAndSet(false, true)) {
+                try {
+                    action.run();
+                } catch (Throwable ignored) {
+                    // TODO this exception is being swallowed
+                }
+            }
+            super.cancel();
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnCancellationInvokeUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnCancellationInvokeUni.java
@@ -1,0 +1,53 @@
+package io.smallrye.mutiny.operators.multi;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+public class MultiOnCancellationInvokeUni<T> extends AbstractMultiOperator<T, T> {
+
+    private final Supplier<Uni<?>> supplier;
+
+    public MultiOnCancellationInvokeUni(Multi<? extends T> upstream, Supplier<Uni<?>> supplier) {
+        super(nonNull(upstream, "upstream"));
+        this.supplier = nonNull(supplier, "supplier");
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super T> downstream) {
+        upstream.subscribe().withSubscriber(new MultiOnCancellationInvokeUniProcessor(downstream));
+    }
+
+    class MultiOnCancellationInvokeUniProcessor extends MultiOperatorProcessor<T, T> {
+
+        private final AtomicBoolean supplierInvoked = new AtomicBoolean();
+
+        public MultiOnCancellationInvokeUniProcessor(MultiSubscriber<? super T> downstream) {
+            super(downstream);
+        }
+
+        @Override
+        public void cancel() {
+            execute().subscribe().with(
+                    ignoredItem -> super.cancel(),
+                    ignoredFailure -> super.cancel());
+        }
+
+        private Uni<?> execute() {
+            if (supplierInvoked.compareAndSet(false, true)) {
+                try {
+                    return nonNull(supplier.get(), "uni");
+                } catch (Throwable err) {
+                    return Uni.createFrom().failure(err);
+                }
+            } else {
+                return Uni.createFrom().nullItem();
+            }
+        }
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnCancellationInvokeUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnCancellationInvokeUniTest.java
@@ -1,0 +1,121 @@
+package io.smallrye.mutiny.operators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.test.MultiAssertSubscriber;
+
+public class MultiOnCancellationInvokeUniTest {
+
+    @Test
+    public void testCancellationWithNoRequestedItem() {
+        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+
+        AtomicReference<Integer> item = new AtomicReference<>();
+        AtomicBoolean cancellation = new AtomicBoolean();
+
+        Multi.createFrom().item(1)
+                .onItem().invoke(item::set)
+                .onCancellation().invokeUni(() -> {
+                    cancellation.set(true);
+                    return Uni.createFrom().item("value");
+                })
+                .subscribe().withSubscriber(ts);
+
+        ts.cancel()
+                .assertHasNotReceivedAnyItem()
+                .assertHasNotCompleted();
+
+        assertThat(item.get()).isNull();
+        assertThat(cancellation.get()).isTrue();
+    }
+
+    @Test
+    public void testCancellationWithNoRequestedItemAndFailedUni() {
+        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+
+        AtomicReference<Integer> item = new AtomicReference<>();
+        AtomicBoolean cancellation = new AtomicBoolean();
+
+        Multi.createFrom().item(1)
+                .onItem().invoke(item::set)
+                .onCancellation().invokeUni(() -> {
+                    cancellation.set(true);
+                    return Uni.createFrom().failure(new RuntimeException("bam"));
+                })
+                .subscribe().withSubscriber(ts);
+
+        ts.cancel()
+                .assertHasNotReceivedAnyItem()
+                .assertHasNotCompleted();
+
+        assertThat(item.get()).isNull();
+        assertThat(cancellation.get()).isTrue();
+    }
+
+    @Test
+    public void testCancellationWithNoRequestedItemAndThrowingInvokeUni() {
+        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+
+        AtomicReference<Integer> item = new AtomicReference<>();
+        AtomicBoolean cancellation = new AtomicBoolean();
+
+        Multi.createFrom().item(1)
+                .onItem().invoke(item::set)
+                .onCancellation().invokeUni(() -> {
+                    cancellation.set(true);
+                    throw new RuntimeException("bam");
+                })
+                .subscribe().withSubscriber(ts);
+
+        ts.cancel()
+                .assertHasNotReceivedAnyItem()
+                .assertHasNotCompleted();
+
+        assertThat(item.get()).isNull();
+        assertThat(cancellation.get()).isTrue();
+    }
+
+    @Test
+    public void testCancellationAfterOneItem() {
+        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+
+        AtomicReference<Object> item = new AtomicReference<>();
+        AtomicBoolean cancellation = new AtomicBoolean();
+        AtomicInteger counter = new AtomicInteger();
+
+        Multi.createFrom().emitter(e -> {
+            e.emit(1);
+        })
+                .onItem().invoke(item::set)
+                .onCancellation().invokeUni(() -> {
+                    counter.incrementAndGet();
+                    cancellation.set(true);
+                    return Uni.createFrom().item("value");
+                })
+                .subscribe().withSubscriber(ts);
+
+        ts.request(10);
+
+        assertThat(item.get()).isEqualTo(1);
+        assertThat(cancellation.get()).isFalse();
+        assertThat(counter.get()).isEqualTo(0);
+
+        ts.cancel()
+                .assertHasNotCompleted()
+                .assertHasNotFailed();
+
+        assertThat(cancellation.get()).isTrue();
+        assertThat(counter.get()).isEqualTo(1);
+
+        ts.cancel();
+        assertThat(counter.get()).isEqualTo(1);
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnEventTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnEventTest.java
@@ -46,6 +46,45 @@ public class MultiOnEventTest {
                 .onTermination().invoke((f, c) -> termination.set(f == null && !c))
                 .onTermination().invoke(() -> termination2.set(true))
                 .on().request(requests::set)
+                .onCancellation().invoke(() -> cancellation.set(true))
+                .subscribe(ts);
+
+        ts
+                .request(20)
+                .assertCompletedSuccessfully()
+                .assertReceived(1);
+
+        assertThat(subscription.get()).isNotNull();
+        assertThat(item.get()).isEqualTo(1);
+        assertThat(failure.get()).isNull();
+        assertThat(completion.get()).isTrue();
+        assertThat(termination.get()).isTrue();
+        assertThat(termination2.get()).isTrue();
+        assertThat(requests.get()).isEqualTo(20);
+        assertThat(cancellation.get()).isFalse();
+    }
+
+    @Test
+    public void testCallbacksWhenItemIsEmittedWithDeprecatedOnCancellation() {
+        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+
+        AtomicReference<Subscription> subscription = new AtomicReference<>();
+        AtomicReference<Integer> item = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean completion = new AtomicBoolean();
+        AtomicLong requests = new AtomicLong();
+        AtomicBoolean termination = new AtomicBoolean();
+        AtomicBoolean termination2 = new AtomicBoolean();
+        AtomicBoolean cancellation = new AtomicBoolean();
+
+        Multi.createFrom().item(1)
+                .on().subscribed(subscription::set)
+                .on().item().invoke(item::set)
+                .on().failure().invoke(failure::set)
+                .on().completion(() -> completion.set(true))
+                .onTermination().invoke((f, c) -> termination.set(f == null && !c))
+                .onTermination().invoke(() -> termination2.set(true))
+                .on().request(requests::set)
                 .on().cancellation(() -> cancellation.set(true))
                 .subscribe(ts);
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnTerminationUniInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnTerminationUniInvokeTest.java
@@ -46,7 +46,7 @@ public class MultiOnTerminationUniInvokeTest {
                     return Uni.createFrom().item(69).invoke(uniItem::set);
                 })
                 .on().request(requests::set)
-                .on().cancellation(() -> cancellation.set(true))
+                .onCancellation().invoke(() -> cancellation.set(true))
                 .subscribe().withSubscriber(ts);
 
         ts
@@ -95,7 +95,7 @@ public class MultiOnTerminationUniInvokeTest {
                     return Uni.createFrom().item(69).invoke(uniItem::set);
                 })
                 .on().request(requests::set)
-                .on().cancellation(() -> cancellation.set(true))
+                .onCancellation().invoke(() -> cancellation.set(true))
                 .subscribe().withSubscriber(ts);
 
         ts
@@ -143,7 +143,7 @@ public class MultiOnTerminationUniInvokeTest {
                     return Uni.createFrom().failure(new IOException("bam"));
                 })
                 .on().request(requests::set)
-                .on().cancellation(() -> cancellation.set(true))
+                .onCancellation().invoke(() -> cancellation.set(true))
                 .subscribe().withSubscriber(ts);
 
         ts
@@ -190,7 +190,7 @@ public class MultiOnTerminationUniInvokeTest {
                     throw new RuntimeException("bam");
                 })
                 .on().request(requests::set)
-                .on().cancellation(() -> cancellation.set(true))
+                .onCancellation().invoke(() -> cancellation.set(true))
                 .subscribe().withSubscriber(ts);
 
         ts
@@ -237,7 +237,7 @@ public class MultiOnTerminationUniInvokeTest {
                     return Uni.createFrom().failure(new RuntimeException("tada"));
                 })
                 .on().request(requests::set)
-                .on().cancellation(() -> cancellation.set(true))
+                .onCancellation().invoke(() -> cancellation.set(true))
                 .subscribe().withSubscriber(ts);
 
         ts
@@ -290,7 +290,7 @@ public class MultiOnTerminationUniInvokeTest {
                     throw new RuntimeException("tada");
                 })
                 .on().request(requests::set)
-                .on().cancellation(() -> cancellation.set(true))
+                .onCancellation().invoke(() -> cancellation.set(true))
                 .subscribe().withSubscriber(ts);
 
         ts
@@ -344,7 +344,7 @@ public class MultiOnTerminationUniInvokeTest {
                         subCancellation.set(sb);
                     });
                 })
-                .on().cancellation(() -> cancellation.set(true))
+                .onCancellation().invoke(() -> cancellation.set(true))
                 .subscribe().withSubscriber(ts);
 
         ts.cancel()
@@ -406,7 +406,7 @@ public class MultiOnTerminationUniInvokeTest {
                                 subCancellation.set(sb);
                             });
                 })
-                .on().cancellation(() -> cancellation.set(true))
+                .onCancellation().invoke(() -> cancellation.set(true))
                 .subscribe().withSubscriber(ts);
 
         ts.request(10);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToMultiTest.java
@@ -88,7 +88,7 @@ public class UniOnItemTransformToMultiTest {
         final AtomicBoolean called = new AtomicBoolean();
 
         Uni.createFrom().<Integer> nothing()
-                .on().cancellation(() -> called.set(true))
+                .onCancellation().invoke(() -> called.set(true))
                 .onItem().transformToMulti(x -> Multi.createFrom().range(x, 10))
                 .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
 
@@ -106,7 +106,7 @@ public class UniOnItemTransformToMultiTest {
         final AtomicBoolean calledUni = new AtomicBoolean();
 
         Uni.createFrom().item(1)
-                .on().cancellation(() -> calledUni.set(true))
+                .onCancellation().invoke(() -> calledUni.set(true))
                 .onItem().transformToMulti(i -> Multi.createFrom().nothing()
                         .on().cancellation(() -> called.set(true)))
                 .subscribe().withSubscriber(MultiAssertSubscriber.create(10))

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniToMultiTest.java
@@ -111,7 +111,7 @@ public class UniToMultiTest {
     public void testWithNoEvents() {
         AtomicBoolean called = new AtomicBoolean();
         Multi<Void> multi = Uni.createFrom().<Void> nothing()
-                .on().cancellation(() -> called.set(true))
+                .onCancellation().invoke(() -> called.set(true))
                 .toMulti();
         multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1))
                 .assertNotTerminated()
@@ -123,7 +123,7 @@ public class UniToMultiTest {
     public void testWithNoEvents2() {
         AtomicBoolean called = new AtomicBoolean();
         Multi<Void> multi = Multi.createFrom().uni(Uni.createFrom().<Void> nothing()
-                .on().cancellation(() -> called.set(true)));
+                .onCancellation().invoke(() -> called.set(true)));
         multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1))
                 .assertNotTerminated()
                 .cancel()


### PR DESCRIPTION
Fix for #221 

- Move uni.on().cancellation() to uni.onCancellation()
- Move multi.on().cancellation() to multi.onCancellation()
- Documentation update for multi.onCancellation()
