### PR TITLE
UniCache enhanced with validity predicate

### DIFF
--- a/documentation/src/main/docs/faq.adoc
+++ b/documentation/src/main/docs/faq.adoc
@@ -729,6 +729,31 @@ You can implement this behavior as follows:
 include::../../../src/test/java/snippets/DelayTest.java[tags=delay-multi-random]
 ----
 
+== How do I _cache_ events of a Uni?
+
+You can cache the events (item or failure) that are emitted by a `Uni`:
+
+[source,java,indent=0]
+----
+include::../../../src/test/java/snippets/CacheTest.java[tags=indefinitely]
+----
+
+Using `.cacheEvents().indefinitely()` will also cache failures, it simply holds the first event emitted by the upstream.
+
+For fine grain control whether events should be cached you can pass a predicate that is evaluated on each subscription:
+
+[source,java,indent=0]
+----
+include::../../../src/test/java/snippets/CacheTest.java[tags=whilst]
+----
+
+Further options are:
+
+[source,java,indent=0]
+----
+include::../../../src/test/java/snippets/CacheTest.java[tags=others]
+----
+
 == Where do I find the JavaDoc?
 
 The JavaDoc is published https://smallrye.io/smallrye-mutiny/apidocs/[there].

--- a/documentation/src/test/java/snippets/CacheTest.java
+++ b/documentation/src/test/java/snippets/CacheTest.java
@@ -1,0 +1,55 @@
+package snippets;
+
+import io.smallrye.mutiny.Uni;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CacheTest {
+
+    @Test
+    public void indefinitely() {
+        // tag::indefinitely[]
+        AtomicInteger source = new AtomicInteger(0);
+        Uni<Integer> uni = Uni.createFrom().item(source::getAndIncrement);
+        // On first subscription to this `cachedUni` the item or failure will be computed from `uni`
+        Uni<Integer> cachedUni = uni.cacheEvents().indefinitely();
+        cachedUni.subscribe().with(System.out::println); // prints '0'
+        // further subscriptions will not cause re-subscription to the upstream `uni` but retrieve the cached item
+        cachedUni.subscribe().with(System.out::println); // prints again '0'
+        // end::indefinitely[]
+        assertThat(cachedUni.await().indefinitely()).isEqualTo(0);
+    }
+
+    @Test
+    public void whilst() {
+        // tag::whilst[]
+        Uni<Instant> uni = Uni.createFrom().item(Instant::now);
+        // After the item was retrieved from `uni` the `cachedUni` will emit the cached events until the predicate fails.
+        // As soon as an event does not pass the predicate, the `cachedUni` will re-subscribe to the upstream for computation of a new event.
+        Uni<Instant> cachedUni = uni.cacheEvents().whilst((item, failure) -> item.isAfter(Instant.now().minus(Duration.ofSeconds(10))));
+        cachedUni.subscribe().with(System.out::println); // prints '2020-08-05T23:42:05.1337Z'
+        cachedUni.subscribe().with(System.out::println); // prints again '2020-08-05T23:42:05.1337Z'
+        // end::whilst[]
+        assertThat(cachedUni.await().indefinitely()).isEqualTo(cachedUni.await().indefinitely());
+    }
+
+    @Test
+    public void others() {
+        Uni<Integer> uni = Uni.createFrom().item(0);
+        // tag::others[]
+        // Just an item will be cached (indefinitely), a failure will cause a re-subscription on next subscriber to the `cachedItemUni`.
+        Uni<Integer> cachedItemUni = uni.cacheEvents().itemOnly();
+
+        // A cached item will be invalidated the given duration after it was retrieved. Failures always cause a re-subscription to the upstream.
+        Uni<Integer> durationCacheUni = uni.cacheEvents().atMost(Duration.ofSeconds(30));
+        // end::others[]
+        assertThat(cachedItemUni.await().indefinitely()).isEqualTo(0);
+        assertThat(durationCacheUni.await().indefinitely()).isEqualTo(0);
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
@@ -107,8 +107,8 @@ public abstract class AbstractUni<T> implements Uni<T> {
     }
 
     @Override
-    public Uni<T> cache() {
-        return Infrastructure.onUniCreation(new UniCache<>(this));
+    public UniCacheEvents<T> cacheEvents() {
+        return new UniCacheEvents<>(this);
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCache.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCache.java
@@ -5,6 +5,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiPredicate;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniSubscriber;
@@ -18,12 +19,14 @@ public class UniCache<I> extends UniOperator<I, I> implements UniSubscriber<I> {
     private static final int COMPLETED = 3;
     private final AtomicReference<UniSubscription> subscription = new AtomicReference<>();
     private final List<UniSubscriber<? super I>> subscribers = new ArrayList<>();
-    private int state = 0;
+    private final BiPredicate<I, Throwable> validator;
+    private int state = NOT_INITIALIZED;
     private I item;
     private Throwable failure;
 
-    UniCache(Uni<? extends I> upstream) {
+    UniCache(Uni<? extends I> upstream, BiPredicate<I, Throwable> validator) {
         super(nonNull(upstream, "upstream"));
+        this.validator = nonNull(validator, "validator");
     }
 
     @Override
@@ -48,12 +51,7 @@ public class UniCache<I> extends UniOperator<I, I> implements UniSubscriber<I> {
                     break;
                 case COMPLETED:
                     // Result already computed
-                    subscribers.add(subscriber);
-                    action = () -> {
-                        // We must first pass a subscription
-                        subscriber.onSubscribe(() -> onCancellation(subscriber));
-                        replay(subscriber);
-                    };
+                    action = handleCompleted(subscriber);
                     break;
                 default:
                     throw new IllegalStateException("Unknown state: " + state);
@@ -70,18 +68,50 @@ public class UniCache<I> extends UniOperator<I, I> implements UniSubscriber<I> {
         subscribers.remove(subscriber);
     }
 
-    private void replay(UniSubscriber<? super I> subscriber) {
-        synchronized (this) {
-            if (state != COMPLETED) {
-                throw new IllegalStateException(
-                        "Invalid state - expected being in the DONE state, but is in state: " + state);
+    /**
+     * Handling a new subscriber this UniCache is already {@link #COMPLETED}.
+     * Verifies the cached result against the {@link #validator} and
+     * either replays the cached result or renews our own subscription
+     * to restart the cache lifecycle.
+     *
+     * @param subscriber the newly subscribed {@link UniSubscriber}
+     * @return the {@link Runnable} to be executed afterwards
+     */
+    private Runnable handleCompleted(UniSubscriber<? super I> subscriber) {
+        // Closure of item and failure for validity checking and replaying the same objects
+        I item = this.item;
+        Throwable failure = this.failure;
+
+        return () -> {
+            if (validator.test(item, failure)) {
+                // We must first pass a subscription
+                subscriber.onSubscribe(() -> onCancellation(subscriber));
+                // replay the item for that subscriber
+                if (failure != null) {
+                    subscriber.onFailure(failure);
+                } else {
+                    subscriber.onItem(item);
+                }
+            } else {
+                // Items isn't valid any more
+                // Our own subscription has to be renewed if not already in process.
+                boolean resubscribe = false;
+                synchronized (this) {
+                    subscribers.add(subscriber);
+                    // other subscriptions may be raced into this branch too and triggered re-subscription before
+                    if (state == COMPLETED) {
+                        state = SUBSCRIBING;
+                        subscription.set(null);
+                        this.item = null;
+                        this.failure = null;
+                        resubscribe = true;
+                    }
+                }
+                if (resubscribe) {
+                    AbstractUni.subscribe(upstream(), this);
+                }
             }
-        }
-        if (failure != null) {
-            subscriber.onFailure(failure);
-        } else {
-            subscriber.onItem(item);
-        }
+        };
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCacheEvents.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCacheEvents.java
@@ -1,0 +1,81 @@
+package io.smallrye.mutiny.operators;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.time.Duration;
+import java.util.function.BiPredicate;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+/**
+ * {@link Uni}-API group for {@link UniCache} configuration
+ */
+public class UniCacheEvents<T> {
+
+    @SuppressWarnings("rawtypes")
+    private static final BiPredicate INDEFINITELY_VALIDATOR = (item, failure) -> true;
+
+    @SuppressWarnings("rawtypes")
+    private static final BiPredicate ITEM_ONLY_VALIDATOR = (item, failure) -> item != null;
+
+    private final Uni<T> upstream;
+
+    public UniCacheEvents(Uni<T> upstream) {
+        this.upstream = nonNull(upstream, "upstream");
+    }
+
+    /**
+     * Caches the events (item or failure) of this {@link Uni} and replays it for all further
+     * {@link io.smallrye.mutiny.subscription.UniSubscriber}.
+     *
+     * @return the new {@link Uni}. Unlike regular {@link Uni}, re-subscribing to this {@link Uni} does not re-compute
+     *         the outcome but replayed the cached events until the end of time.
+     */
+    public Uni<T> indefinitely() {
+        return whilst(INDEFINITELY_VALIDATOR);
+    }
+
+    /**
+     * Caches the events (item or failure) of this {@link Uni} as long as the validator assures them validity.
+     * <p>
+     * <b>Remark: the {@link BiPredicate} must not have any side-effects since it blocks subscriptions to the cached Uni</b>
+     *
+     * @param validator A {@link BiPredicate} consuming the item as well as the failure to check the cache validity.
+     * @return the new {@link Uni}. Unlike regular {@link Uni}, re-subscribing to this {@link Uni} does re-compute
+     *         the outcome only after the validator {@link BiPredicate} does not succeed, otherwise the cached events are
+     *         replayed.
+     */
+    public Uni<T> whilst(BiPredicate<T, Throwable> validator) {
+        return Infrastructure.onUniCreation(new UniCache<>(upstream, validator));
+    }
+
+    /**
+     * Caches an item retrieved by this {@link Uni} indefinitely and re-subscribe to the upstream on failure.
+     * <p>
+     * Please note, that all subscriptions may retrieve a failure until an item was successful computed by the upstream.
+     * As soon as there is an item present, it is replayed to all subsequent subscribers.
+     *
+     * @return the new {@link Uni}. Unlike regular {@link Uni}, re-subscribing to this {@link Uni} does re-compute items,
+     *         but will re-compute failures on subsequent subscriptions.
+     */
+    public Uni<T> itemOnly() {
+        return whilst(ITEM_ONLY_VALIDATOR);
+    }
+
+    /**
+     * Caches an item retrieved by this {@link Uni} for a given validity duration.
+     * Duration period starts at time a item is retrieved from the upstream, failures will not be cached but a
+     * re-subscription to the upstream will be executed on next subscription after a failure was propagated.
+     * <p>
+     * The first subscription to the cached {@link Uni} after the duration is exceeded will cause a re-subscription
+     * (with the potential to failure as is at the first subscription).
+     *
+     * @param validity a duration how long a computed item should be cached until re-computation.
+     * @return the new {@link Uni}. Unlike regular {@link Uni}, re-subscribing to this {@link Uni} does only re-compute items
+     *         if the last received item from the upstream is older than the given validity.
+     */
+    public Uni<T> atMost(Duration validity) {
+        return Infrastructure.onUniCreation(new UniCacheNarrowed<>(upstream, validity));
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCacheNarrowed.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCacheNarrowed.java
@@ -1,0 +1,53 @@
+package io.smallrye.mutiny.operators;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.BiPredicate;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * A {@link UniCache} implementation that keeps items at most a given duration
+ * and resubscribes to the upstream after the duration has exceeded.
+ */
+public class UniCacheNarrowed<I> extends UniCache<I> {
+
+    private final UniCacheNarrowedValidator<I> validator;
+
+    public UniCacheNarrowed(Uni<? extends I> upstream, Duration validity) {
+        this(upstream, new UniCacheNarrowedValidator<>(validity));
+    }
+
+    private UniCacheNarrowed(Uni<? extends I> upstream, UniCacheNarrowedValidator<I> validator) {
+        super(upstream, validator);
+        this.validator = validator;
+    }
+
+    @Override
+    public void onItem(I item) {
+        super.onItem(item);
+        validator.refreshEventTime();
+    }
+}
+
+/**
+ * {@link UniCache} validator implementation for event age related validation.
+ */
+class UniCacheNarrowedValidator<I> implements BiPredicate<I, Throwable> {
+
+    private final Duration validity;
+    private Instant cacheExpiration = Instant.MIN;
+
+    UniCacheNarrowedValidator(Duration validity) {
+        this.validity = validity;
+    }
+
+    synchronized void refreshEventTime() {
+        this.cacheExpiration = Instant.now().plus(validity);
+    }
+
+    @Override
+    public synchronized boolean test(I i, Throwable throwable) {
+        return Instant.now().isBefore(cacheExpiration);
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCacheTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCacheTest.java
@@ -1,15 +1,27 @@
 package io.smallrye.mutiny.operators;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.testng.annotations.Test;
 
@@ -69,9 +81,14 @@ public class UniCacheTest {
         }
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "`upstream`.*")
     public void testThatSourceCannotBeNull() {
-        new UniCache<>(null);
+        new UniCache<>(null, (i, t) -> true);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "`validator`.*")
+    public void testThatValidatorCannotBeNull() {
+        new UniCache<>(Uni.createFrom().item(0), null);
     }
 
     @Test
@@ -93,6 +110,44 @@ public class UniCacheTest {
     }
 
     @Test
+    public void testThatImmediateCachedValuesCanBeRecomputed() {
+        AtomicInteger itemValidationCount = new AtomicInteger(0);
+        AtomicBoolean isCacheValid = new AtomicBoolean(true);
+        BiPredicate<Integer, Throwable> validator = (i, t) -> {
+            itemValidationCount.incrementAndGet();
+            return isCacheValid.get();
+        };
+        AtomicInteger counter = new AtomicInteger();
+        Uni<Integer> cache = Uni.createFrom().item(counter.incrementAndGet())
+                .cacheEvents().whilst(validator);
+
+        UniAssertSubscriber<Integer> sub1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> sub2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> sub3 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> sub4 = UniAssertSubscriber.create();
+
+        // initial value from upstream
+        cache.subscribe().withSubscriber(sub1);
+        // cached value
+        cache.subscribe().withSubscriber(sub2);
+
+        isCacheValid.set(false);
+        // recomputed value
+        cache.subscribe().withSubscriber(sub3);
+
+        isCacheValid.set(true);
+        cache.subscribe().withSubscriber(sub4);
+        // item validation count is (subscription count minus upstream subscription count) since only cached items gets validated
+        // the initially retrieved from upstream is always accepted
+        assertThat(itemValidationCount.get()).isEqualTo(3);
+
+        sub1.assertCompletedSuccessfully().assertItem(1);
+        sub2.assertCompletedSuccessfully().assertItem(1);
+        sub3.assertCompletedSuccessfully().assertItem(1);
+        sub4.assertCompletedSuccessfully().assertItem(1);
+    }
+
+    @Test
     public void testThatIFailureAreCached() {
         AtomicInteger counter = new AtomicInteger();
         Uni<Object> cache = Uni.createFrom().failure(new Exception("" + counter.getAndIncrement())).cache();
@@ -108,6 +163,44 @@ public class UniCacheTest {
         sub1.assertFailure(Exception.class, "0");
         sub2.assertFailure(Exception.class, "0");
         sub3.assertFailure(Exception.class, "0");
+    }
+
+    @Test
+    public void testThatCachedIFailureCanBeRecomputed() {
+        AtomicInteger itemValidationCount = new AtomicInteger(0);
+        AtomicBoolean isCacheValid = new AtomicBoolean(true);
+        BiPredicate<Object, Throwable> validator = (i, t) -> {
+            itemValidationCount.incrementAndGet();
+            return isCacheValid.get();
+        };
+        AtomicInteger counter = new AtomicInteger();
+        Uni<Object> cache = Uni.createFrom().failure(new Exception("" + counter.getAndIncrement()))
+                .cacheEvents().whilst(validator);
+
+        UniAssertSubscriber<Object> sub1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Object> sub2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Object> sub3 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Object> sub4 = UniAssertSubscriber.create();
+
+        // initial value from upstream
+        cache.subscribe().withSubscriber(sub1);
+        // cached value
+        cache.subscribe().withSubscriber(sub2);
+
+        isCacheValid.set(false);
+        // recomputed value
+        cache.subscribe().withSubscriber(sub3);
+
+        isCacheValid.set(true);
+        cache.subscribe().withSubscriber(sub4);
+        // item validation count is (subscription count minus upstream subscription count) since only cached items gets validated
+        // the initially retrieved from upstream is always accepted
+        assertThat(itemValidationCount.get()).isEqualTo(3);
+
+        sub1.assertFailure(Exception.class, "0");
+        sub2.assertFailure(Exception.class, "0");
+        sub3.assertFailure(Exception.class, "0");
+        sub4.assertFailure(Exception.class, "0");
     }
 
     @Test
@@ -271,6 +364,154 @@ public class UniCacheTest {
         test.assertCompletedSuccessfully().assertItem(23);
 
         uni.subscribe().withSubscriber(subscriber);
+    }
+
+    @Test
+    public void testThatCacheInvalidationCausesResubscriptionAndCannotRace() {
+        AtomicInteger cacheValidationCount = new AtomicInteger(0);
+        BiPredicate<Integer, Throwable> validator = (i, f) -> cacheValidationCount.incrementAndGet() % 2 == 0;
+        AtomicInteger sourceSubscriptionCount = new AtomicInteger(0);
+        Uni<Integer> uni = Uni.createFrom().deferred(() -> Uni.createFrom().item(sourceSubscriptionCount.getAndIncrement()))
+                .cacheEvents().whilst(validator);
+
+        // Every second subscription causes a re-subscription to the upstream
+        // This must not cause race conditions
+        List<UniAssertSubscriber<Integer>> results = Collections.synchronizedList(new LinkedList<>());
+        Executor parallel = Executors.newFixedThreadPool(2);
+        for (int i = 0; i < 2000; i++) {
+            Runnable subscribe = () -> {
+                UniAssertSubscriber<Integer> subscriber = new UniAssertSubscriber<>(false);
+                uni.subscribe().withSubscriber(subscriber);
+                results.add(subscriber);
+            };
+            race(subscribe, subscribe, parallel);
+        }
+
+        Uni.createFrom().item(0).onItem().delayIt().by(Duration.ofMillis(500)).await().indefinitely();
+
+        // there are two subscriptions in each of the 2000 loop iterations
+        // every second of them the cache is invalidated an the UniCaches subscription renewed
+        assertThat(sourceSubscriptionCount.get()).isEqualTo(2001);
+        // cache validation count is (subscription count (2x2000) - 1) since the initial subscription will not be validated
+        assertThat(cacheValidationCount.get()).isEqualTo(3999);
+        // every subscriber should have received an item
+        results.forEach(UniAssertSubscriber::assertCompletedSuccessfully);
+        // every item should be retrieved by at least one subscriber
+        Map<Integer, List<Integer>> groupResults = results.stream().map(UniAssertSubscriber::getItem)
+                .collect(Collectors.groupingBy(Function.identity()));
+        assertThat(groupResults).hasSize(2001);
+        Set<Integer> distinctItems = new HashSet<>(groupResults.keySet());
+        assertThat(distinctItems).hasSize(2001);
+        assertThat(distinctItems)
+                .containsExactlyInAnyOrderElementsOf(IntStream.rangeClosed(0, 2000).boxed().collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testThatItemOnlyValidatorResubscribesOnFailure() {
+        AtomicInteger subscriptionCount = new AtomicInteger(0);
+        AtomicBoolean produceFailure = new AtomicBoolean(true);
+        Uni uni = Uni.createFrom().deferred(() -> {
+            if (produceFailure.getAndSet(false)) {
+                return Uni.createFrom().failure(new Exception("" + subscriptionCount.getAndIncrement()));
+            } else {
+                return Uni.createFrom().item(subscriptionCount.getAndIncrement());
+            }
+        }).cacheEvents().itemOnly();
+
+        UniAssertSubscriber<Integer> sub1 = new UniAssertSubscriber<>();
+        UniAssertSubscriber<Integer> sub2 = new UniAssertSubscriber<>();
+        UniAssertSubscriber<Integer> sub3 = new UniAssertSubscriber<>();
+
+        uni.subscribe().withSubscriber(sub1);
+        uni.subscribe().withSubscriber(sub2);
+        uni.subscribe().withSubscriber(sub3);
+
+        assertThat(subscriptionCount.get()).isEqualTo(2);
+        sub1.assertFailure(Exception.class, "0");
+        sub2.assertItem(1);
+        sub3.assertItem(1);
+    }
+
+    @Test
+    public void testThatItemIsRenewedAfterCacheDurationExceeded() {
+        AtomicInteger subscriptionCount = new AtomicInteger(0);
+        Uni uni = Uni.createFrom().deferred(() -> Uni.createFrom().item(subscriptionCount.getAndIncrement()))
+                .cacheEvents().atMost(Duration.ofMillis(100));
+
+        UniAssertSubscriber<Integer> sub1 = new UniAssertSubscriber<>();
+        UniAssertSubscriber<Integer> sub2 = new UniAssertSubscriber<>();
+        UniAssertSubscriber<Integer> sub3 = new UniAssertSubscriber<>();
+        UniAssertSubscriber<Integer> sub4 = new UniAssertSubscriber<>();
+
+        uni.subscribe().withSubscriber(sub1);
+        uni.subscribe().withSubscriber(sub2);
+
+        Uni.createFrom().item(0).onItem().delayIt().by(Duration.ofMillis(100)).await().indefinitely();
+
+        uni.subscribe().withSubscriber(sub3);
+        uni.subscribe().withSubscriber(sub4);
+
+        assertThat(subscriptionCount.get()).isEqualTo(2);
+        sub1.assertItem(0);
+        sub2.assertItem(0);
+        sub3.assertItem(1);
+        sub3.assertItem(1);
+    }
+
+    @Test
+    public void testThatFailureIsRenewedEvenBeforeCacheDurationExceeded() {
+        AtomicInteger subscriptionCount = new AtomicInteger(0);
+        Uni uni = Uni.createFrom()
+                .deferred(() -> Uni.createFrom().failure(new Exception("" + subscriptionCount.getAndIncrement())))
+                .cacheEvents().atMost(Duration.ofMinutes(1));
+
+        UniAssertSubscriber<Integer> sub1 = new UniAssertSubscriber<>();
+        UniAssertSubscriber<Integer> sub2 = new UniAssertSubscriber<>();
+        UniAssertSubscriber<Integer> sub3 = new UniAssertSubscriber<>();
+        UniAssertSubscriber<Integer> sub4 = new UniAssertSubscriber<>();
+
+        uni.subscribe().withSubscriber(sub1);
+        uni.subscribe().withSubscriber(sub2);
+        uni.subscribe().withSubscriber(sub3);
+        uni.subscribe().withSubscriber(sub4);
+
+        assertThat(subscriptionCount.get()).isEqualTo(4);
+        sub1.assertFailure(Exception.class, "0");
+        sub2.assertFailure(Exception.class, "1");
+        sub3.assertFailure(Exception.class, "2");
+        sub4.assertFailure(Exception.class, "3");
+    }
+
+    @Test
+    /*
+        TODO: This test is flaky: sometimes it ran into:
+        `java.lang.AssertionError: The uni didn't completed successfully: java.lang.IllegalStateException: Invalid transition, expected to be in the HAS_SUBSCRIPTION state but was in [1|2]`
+     */
+    public void testThatOnlyInvalidCacheEventsDoesNotRace() {
+        AtomicInteger cacheValidationCount = new AtomicInteger(0);
+        // events are always invalid, every test causes a resubscribe to upstream, since `onItem` is propagated to UniCache subscripte
+        BiPredicate<Integer, Throwable> validator = (i, f) -> false;
+        // multiple subscriptions may (and will) retrieve a single item from upstream after invalidation, so we cannot verify upstream subscription count
+        Uni<Integer> uni = Uni.createFrom().deferred(() -> Uni.createFrom().item(0))
+                .cacheEvents().whilst(validator);
+
+        // Every second subscription causes a re-subscription to the upstream
+        // This must not cause race conditions
+        List<UniAssertSubscriber<Integer>> results = Collections.synchronizedList(new LinkedList<>());
+        Executor parallel = Executors.newFixedThreadPool(10);
+        Runnable subscribe = () -> {
+            UniAssertSubscriber<Integer> subscriber = new UniAssertSubscriber<>(false);
+            uni.subscribe().withSubscriber(subscriber);
+            results.add(subscriber);
+        };
+        for (int i = 0; i < 1000; i++) {
+            parallel.execute(subscribe);
+        }
+
+        Uni.createFrom().item(0).onItem().delayIt().by(Duration.ofMillis(500)).await().indefinitely();
+
+        assertThat(results).hasSize(1000);
+        results.forEach(UniAssertSubscriber::assertCompletedSuccessfully);
     }
 
 }


### PR DESCRIPTION
As proposed with https://github.com/smallrye/smallrye-mutiny/issues/231 a UniCacheItemOrFailure was introduced for
more fine grain cache configuration inititally with just a predicate for
validating whether cached item or failure is still valid. Once the cache
gets invalid, the UniCache's own subscription is renewed for receiving a
fresh value.