### PR TITLE
Added a Caused.by unwrapper

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/Caused.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/Caused.java
@@ -1,0 +1,38 @@
+package io.smallrye.mutiny.helpers;
+
+import java.util.function.Predicate;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * An utility class that creates a predicate on a throwable. If the tested throwable is a runtime exception that has a cause, it unwraps the cause and checks if it is assignable to the cause class
+ * provided on predicate creation. It is a companion to the unchecked utilities which wrap checked exceptions into unchecked Runtime exceptions. If the tested throwable has cause, the assignment check
+ * will occur on the throwable itself. This class is not meant to be sub-classed so it is declared as final.
+ */
+public final class Caused implements Predicate<Throwable> {
+
+  private Class<? extends Throwable> cause;
+
+  private Caused(Class<? extends Throwable> cause) {
+    this.cause = cause;
+  }
+
+  /**
+   * Main entry point used to create that predicate
+   * 
+   * @param cause
+   *                the throwable type want to check
+   * @return a predicate which can be used in {@link Uni#onFailure()}
+   */
+  public static Caused by(Class<? extends Throwable> cause) {
+    if (cause == null) throw new IllegalArgumentException("You must provide a cause class");
+    return new Caused(cause);
+  }
+
+  @Override
+  public boolean test(Throwable t) {
+    if (t.getCause() == null) return cause.isAssignableFrom(t.getClass());
+    return cause.isAssignableFrom(t.getCause().getClass());
+  }
+
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/CausedTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/CausedTest.java
@@ -1,0 +1,94 @@
+package io.smallrye.mutiny.helpers;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.unchecked.Unchecked;
+
+public class CausedTest {
+
+  private static final String GENERIC = "Generic";
+  private static final String SPECIFIC = "Specific";
+
+  @Test
+  public void testWithWrappedCheckedException() {
+    assertEquals(SPECIFIC, Uni.createFrom()
+                              .item(Unchecked.supplier(this::stringSupplierThrowingIOException))
+                              .onFailure(Caused.by(IOException.class))
+                              .recoverWithItem(SPECIFIC)
+                              .onFailure()
+                              .recoverWithItem(GENERIC)
+                              .await()
+                              .indefinitely());
+  }
+
+  @Test
+  public void testWithWrappedCheckedExceptionSubclass() {
+    assertEquals(SPECIFIC, Uni.createFrom()
+                              .item(Unchecked.supplier(this::stringSupplierThrowingFileNotFoundException))
+                              .onFailure(Caused.by(IOException.class))
+                              .recoverWithItem(SPECIFIC)
+                              .onFailure()
+                              .recoverWithItem(GENERIC)
+                              .await()
+                              .indefinitely());
+  }
+
+  @Test
+  public void testWithUncheckedException() {
+    assertEquals(SPECIFIC, Uni.createFrom()
+                              .item(Unchecked.supplier(this::numberSupplierThrowingIllegalArgumentException))
+                              .onFailure(Caused.by(IllegalArgumentException.class))
+                              .recoverWithItem(SPECIFIC)
+                              .onFailure()
+                              .recoverWithItem(GENERIC)
+                              .await()
+                              .indefinitely());
+  }
+
+  @Test
+  public void testWithUncheckedExceptionSubclass() {
+    assertEquals(SPECIFIC, Uni.createFrom()
+                              .item(Unchecked.supplier(this::numberSupplierThrowingNumberFormatException))
+                              .onFailure(Caused.by(IllegalArgumentException.class))
+                              .recoverWithItem(SPECIFIC)
+                              .onFailure()
+                              .recoverWithItem(GENERIC)
+                              .await()
+                              .indefinitely());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithNullParameter() {
+    Uni.createFrom()
+       .item(Unchecked.supplier(this::numberSupplierThrowingNumberFormatException))
+       .onFailure(Caused.by(null))
+       .recoverWithItem(SPECIFIC)
+       .onFailure()
+       .recoverWithItem(GENERIC)
+       .await()
+       .indefinitely();
+  }
+
+  private String stringSupplierThrowingIOException() throws IOException {
+    throw new IOException();
+  }
+
+  private String stringSupplierThrowingFileNotFoundException() throws FileNotFoundException {
+    throw new FileNotFoundException();
+  }
+
+  private String numberSupplierThrowingIllegalArgumentException() {
+    throw new IllegalArgumentException();
+  }
+
+  private String numberSupplierThrowingNumberFormatException() {
+    throw new NumberFormatException();
+  }
+
+}


### PR DESCRIPTION
Hello,

I submit this add-on cause I needed it in a project.

I created a Caused class which can be used to fluently unwrap checked exception previously wrapped by Unchecked utilities.

I did it that way so it does not change the onFailure paradigm.

Julien