### PR TITLE
Check for null subscriber in Context Propagation Multi interceptor

### DIFF
--- a/context-propagation/pom.xml
+++ b/context-propagation/pom.xml
@@ -44,6 +44,33 @@
         </dependency>
 
 
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+            <version>${reactive-streams.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <junitArtifactName>none:none</junitArtifactName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/context-propagation/pom.xml
+++ b/context-propagation/pom.xml
@@ -42,6 +42,8 @@
             <artifactId>smallrye-config</artifactId>
             <scope>test</scope>
         </dependency>
+
+
     </dependencies>
-    
+
 </project>

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/MultiContextPropagationTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/MultiContextPropagationTest.java
@@ -22,7 +22,7 @@ import io.smallrye.mutiny.test.MultiAssertSubscriber;
 
 public class MultiContextPropagationTest {
 
-    private ExecutorService executor = Executors.newFixedThreadPool(4);
+    private final ExecutorService executor = Executors.newFixedThreadPool(4);
 
     @BeforeMethod
     public void initContext() {

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationMultiTckTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationMultiTckTest.java
@@ -1,0 +1,42 @@
+package io.smallrye.mutiny.context.tck;
+
+import java.util.stream.LongStream;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.Assert;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.context.ContextPropagationMultiInterceptor;
+
+/**
+ * Reactive Streams TCK for io.smallrye.mutiny.context.ContextPropagationMultiInterceptor.ContextPropagationMulti.
+ */
+public class ContextPropagationMultiTckTest extends PublisherVerification<Long> {
+
+    private final ContextPropagationMultiInterceptor interceptor;
+
+    public ContextPropagationMultiTckTest() {
+        super(new TestEnvironment(100));
+        interceptor = new ContextPropagationMultiInterceptor();
+    }
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        Multi<Long> items = Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed());
+        items = interceptor.onMultiCreation(items);
+        Assert.assertEquals(items.getClass().getName(),
+                "io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$ContextPropagationMulti");
+        return items;
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        Multi<Long> failed = Multi.createFrom().failure(new RuntimeException("failed"));
+        failed = interceptor.onMultiCreation(failed);
+        Assert.assertEquals(failed.getClass().getName(),
+                "io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$ContextPropagationMulti");
+        return failed;
+    }
+}

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationSubscriberTckTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationSubscriberTckTest.java
@@ -1,0 +1,71 @@
+package io.smallrye.mutiny.context.tck;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+
+import io.smallrye.mutiny.context.ContextPropagationMultiInterceptor;
+
+public class ContextPropagationSubscriberTckTest extends SubscriberWhiteboxVerification<Long> {
+
+    private final ContextPropagationMultiInterceptor interceptor;
+
+    protected ContextPropagationSubscriberTckTest() {
+        super(new TestEnvironment(100));
+        interceptor = new ContextPropagationMultiInterceptor();
+    }
+
+    @Override
+    public Long createElement(int i) {
+        return (long) i;
+    }
+
+    @SuppressWarnings({ "unchecked", "ReactiveStreamsSubscriberImplementation" })
+    @Override
+    public Subscriber<Long> createSubscriber(WhiteboxSubscriberProbe<Long> probe) {
+        return (Subscriber<Long>) interceptor.onSubscription(null, new Subscriber<Long>() {
+
+            private final AtomicReference<Subscription> upstream = new AtomicReference<>();
+
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                // While the TCK expect a single subscriber, it's not necessary the case (broadcast for instance)
+                // So cancel the second subscription here.
+                if (upstream.compareAndSet(null, subscription)) {
+                    subscription.request(1);
+                    probe.registerOnSubscribe(new SubscriberPuppet() {
+                        @Override
+                        public void triggerRequest(long elements) {
+                            subscription.request(elements);
+                        }
+
+                        @Override
+                        public void signalCancel() {
+                            subscription.cancel();
+                        }
+                    });
+                } else {
+                    subscription.cancel();
+                }
+            }
+
+            @Override
+            public void onNext(Long item) {
+                probe.registerOnNext(item);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                probe.registerOnError(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                probe.registerOnComplete();
+            }
+        });
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
@@ -235,7 +235,7 @@ public class MultiCreate {
      */
     public <T> Multi<T> items(Supplier<? extends Stream<? extends T>> supplier) {
         Supplier<? extends Stream<? extends T>> actual = nonNull(supplier, "supplier");
-        return new StreamBasedMulti<>(actual);
+        return Infrastructure.onMultiCreation(new StreamBasedMulti<>(actual));
     }
 
     /**

--- a/reactive-streams-operators/pom.xml
+++ b/reactive-streams-operators/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -34,6 +35,23 @@
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny-test-utils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny-context-propagation</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-context-propagation</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/reactive-streams-operators/pom.xml
+++ b/reactive-streams-operators/pom.xml
@@ -36,23 +36,6 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny-test-utils</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>mutiny-context-propagation</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-context-propagation</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.config</groupId>
-            <artifactId>smallrye-config</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -114,6 +97,33 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>tck-with-context-propagation</id>
+            <activation>
+                <property>
+                    <name>!disable.tck-with-cp</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.smallrye.reactive</groupId>
+                    <artifactId>mutiny-context-propagation</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.smallrye</groupId>
+                    <artifactId>smallrye-context-propagation</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.smallrye.config</groupId>
+                    <artifactId>smallrye-config</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 


### PR DESCRIPTION
Check for null subscribers in the context propagation implementation of AbstractMulti as mandated by the reactive streams spec.
Also, reduce the number of allocation and delegation as we just need to invoke the `subscribe` method.
