### PR TITLE
Improve internal test utilities

### DIFF
--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/MultiContextPropagationTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/MultiContextPropagationTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiContextPropagationTest {
 
@@ -175,14 +175,14 @@ public class MultiContextPropagationTest {
             return r;
         }).broadcast().toAllSubscribers();
 
-        MultiAssertSubscriber<Integer> sub1 = multi
+        AssertSubscriber<Integer> sub1 = multi
                 .map(i -> {
                     assertThat(ctx).isEqualTo(MyContext.get());
                     return i;
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
-        MultiAssertSubscriber<Integer> sub2 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+        AssertSubscriber<Integer> sub2 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         sub1.await().assertCompletedSuccessfully().assertReceived(2, 3);
         sub2.await().assertCompletedSuccessfully().assertReceived(2, 3);

--- a/documentation/src/test/java/snippets/BroadcastProcessorTest.java
+++ b/documentation/src/test/java/snippets/BroadcastProcessorTest.java
@@ -2,7 +2,7 @@ package snippets;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 import org.junit.Test;
 
 public class BroadcastProcessorTest {
@@ -28,7 +28,7 @@ public class BroadcastProcessorTest {
         // the subscriber receives this signal.
 
         // end::code[]
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create(Long.MAX_VALUE);
+        AssertSubscriber<String> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
         multi.subscribe().withSubscriber(subscriber)
                 .await()
                 .assertCompletedSuccessfully();

--- a/documentation/src/test/java/snippets/PaginationTest.java
+++ b/documentation/src/test/java/snippets/PaginationTest.java
@@ -2,7 +2,7 @@ package snippets;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -12,8 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +31,7 @@ public class PaginationTest {
                 .until(list -> list.isEmpty())
                 .onItem().disjoint();
         // end::code[]
-        stream.subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+        stream.subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived("a", "b", "c", "d", "e", "f", "g", "h");
 
@@ -51,8 +49,8 @@ public class PaginationTest {
                         state -> api.retrieve(state.getAndIncrement()))
                 .whilst(page -> page.hasNext());
         // end::code2[]
-        MultiAssertSubscriber<Page> subscriber = stream.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10))
+        AssertSubscriber<Page> subscriber = stream.subscribe()
+                .withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully();
 
         assertThat(subscriber.items()).hasSize(3);

--- a/documentation/src/test/java/snippets/UnicastProcessorTest.java
+++ b/documentation/src/test/java/snippets/UnicastProcessorTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class UnicastProcessorTest {
 
@@ -27,7 +27,7 @@ public class UnicastProcessorTest {
         }).start();
 
         // end::code[]
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create(Long.MAX_VALUE);
+        AssertSubscriber<String> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
         multi.subscribe().withSubscriber(subscriber)
                 .await()
                 .run(() -> assertThat(subscriber.items()).hasSize(1000));

--- a/implementation/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
@@ -6,7 +6,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.converters.multi.BuiltinConverters;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiConvertFromTest {
 
@@ -14,10 +14,10 @@ public class MultiConvertFromTest {
     public void testCreatingFromCompletionStageWithValue() {
         CompletableFuture<Integer> valued = CompletableFuture.completedFuture(1);
 
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .completionStage(valued)
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertReceived(1);
     }
@@ -26,10 +26,10 @@ public class MultiConvertFromTest {
     public void testCreatingFromCompletionStageWithEmpty() {
         CompletableFuture<Void> empty = CompletableFuture.completedFuture(null);
 
-        MultiAssertSubscriber<Void> subscriber = Multi.createFrom()
+        AssertSubscriber<Void> subscriber = Multi.createFrom()
                 .converter(BuiltinConverters.fromCompletionStage(), empty)
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         Multi.createFrom().completionStage(empty);
 
@@ -41,10 +41,10 @@ public class MultiConvertFromTest {
         CompletableFuture<Void> boom = new CompletableFuture<>();
         boom.completeExceptionally(new Exception("boom"));
 
-        MultiAssertSubscriber<Void> subscriber = Multi.createFrom()
+        AssertSubscriber<Void> subscriber = Multi.createFrom()
                 .converter(BuiltinConverters.fromCompletionStage(), boom)
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(Exception.class, "boom");
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiBroadcastTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiBroadcastTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.MultiEmitterProcessor;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiBroadcastTest {
 
@@ -21,13 +21,13 @@ public class MultiBroadcastTest {
 
         Multi<Integer> multi = processor.toMulti().broadcast().toAllSubscribers();
 
-        MultiAssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         s1.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(1).emit(2).emit(3);
         s1.assertReceived(1, 2, 3).assertNotTerminated();
 
-        MultiAssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(AssertSubscriber.create(1));
         s2.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(4).emit(5);
@@ -53,13 +53,13 @@ public class MultiBroadcastTest {
 
         Multi<Integer> multi = processor.toMulti().broadcast().toAllSubscribers();
 
-        MultiAssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         s1.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(1).emit(2).emit(3);
         s1.assertReceived(1, 2, 3).assertNotTerminated();
 
-        MultiAssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(AssertSubscriber.create(1));
         s2.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(4).emit(5);
@@ -79,13 +79,13 @@ public class MultiBroadcastTest {
 
         Multi<Integer> multi = processor.toMulti().broadcast().toAllSubscribers();
 
-        MultiAssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         s1.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(1).emit(2).emit(3);
         s1.assertReceived(1, 2, 3).assertNotTerminated();
 
-        MultiAssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(AssertSubscriber.create(1));
         s2.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(4).emit(5);
@@ -112,13 +112,13 @@ public class MultiBroadcastTest {
 
         Multi<Integer> multi = processor.toMulti().broadcast().toAllSubscribers();
 
-        MultiAssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         s1.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(1).emit(2).emit(3);
         s1.assertReceived(1, 2, 3).assertNotTerminated();
 
-        MultiAssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(AssertSubscriber.create(1));
         s2.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(4).emit(5);
@@ -130,7 +130,7 @@ public class MultiBroadcastTest {
         s1.cancel();
         assertThat(cancelled).isFalse();
         assertThat(processor.isCancelled()).isFalse();
-        MultiAssertSubscriber<Integer> s3 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s3 = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         processor.emit(23);
         processor.complete();
         s3.assertReceived(23).assertCompletedSuccessfully();
@@ -142,15 +142,15 @@ public class MultiBroadcastTest {
         processor.emit(1).emit(2).emit(3);
         processor.complete();
 
-        processor.toMulti().broadcast().toAllSubscribers().subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+        processor.toMulti().broadcast().toAllSubscribers().subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertReceived(1, 2, 3)
                 .assertCompletedSuccessfully();
     }
 
     @Test
     public void testPublishAtLeast() {
-        MultiAssertSubscriber<Integer> s1 = MultiAssertSubscriber.create(10);
-        MultiAssertSubscriber<Integer> s2 = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> s1 = AssertSubscriber.create(10);
+        AssertSubscriber<Integer> s2 = AssertSubscriber.create(10);
 
         Multi<Integer> multi = Multi.createFrom().range(1, 5).broadcast().toAtLeast(2);
 
@@ -176,13 +176,13 @@ public class MultiBroadcastTest {
         Multi<Integer> multi = processor.toMulti().broadcast().withCancellationAfterLastSubscriberDeparture()
                 .toAllSubscribers();
 
-        MultiAssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         s1.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(1).emit(2).emit(3);
         s1.assertReceived(1, 2, 3).assertNotTerminated();
 
-        MultiAssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(AssertSubscriber.create(1));
         s2.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(4).emit(5);
@@ -207,13 +207,13 @@ public class MultiBroadcastTest {
                 .withCancellationAfterLastSubscriberDeparture(Duration.ofSeconds(1))
                 .toAllSubscribers();
 
-        MultiAssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         s1.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(1).emit(2).emit(3);
         s1.assertReceived(1, 2, 3).assertNotTerminated();
 
-        MultiAssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(AssertSubscriber.create(1));
         s2.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(4).emit(5);
@@ -236,14 +236,14 @@ public class MultiBroadcastTest {
         Multi<Integer> multi = processor.toMulti().broadcast().withCancellationAfterLastSubscriberDeparture()
                 .toAtLeast(2);
 
-        MultiAssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         s1.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(1).emit(2).emit(3);
 
         s1.assertHasNotReceivedAnyItem().assertNotTerminated();
 
-        MultiAssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
 
         s1.assertReceived(1, 2, 3).assertNotTerminated();
         s2.assertReceived(1, 2, 3).assertNotTerminated();
@@ -264,14 +264,14 @@ public class MultiBroadcastTest {
                 .withCancellationAfterLastSubscriberDeparture(Duration.ofSeconds(1))
                 .toAtLeast(2);
 
-        MultiAssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         s1.assertHasNotReceivedAnyItem().assertNotTerminated();
 
         processor.emit(1).emit(2).emit(3);
 
         s1.assertHasNotReceivedAnyItem().assertNotTerminated();
 
-        MultiAssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
 
         s1.assertReceived(1, 2, 3).assertNotTerminated();
         s2.assertReceived(1, 2, 3).assertNotTerminated();

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiFlattenTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiFlattenTest.java
@@ -14,21 +14,21 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiFlattenTest {
 
     @Test
     public void testWithMultis() {
         AtomicBoolean subscribed = new AtomicBoolean();
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().items(
+        AssertSubscriber<String> subscriber = Multi.createFrom().items(
                 Multi.createFrom().items("a", "b", "c"),
                 Multi.createFrom().items("d", "e"),
                 Multi.createFrom().empty(),
                 Multi.createFrom().items("f", "g")
                         .onSubscribe().invoke(s -> subscribed.set(true)))
                 .onItem().<String> disjoint()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4));
+                .subscribe().withSubscriber(AssertSubscriber.create(4));
         assertThat(subscribed).isFalse();
         subscriber.assertReceived("a", "b", "c", "d");
         subscriber.request(3);
@@ -40,14 +40,14 @@ public class MultiFlattenTest {
     @Test
     public void testWithPublishers() {
         AtomicBoolean subscribed = new AtomicBoolean();
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().items(
+        AssertSubscriber<String> subscriber = Multi.createFrom().items(
                 Flowable.just("a", "b", "c"),
                 Flowable.just("d", "e"),
                 Flowable.empty(),
                 Flowable.just("f", "g")
                         .doOnSubscribe(s -> subscribed.set(true)))
                 .onItem().<String> disjoint()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4));
+                .subscribe().withSubscriber(AssertSubscriber.create(4));
         assertThat(subscribed).isFalse();
         subscriber.assertReceived("a", "b", "c", "d");
         subscriber.request(3);
@@ -58,13 +58,13 @@ public class MultiFlattenTest {
 
     @Test
     public void testWithArrays() {
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().items(
+        AssertSubscriber<String> subscriber = Multi.createFrom().items(
                 new String[] { "a", "b", "c" },
                 new String[] { "d", "e" },
                 new String[] {},
                 new String[] { "f", "g" })
                 .onItem().<String> disjoint()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4));
+                .subscribe().withSubscriber(AssertSubscriber.create(4));
         subscriber.assertReceived("a", "b", "c", "d");
         subscriber.request(3);
         subscriber.assertCompletedSuccessfully();
@@ -73,14 +73,14 @@ public class MultiFlattenTest {
 
     @Test
     public void testWithIterables() {
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().items(
+        AssertSubscriber<String> subscriber = Multi.createFrom().items(
                 Arrays.asList("a", "b", "c"),
                 Arrays.asList("d", "e"),
                 Collections.emptySet(),
                 Collections.singleton("f"),
                 Collections.singleton("g"))
                 .onItem().<String> disjoint()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4));
+                .subscribe().withSubscriber(AssertSubscriber.create(4));
         subscriber.assertReceived("a", "b", "c", "d");
         subscriber.request(3);
         subscriber.assertCompletedSuccessfully();
@@ -90,14 +90,14 @@ public class MultiFlattenTest {
     @Test
     public void testWithMultisWithAFailure() {
         AtomicBoolean subscribed = new AtomicBoolean();
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().items(
+        AssertSubscriber<String> subscriber = Multi.createFrom().items(
                 Multi.createFrom().items("a", "b", "c"),
                 Multi.createFrom().items("d", "e"),
                 Multi.createFrom().failure(new IOException("boom")),
                 Multi.createFrom().items("f", "g")
                         .onSubscribe().invoke(s -> subscribed.set(true)))
                 .onItem().<String> disjoint()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4));
+                .subscribe().withSubscriber(AssertSubscriber.create(4));
         assertThat(subscribed).isFalse();
         subscriber.assertReceived("a", "b", "c", "d");
         subscriber.request(3);
@@ -108,7 +108,7 @@ public class MultiFlattenTest {
     @Test
     public void testWithMultisWithOneEmittingAFailure() {
         AtomicBoolean subscribed = new AtomicBoolean();
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().items(
+        AssertSubscriber<String> subscriber = Multi.createFrom().items(
                 Multi.createFrom().items("a", "b", "c"),
                 Multi.createFrom().items("d", "e"),
                 Multi.createFrom().emitter(e -> {
@@ -118,7 +118,7 @@ public class MultiFlattenTest {
                 Multi.createFrom().items("g")
                         .onSubscribe().invoke(s -> subscribed.set(true)))
                 .onItem().<String> disjoint()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4));
+                .subscribe().withSubscriber(AssertSubscriber.create(4));
         assertThat(subscribed).isFalse();
         subscriber.assertReceived("a", "b", "c", "d");
         subscriber.request(3);
@@ -128,14 +128,14 @@ public class MultiFlattenTest {
 
     @Test
     public void testWithIterablesContainingNull() {
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().items(
+        AssertSubscriber<String> subscriber = Multi.createFrom().items(
                 Arrays.asList("a", "b", "c"),
                 Arrays.asList("d", "e"),
                 Collections.emptySet(),
                 Collections.singleton(null),
                 Collections.singleton("g"))
                 .onItem().<String> disjoint()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4));
+                .subscribe().withSubscriber(AssertSubscriber.create(4));
         subscriber.assertReceived("a", "b", "c", "d");
         subscriber.request(3);
         subscriber.assertHasFailedWith(NullPointerException.class, "");
@@ -145,17 +145,17 @@ public class MultiFlattenTest {
     public void testWithInvalidType() {
         Multi.createFrom().items("a", "b", "c")
                 .onItem().disjoint()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+                .subscribe().withSubscriber(AssertSubscriber.create(2))
                 .assertHasFailedWith(IllegalArgumentException.class, "String");
     }
 
     @Test
     public void testFlatMapRequestsWithEmissionOnExecutor() {
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().items("a", "b", "c", "d", "e", "f", "g", "h")
+        AssertSubscriber<String> subscriber = Multi.createFrom().items("a", "b", "c", "d", "e", "f", "g", "h")
                 .onItem()
                 .transformToUni(s -> Uni.createFrom().item(s.toUpperCase()).onItem().delayIt().by(Duration.ofMillis(10)))
                 .concatenate()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(0));
+                .subscribe().withSubscriber(AssertSubscriber.create(0));
 
         subscriber
                 .assertSubscribed()

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiRepetitionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiRepetitionTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniEmitter;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiRepetitionTest {
 
@@ -27,8 +27,8 @@ public class MultiRepetitionTest {
                 .atMost(2);
 
         assertThat(shared).hasValue(0);
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertReceived(1);
         assertThat(shared).hasValue(1);
@@ -44,8 +44,8 @@ public class MultiRepetitionTest {
                 .atMost(2);
 
         assertThat(shared).hasValue(0);
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertReceived(1);
         assertThat(shared).hasValue(1);
@@ -64,8 +64,8 @@ public class MultiRepetitionTest {
                         (state, emitter) -> emitter.complete(state.incrementAndGet()))
                 .atMost(2);
 
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(IllegalStateException.class, "boom");
     }
@@ -79,8 +79,8 @@ public class MultiRepetitionTest {
                         (state, emitter) -> emitter.complete(state.incrementAndGet()))
                 .atMost(2);
 
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(NullPointerException.class, "supplier");
     }
@@ -111,8 +111,8 @@ public class MultiRepetitionTest {
                 .atMost(2);
 
         assertThat(shared).hasValue(0);
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertReceived(1);
         assertThat(shared).hasValue(1);
@@ -128,8 +128,8 @@ public class MultiRepetitionTest {
                 .atMost(2);
 
         assertThat(shared).hasValue(0);
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertReceived(1);
         assertThat(shared).hasValue(1);
@@ -147,8 +147,8 @@ public class MultiRepetitionTest {
                 .uni(boom, (state) -> Uni.createFrom().item(state.incrementAndGet()))
                 .atMost(2);
 
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(IllegalStateException.class, "boom");
     }
@@ -159,8 +159,8 @@ public class MultiRepetitionTest {
                 .<Integer> uni(() -> Uni.createFrom().failure(new IllegalStateException("boom")))
                 .atMost(2);
 
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(IllegalStateException.class, "boom");
     }
@@ -171,8 +171,8 @@ public class MultiRepetitionTest {
                 .<Integer> uni(() -> null)
                 .atMost(2);
 
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(NullPointerException.class, "");
     }
@@ -185,8 +185,8 @@ public class MultiRepetitionTest {
                 .uni(boom, (state) -> Uni.createFrom().item(state.incrementAndGet()))
                 .atMost(2);
 
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(NullPointerException.class, "supplier");
     }
@@ -211,8 +211,8 @@ public class MultiRepetitionTest {
                 .atMost(2);
 
         assertThat(shared).hasValue(0);
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertReceived(1);
         assertThat(shared).hasValue(1);
@@ -228,8 +228,8 @@ public class MultiRepetitionTest {
                 .atMost(2);
 
         assertThat(shared).hasValue(0);
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertReceived(1);
         assertThat(shared).hasValue(1);
@@ -247,8 +247,8 @@ public class MultiRepetitionTest {
                 .completionStage(boom, (state) -> CompletableFuture.completedFuture(state.incrementAndGet()))
                 .atMost(2);
 
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(IllegalStateException.class, "boom");
     }
@@ -261,8 +261,8 @@ public class MultiRepetitionTest {
                 })
                 .atMost(2);
 
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(IllegalStateException.class, "boom");
     }
@@ -275,8 +275,8 @@ public class MultiRepetitionTest {
                 .completionStage(boom, (state) -> CompletableFuture.completedFuture(state.incrementAndGet()))
                 .atMost(2);
 
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(NullPointerException.class, "supplier");
     }
@@ -287,8 +287,8 @@ public class MultiRepetitionTest {
                 .<Integer> completionStage(() -> CompletableFuture.completedFuture(null))
                 .atMost(2);
 
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(2));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(2));
 
         subscriber.assertTerminated().assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
@@ -314,8 +314,8 @@ public class MultiRepetitionTest {
                 .atMost(2);
 
         assertThat(shared).hasValue(0);
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertReceived(1);
         assertThat(shared).hasValue(1);
@@ -331,8 +331,8 @@ public class MultiRepetitionTest {
                 .atMost(2);
 
         assertThat(shared).hasValue(0);
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertReceived(1);
         assertThat(shared).hasValue(1);

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/CausedTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/CausedTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.unchecked.Unchecked;
@@ -63,7 +63,7 @@ public class CausedTest {
                 .indefinitely());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testWithNullParameter() {
         Uni.createFrom()
                 .item(Unchecked.supplier(this::numberSupplierThrowingNumberFormatException))

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/HalfSerializerTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/HalfSerializerTest.java
@@ -17,7 +17,7 @@ import org.reactivestreams.Subscription;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.subscription.MultiSubscriber;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class HalfSerializerTest {
 
@@ -27,7 +27,7 @@ public class HalfSerializerTest {
         AtomicInteger wip = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicReference<Subscriber<Object>> subscriber = new AtomicReference<>();
-        MultiAssertSubscriber<Object> test = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Object> test = AssertSubscriber.create(10);
 
         MultiSubscriber s = new MultiSubscriber() {
             @Override
@@ -67,7 +67,7 @@ public class HalfSerializerTest {
         AtomicInteger wip = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicReference<Subscriber<Object>> subscriber = new AtomicReference<>();
-        MultiAssertSubscriber<Object> test = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Object> test = AssertSubscriber.create(10);
 
         MultiSubscriber s = new MultiSubscriber() {
             @Override
@@ -107,7 +107,7 @@ public class HalfSerializerTest {
         AtomicInteger wip = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicReference<Subscriber<Object>> subscriber = new AtomicReference<>();
-        MultiAssertSubscriber<Object> test = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Object> test = AssertSubscriber.create(10);
 
         MultiSubscriber s = new MultiSubscriber() {
             @Override
@@ -145,7 +145,7 @@ public class HalfSerializerTest {
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
         Subscription subscription = mock(Subscription.class);
-        MultiAssertSubscriber<Object> test = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Object> test = AssertSubscriber.create(10);
         test.onSubscribe(subscription);
 
         CountDownLatch latch = new CountDownLatch(2);
@@ -174,7 +174,7 @@ public class HalfSerializerTest {
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
         Subscription subscription = mock(Subscription.class);
-        MultiAssertSubscriber<Object> test = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Object> test = AssertSubscriber.create(10);
         test.onSubscribe(subscription);
 
         CountDownLatch latch = new CountDownLatch(2);

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/MultiSubscribers.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/MultiSubscribers.java
@@ -1,0 +1,46 @@
+package io.smallrye.mutiny.helpers;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+public class MultiSubscribers {
+
+    private MultiSubscribers() {
+        // Avoid direct instantiation.
+    }
+
+    public static <T> MultiSubscriber<T> toMultiSubscriber(Subscriber<T> subscriber) {
+        return new MultiSubscriberWrapper<>(subscriber);
+    }
+
+    private static class MultiSubscriberWrapper<T> implements MultiSubscriber<T> {
+
+        private final Subscriber<T> delegate;
+
+        private MultiSubscriberWrapper(Subscriber<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void onItem(T item) {
+            delegate.onNext(item);
+        }
+
+        @Override
+        public void onFailure(Throwable failure) {
+            delegate.onError(failure);
+        }
+
+        @Override
+        public void onCompletion() {
+            delegate.onComplete();
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            delegate.onSubscribe(subscription);
+        }
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/StrictMultiSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/StrictMultiSubscriberTest.java
@@ -13,13 +13,13 @@ import org.reactivestreams.Subscription;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class StrictMultiSubscriberTest {
 
     @Test
     public void testItemReception() {
-        MultiAssertSubscriber<Integer> test = MultiAssertSubscriber.create(Long.MAX_VALUE);
+        AssertSubscriber<Integer> test = AssertSubscriber.create(Long.MAX_VALUE);
         StrictMultiSubscriber<Integer> strict = new StrictMultiSubscriber<>(test);
         Multi.createFrom().range(0, 5)
                 .subscribe().withSubscriber(strict);
@@ -28,7 +28,7 @@ public class StrictMultiSubscriberTest {
 
     @Test
     public void testItemReceptionWithBackPressure() {
-        MultiAssertSubscriber<Integer> test = MultiAssertSubscriber.create(0);
+        AssertSubscriber<Integer> test = AssertSubscriber.create(0);
         StrictMultiSubscriber<Integer> strict = new StrictMultiSubscriber<>(test);
         Multi.createFrom().range(0, 5)
                 .subscribe().withSubscriber(strict);
@@ -47,7 +47,7 @@ public class StrictMultiSubscriberTest {
 
     @Test
     public void testFailureReception() {
-        MultiAssertSubscriber<Integer> test = MultiAssertSubscriber.create(Long.MAX_VALUE);
+        AssertSubscriber<Integer> test = AssertSubscriber.create(Long.MAX_VALUE);
         StrictMultiSubscriber<Integer> strict = new StrictMultiSubscriber<>(test);
         Multi.createFrom().range(0, 5).onCompletion().failWith(new IOException("boom"))
                 .subscribe().withSubscriber(strict);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCacheTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCacheTest.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiEmitter;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCacheTest {
 
@@ -18,11 +18,11 @@ public class MultiCacheTest {
         Multi<Integer> multi = Multi.createFrom().deferred(() -> Multi.createFrom().items(count.incrementAndGet(),
                 count.incrementAndGet()))
                 .cache();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(2))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2);
     }
@@ -34,11 +34,11 @@ public class MultiCacheTest {
                 .emit(count.incrementAndGet())
                 .fail(new IOException("boom-" + count.incrementAndGet())))
                 .cache();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(2))
                 .assertReceived(1, 2)
                 .assertHasFailedWith(IOException.class, "boom-3");
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertReceived(1, 2)
                 .assertHasFailedWith(IOException.class, "boom-3");
     }
@@ -53,13 +53,13 @@ public class MultiCacheTest {
                     .emit(count.incrementAndGet());
         })
                 .cache();
-        MultiAssertSubscriber<Integer> s1 = multi
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+        AssertSubscriber<Integer> s1 = multi
+                .subscribe().withSubscriber(AssertSubscriber.create(2))
                 .assertReceived(1, 2)
                 .assertNotTerminated();
 
-        MultiAssertSubscriber<Integer> s2 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+        AssertSubscriber<Integer> s2 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertReceived(1, 2)
                 .assertNotTerminated();
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCastTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCastTest.java
@@ -3,7 +3,7 @@ package io.smallrye.mutiny.operators;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCastTest {
 
@@ -17,7 +17,7 @@ public class MultiCastTest {
     public void testCastThatWorks() {
         Multi.createFrom().item(1)
                 .onItem().castTo(Number.class)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully()
                 .assertReceived(1);
     }
@@ -26,7 +26,7 @@ public class MultiCastTest {
     public void testCastThatDoesNotWork() {
         Multi.createFrom().item(1)
                 .onItem().castTo(String.class)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertHasFailedWith(ClassCastException.class, "String");
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCombineTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCombineTest.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 import io.smallrye.mutiny.tuples.Functions;
 import io.smallrye.mutiny.tuples.Tuple2;
 import io.smallrye.mutiny.tuples.Tuple3;
@@ -39,7 +39,7 @@ public class MultiCombineTest {
                 .flatMap(l -> Multi.createFrom().iterable(l))
                 .onItem().castTo(Integer.class);
 
-        combined.subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+        combined.subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
     }
@@ -185,9 +185,9 @@ public class MultiCombineTest {
     @Test
     public void testCombinationWithBackPressure() {
         Multi<Integer> stream = Multi.createFrom().range(1, 5);
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().combining().streams(stream, stream)
+        AssertSubscriber<Integer> subscriber = Multi.createBy().combining().streams(stream, stream)
                 .using(Integer::sum)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(0));
+                .subscribe().withSubscriber(AssertSubscriber.create(0));
 
         subscriber.assertNotTerminated().assertHasNotReceivedAnyItem();
 
@@ -240,14 +240,14 @@ public class MultiCombineTest {
         Multi.createBy().combining()
                 .streams(Multi.createFrom().<Integer> empty(), Multi.createFrom().range(1, 2_000_000))
                 .using(Integer::sum)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
 
         Multi.createBy().combining()
                 .streams(Multi.createFrom().range(1, 2_000_000), Multi.createFrom().<Integer> empty())
                 .using(Integer::sum)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -256,7 +256,7 @@ public class MultiCombineTest {
     public void testCombiningASingleStreamUsingIterable() {
         Multi.createBy().combining().streams(Collections.singletonList(Multi.createFrom().item(1))).using(l -> l.get(0))
                 .onItem().castTo(Integer.class)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully()
                 .assertReceived(1);
     }
@@ -265,7 +265,7 @@ public class MultiCombineTest {
     public void testCombiningASingleEmptyStreamUsingIterable() {
         Multi.createBy().combining().streams(Collections.singletonList(Multi.createFrom().empty())).using(l -> l.get(0))
                 .onItem().castTo(Integer.class)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -321,7 +321,7 @@ public class MultiCombineTest {
         Multi<Integer> multi = Multi.createFrom().item(1);
 
         Multi.createBy().combining().streams(multi, multi).using((i, j) -> null)
-                .subscribe().withSubscriber(new MultiAssertSubscriber<>(2))
+                .subscribe().withSubscriber(new AssertSubscriber<>(2))
                 .assertHasFailedWith(NullPointerException.class, "");
     }
 
@@ -332,7 +332,7 @@ public class MultiCombineTest {
         Multi.createBy().combining().streams(multi, multi).using((i, j) -> {
             throw new IllegalArgumentException("boom");
         })
-                .subscribe().withSubscriber(new MultiAssertSubscriber<>(2))
+                .subscribe().withSubscriber(new AssertSubscriber<>(2))
                 .assertHasFailedWith(IllegalArgumentException.class, "boom");
     }
 
@@ -342,7 +342,7 @@ public class MultiCombineTest {
         Multi<Integer> multi2 = Multi.createFrom().emitter(e -> e.emit(1).fail(new IOException("boom")));
 
         Multi.createBy().combining().streams(multi, multi2).asTuple()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(3))
+                .subscribe().withSubscriber(AssertSubscriber.create(3))
                 .assertHasFailedWith(IOException.class, "boom")
                 .assertReceived(Tuple2.of(1, 1));
     }
@@ -354,7 +354,7 @@ public class MultiCombineTest {
         Multi<Integer> multi3 = Multi.createFrom().emitter(e -> e.emit(1).emit(2).fail(new IOException("boom")));
 
         Multi.createBy().combining().streams(multi, multi2, multi, multi3).collectFailures().asTuple()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(3))
+                .subscribe().withSubscriber(AssertSubscriber.create(3))
                 .assertHasFailedWith(IOException.class, "boom")
                 .assertReceived(Tuple4.of(1, 1, 1, 1));
     }
@@ -376,7 +376,7 @@ public class MultiCombineTest {
 
         Multi.createBy().combining().streams(Arrays.asList(stream, stream2))
                 .using(l -> (Integer) l.get(0) + (Integer) l.get(1))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .assertCompletedSuccessfully()
                 .assertReceived(2, 4, 6, 8);
     }
@@ -388,7 +388,7 @@ public class MultiCombineTest {
 
         Multi.createBy().combining().streams(Arrays.asList(stream, stream2))
                 .using(l -> (Integer) l.get(0) + (Integer) l.get(1))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .assertCompletedSuccessfully()
                 .assertReceived(2, 4, 6);
     }
@@ -400,7 +400,7 @@ public class MultiCombineTest {
 
         Multi.createBy().combining().streams(Arrays.asList(stream, stream2))
                 .using(l -> (Integer) l.get(0) + (Integer) l.get(1))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .assertCompletedSuccessfully()
                 .assertReceived(2, 4, 6);
     }
@@ -412,7 +412,7 @@ public class MultiCombineTest {
 
         Multi.createBy().combining().streams(Arrays.asList(stream, stream2, Multi.createFrom().empty()))
                 .using(l -> (Integer) l.get(0) + (Integer) l.get(1))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -422,7 +422,7 @@ public class MultiCombineTest {
         Multi<Integer> stream = Multi.createFrom().items(1, 2, 3, 4);
         Multi<Integer> stream2 = Multi.createFrom().items(1, 2, 3);
         Multi.createBy().combining().streams(stream, stream2).latestItems().using((a, b) -> null)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .assertHasFailedWith(NullPointerException.class, "");
     }
 
@@ -433,7 +433,7 @@ public class MultiCombineTest {
         Multi.createBy().combining().streams(stream, stream2).latestItems().using((a, b) -> {
             throw new IllegalStateException("boom");
         })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .assertHasFailedWith(IllegalStateException.class, "boom");
     }
 
@@ -441,7 +441,7 @@ public class MultiCombineTest {
     public void testCombineLatestWithFailingStream() {
         Multi<Integer> stream = Multi.createFrom().failure(new IOException("boom"));
         Multi.createBy().combining().streams(stream, Multi.createFrom().nothing()).latestItems().using((a, b) -> null)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .assertHasFailedWith(IOException.class, "boom");
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiConcatTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiConcatTest.java
@@ -9,17 +9,17 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiConcatTest {
 
     @Test
     public void testConcatenationOfSeveralMultis() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().streams(
+        AssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().streams(
                 Multi.createFrom().item(5),
                 Multi.createFrom().range(1, 3),
                 Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)).subscribe()
-                .withSubscriber(new MultiAssertSubscriber<>(100));
+                .withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(5, 1, 2, 9, 10, 11);
@@ -27,12 +27,12 @@ public class MultiConcatTest {
 
     @Test
     public void testConcatenationOfSeveralMultisWithConcurrency() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().concatenating()
+        AssertSubscriber<Integer> subscriber = Multi.createBy().concatenating()
                 .streams(
                         Multi.createFrom().item(5),
                         Multi.createFrom().range(1, 3),
                         Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1))
-                .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
+                .subscribe().withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(5, 1, 2, 9, 10, 11);
@@ -40,12 +40,12 @@ public class MultiConcatTest {
 
     @Test
     public void testConcatenationOfSeveralMultisWithConcurrencyAndDeprecatedApply() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().concatenating()
+        AssertSubscriber<Integer> subscriber = Multi.createBy().concatenating()
                 .streams(
                         Multi.createFrom().item(5),
                         Multi.createFrom().range(1, 3),
                         Multi.createFrom().items(8, 9, 10).onItem().apply(i -> i + 1))
-                .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
+                .subscribe().withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(5, 1, 2, 9, 10, 11);
@@ -53,12 +53,12 @@ public class MultiConcatTest {
 
     @Test
     public void testConcatenationOfSeveralMultisAsIterable() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().streams(
+        AssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().streams(
                 Arrays.asList(
                         Multi.createFrom().item(5),
                         Multi.createFrom().range(1, 3),
                         Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)))
-                .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
+                .subscribe().withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(5, 1, 2, 9, 10, 11);
@@ -66,11 +66,11 @@ public class MultiConcatTest {
 
     @Test
     public void testConcatenationOfSeveralPublishers() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().streams(
+        AssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().streams(
                 Flowable.just(5),
                 Multi.createFrom().range(1, 3),
                 Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)).subscribe()
-                .withSubscriber(new MultiAssertSubscriber<>(100));
+                .withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(5, 1, 2, 9, 10, 11);
@@ -78,12 +78,12 @@ public class MultiConcatTest {
 
     @Test
     public void testConcatenationOfSeveralPublishersAsIterable() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().streams(
+        AssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().streams(
                 Arrays.asList(
                         Flowable.just(5),
                         Multi.createFrom().range(1, 3),
                         Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)))
-                .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
+                .subscribe().withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(5, 1, 2, 9, 10, 11);
@@ -92,14 +92,14 @@ public class MultiConcatTest {
     @Test
     public void testMergingEmpty() {
         Multi.createBy().concatenating().streams(Multi.createFrom().empty())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
 
     @Test
     public void testMergingWithEmpty() {
         Multi.createBy().concatenating().streams(Multi.createFrom().empty(), Multi.createFrom().item(2))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully().assertReceived(2);
     }
 
@@ -108,11 +108,11 @@ public class MultiConcatTest {
         IllegalStateException boom = new IllegalStateException("boom");
         IllegalStateException boom2 = new IllegalStateException("boom2");
 
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().collectFailures().streams(
+        AssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().collectFailures().streams(
                 Multi.createFrom().item(5),
                 Multi.createFrom().failure(boom),
                 Multi.createFrom().item(6),
-                Multi.createFrom().failure(boom2)).subscribe().withSubscriber(new MultiAssertSubscriber<>(5));
+                Multi.createFrom().failure(boom2)).subscribe().withSubscriber(new AssertSubscriber<>(5));
 
         subscriber.assertTerminated()
                 .assertReceived(5, 6)
@@ -127,7 +127,7 @@ public class MultiConcatTest {
                 Multi.createFrom().item(5),
                 Multi.createFrom().failure(boom),
                 Multi.createFrom().item(6),
-                Multi.createFrom().failure(boom)).subscribe().withSubscriber(new MultiAssertSubscriber<>(5));
+                Multi.createFrom().failure(boom)).subscribe().withSubscriber(new AssertSubscriber<>(5));
 
         subscriber.assertTerminated()
                 .assertReceived(5)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromDeferredSupplierTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromDeferredSupplierTest.java
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCreateFromDeferredSupplierTest {
 
@@ -16,11 +16,11 @@ public class MultiCreateFromDeferredSupplierTest {
 
     @Test
     public void testWhenTheSupplierProduceNull() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
-        Multi.createFrom().<Integer> deferred(() -> null).subscribe(ts);
+        Multi.createFrom().<Integer> deferred(() -> null).subscribe(subscriber);
 
-        ts
+        subscriber
                 .assertHasNotCompleted()
                 .assertHasNotReceivedAnyItem()
                 .assertHasFailedWith(NullPointerException.class, "");
@@ -28,13 +28,13 @@ public class MultiCreateFromDeferredSupplierTest {
 
     @Test
     public void testWhenTheSupplierThrowsAnException() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         Multi.createFrom().<Integer> deferred(() -> {
             throw new IllegalStateException("boom");
-        }).subscribe(ts);
+        }).subscribe(subscriber);
 
-        ts
+        subscriber
                 .assertHasNotCompleted()
                 .assertHasNotReceivedAnyItem()
                 .assertHasFailedWith(IllegalStateException.class, "boom");
@@ -42,11 +42,11 @@ public class MultiCreateFromDeferredSupplierTest {
 
     @Test
     public void testWithASupplierProducingOne() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
 
-        Multi.createFrom().deferred(() -> Multi.createFrom().item(1)).subscribe(ts);
+        Multi.createFrom().deferred(() -> Multi.createFrom().item(1)).subscribe(subscriber);
 
-        ts.assertCompletedSuccessfully()
+        subscriber.assertCompletedSuccessfully()
                 .assertReceived(1)
                 .assertHasNotFailed();
     }
@@ -57,9 +57,9 @@ public class MultiCreateFromDeferredSupplierTest {
 
         Multi<Integer> multi = Multi.createFrom().deferred(() -> Multi.createFrom().item(count.incrementAndGet()));
 
-        MultiAssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1));
-        MultiAssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1));
-        MultiAssertSubscriber<Integer> s3 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<Integer> s1 = multi.subscribe().withSubscriber(AssertSubscriber.create(1));
+        AssertSubscriber<Integer> s2 = multi.subscribe().withSubscriber(AssertSubscriber.create(1));
+        AssertSubscriber<Integer> s3 = multi.subscribe().withSubscriber(AssertSubscriber.create(1));
 
         s1.assertReceived(1).assertCompletedSuccessfully();
         s2.assertReceived(2).assertCompletedSuccessfully();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromFailureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromFailureTest.java
@@ -9,7 +9,7 @@ import java.util.function.Supplier;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCreateFromFailureTest {
 
@@ -25,9 +25,9 @@ public class MultiCreateFromFailureTest {
 
     @Test
     public void testWithException() {
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().<String> failure(new IOException("boom"))
+        AssertSubscriber<String> subscriber = Multi.createFrom().<String> failure(new IOException("boom"))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create());
+                .withSubscriber(AssertSubscriber.create());
         subscriber.assertHasFailedWith(IOException.class, "boom");
     }
 
@@ -36,8 +36,8 @@ public class MultiCreateFromFailureTest {
         AtomicInteger count = new AtomicInteger();
         Multi<String> failure = Multi.createFrom()
                 .failure(() -> new IOException("boom-" + count.incrementAndGet()));
-        MultiAssertSubscriber<String> subscriber1 = failure.subscribe().withSubscriber(MultiAssertSubscriber.create());
-        MultiAssertSubscriber<String> subscriber2 = failure.subscribe().withSubscriber(MultiAssertSubscriber.create());
+        AssertSubscriber<String> subscriber1 = failure.subscribe().withSubscriber(AssertSubscriber.create());
+        AssertSubscriber<String> subscriber2 = failure.subscribe().withSubscriber(AssertSubscriber.create());
         subscriber1.assertHasFailedWith(IOException.class, "boom-1");
         subscriber2.assertHasFailedWith(IOException.class, "boom-2");
     }
@@ -47,14 +47,14 @@ public class MultiCreateFromFailureTest {
         Multi<String> multi = Multi.createFrom().failure(() -> {
             throw new IllegalStateException("boom");
         });
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create());
+        AssertSubscriber<String> subscriber1 = multi.subscribe().withSubscriber(AssertSubscriber.create());
         subscriber1.assertTerminated().assertHasFailedWith(IllegalStateException.class, "boom");
     }
 
     @Test
     public void testWithNullReturnedBySupplier() {
         Multi<String> multi = Multi.createFrom().failure(() -> null);
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create());
+        AssertSubscriber<String> subscriber1 = multi.subscribe().withSubscriber(AssertSubscriber.create());
         subscriber1.assertTerminated();
 
         assertThat(subscriber1.failures()).hasSize(1)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromItemsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromItemsTest.java
@@ -14,14 +14,14 @@ import java.util.stream.Stream;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCreateFromItemsTest {
 
     @Test
     public void testCreationWithASingleResult() {
         Multi<Integer> multi = Multi.createFrom().item(1);
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .request(1)
@@ -32,7 +32,7 @@ public class MultiCreateFromItemsTest {
     @Test
     public void testCreationWithASingleNullResult() {
         Multi<String> multi = Multi.createFrom().item((String) null);
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .assertCompletedSuccessfully();
@@ -43,7 +43,7 @@ public class MultiCreateFromItemsTest {
         AtomicInteger count = new AtomicInteger();
         Multi<Integer> multi = Multi.createFrom().item(count::incrementAndGet);
         assertThat(count).hasValue(0);
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .run(() -> assertThat(count).hasValue(1)) // The supplier is called at subscription time
@@ -51,7 +51,7 @@ public class MultiCreateFromItemsTest {
                 .assertCompletedSuccessfully()
                 .assertReceived(1);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .request(1)
@@ -62,7 +62,7 @@ public class MultiCreateFromItemsTest {
     @Test
     public void testCreationWithNullProducedBySupplier() {
         Multi<Integer> multi = Multi.createFrom().item(() -> null);
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .assertCompletedSuccessfully();
@@ -73,7 +73,7 @@ public class MultiCreateFromItemsTest {
         Multi<Integer> multi = Multi.createFrom().item(() -> {
             throw new IllegalStateException("boom");
         });
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertHasFailedWith(IllegalStateException.class, "boom");
     }
@@ -81,7 +81,7 @@ public class MultiCreateFromItemsTest {
     @Test
     public void testCreationFromAStreamWithRequest() {
         Multi<Integer> multi = Multi.createFrom().items(Stream.of(1, 2, 3));
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .request(1)
@@ -96,7 +96,7 @@ public class MultiCreateFromItemsTest {
             return Stream.of(1, 2, 3);
         });
         assertThat(count).hasValue(0);
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .run(() -> assertThat(count).hasValue(1))
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
@@ -111,12 +111,12 @@ public class MultiCreateFromItemsTest {
     @Test
     public void testCreateFromEmptyStream() {
         Multi.createFrom().<Integer> items(Stream.empty())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100))
+                .subscribe().withSubscriber(AssertSubscriber.create(100))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
 
         Multi.createFrom().<Integer> items(Stream::empty)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100))
+                .subscribe().withSubscriber(AssertSubscriber.create(100))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -124,12 +124,12 @@ public class MultiCreateFromItemsTest {
     @Test
     public void testCreateFromStreamOfOne() {
         Multi.createFrom().items(Stream.of(1))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100))
+                .subscribe().withSubscriber(AssertSubscriber.create(100))
                 .assertCompletedSuccessfully()
                 .assertReceived(1);
 
         Multi.createFrom().items(() -> Stream.of(2))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100))
+                .subscribe().withSubscriber(AssertSubscriber.create(100))
                 .assertCompletedSuccessfully()
                 .assertReceived(2);
     }
@@ -167,7 +167,7 @@ public class MultiCreateFromItemsTest {
     public void testLimitOnMultiBasedOnStream() {
         Multi.createFrom().items(() -> IntStream.iterate(0, operand -> operand + 1).boxed())
                 .transform().byTakingFirstItems(10)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertCompletedSuccessfully()
                 .assertReceived(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
@@ -177,12 +177,12 @@ public class MultiCreateFromItemsTest {
         assertThatThrownBy(() -> Multi.createFrom().items((Stream<String>) null)).isInstanceOf(IllegalArgumentException.class);
 
         Multi.createFrom().items(() -> null)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(NullPointerException.class, "")
                 .assertHasNotReceivedAnyItem();
 
         Multi.createFrom().items(Stream.of("a", "b", null, "c"))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(NullPointerException.class, "")
                 .assertReceived("a", "b");
     }
@@ -191,7 +191,7 @@ public class MultiCreateFromItemsTest {
     public void testCloseCallbackCalledWithStream() {
         AtomicBoolean called = new AtomicBoolean();
         Multi.createFrom().items(Stream.of("a", "b", "c").onClose(() -> called.set(true)))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertReceived("a", "b", "c")
                 .assertCompletedSuccessfully()
                 .run(() -> assertThat(called).isTrue());
@@ -199,7 +199,7 @@ public class MultiCreateFromItemsTest {
         // Test that the callback is called when the subscriber cancels
         called.set(false);
         Multi.createFrom().items(Stream.of("a", "b", "c").onClose(() -> called.set(true)))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertReceived("a")
                 .cancel()
                 .run(() -> assertThat(called).isTrue());
@@ -215,7 +215,7 @@ public class MultiCreateFromItemsTest {
                 throw new IllegalStateException("boom");
             }
             return value;
-        }).onClose(() -> called.set(true))).subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+        }).onClose(() -> called.set(true))).subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(IllegalStateException.class, "boom")
                 .assertReceived(0);
         assertThat(called).isTrue();
@@ -225,7 +225,7 @@ public class MultiCreateFromItemsTest {
     public void testCreationFromAStreamSupplier() {
         AtomicInteger count = new AtomicInteger();
         Multi<Integer> multi = Multi.createFrom().items(() -> Stream.of(1, 2, count.incrementAndGet()));
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .request(1)
@@ -234,7 +234,7 @@ public class MultiCreateFromItemsTest {
                 .assertReceived(1, 2, 1)
                 .assertCompletedSuccessfully();
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .request(1)
@@ -247,7 +247,7 @@ public class MultiCreateFromItemsTest {
     @Test
     public void testCreationFromAnEmptyStream() {
         Multi<Integer> multi = Multi.createFrom().items(Stream.of());
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .assertCompletedSuccessfully();
@@ -256,11 +256,11 @@ public class MultiCreateFromItemsTest {
     @Test
     public void testCreationFromAnEmptyStreamSupplier() {
         Multi<Integer> multi = Multi.createFrom().items(Stream::empty);
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .assertCompletedSuccessfully();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .assertCompletedSuccessfully();
@@ -279,7 +279,7 @@ public class MultiCreateFromItemsTest {
     @Test
     public void testCreationFromAStreamSupplierProducingNull() {
         Multi<Integer> multi = Multi.createFrom().items((Supplier<Stream<Integer>>) () -> null);
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasFailedWith(NullPointerException.class, "supplier");
     }
 
@@ -288,14 +288,14 @@ public class MultiCreateFromItemsTest {
         Multi<Integer> multi = Multi.createFrom().items((Supplier<Stream<Integer>>) () -> {
             throw new IllegalStateException("boom");
         });
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasFailedWith(IllegalStateException.class, "boom");
     }
 
     @Test
     public void testCreationFromResults() {
         Multi<Integer> multi = Multi.createFrom().items(1, 2, 3);
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .request(2)
@@ -318,7 +318,7 @@ public class MultiCreateFromItemsTest {
     @Test
     public void testCreationFromIterable() {
         Multi<Integer> multi = Multi.createFrom().iterable(Arrays.asList(1, 2, 3));
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .request(2)
@@ -336,7 +336,7 @@ public class MultiCreateFromItemsTest {
     @Test
     public void testCreationFromIterableContainingNull() {
         Multi<Integer> multi = Multi.createFrom().iterable(Arrays.asList(1, null, 3));
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertSubscribed()
                 .request(2)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromOptionalTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromOptionalTest.java
@@ -9,7 +9,7 @@ import java.util.function.Supplier;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCreateFromOptionalTest {
 
@@ -26,15 +26,15 @@ public class MultiCreateFromOptionalTest {
 
     @Test
     public void testWithAValue() {
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().optional(Optional.of("hello")).subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<String> subscriber = Multi.createFrom().optional(Optional.of("hello")).subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
         subscriber.assertCompletedSuccessfully().assertReceived("hello");
     }
 
     @Test
     public void testWithEmpty() {
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().<String> optional(Optional.empty()).subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+        AssertSubscriber<String> subscriber = Multi.createFrom().<String> optional(Optional.empty()).subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
         subscriber.assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
 
@@ -44,8 +44,8 @@ public class MultiCreateFromOptionalTest {
 
         Multi<String> multi = Multi.createFrom()
                 .optional(() -> Optional.of("hello-" + count.incrementAndGet()));
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1));
-        MultiAssertSubscriber<String> subscriber2 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create());
+        AssertSubscriber<String> subscriber1 = multi.subscribe().withSubscriber(AssertSubscriber.create(1));
+        AssertSubscriber<String> subscriber2 = multi.subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber1.assertCompletedSuccessfully().assertReceived("hello-1");
         subscriber2.assertHasNotReceivedAnyItem().assertNotTerminated().request(20)
@@ -55,8 +55,8 @@ public class MultiCreateFromOptionalTest {
     @Test
     public void testWithEmptyProducedInSupplier() {
         Multi<String> multi = Multi.createFrom().optional(Optional::empty);
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1));
-        MultiAssertSubscriber<String> subscriber2 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create());
+        AssertSubscriber<String> subscriber1 = multi.subscribe().withSubscriber(AssertSubscriber.create(1));
+        AssertSubscriber<String> subscriber2 = multi.subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber1.assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
         subscriber2.assertHasNotReceivedAnyItem().assertCompletedSuccessfully();
@@ -67,7 +67,7 @@ public class MultiCreateFromOptionalTest {
         Multi<String> multi = Multi.createFrom().optional(() -> {
             throw new IllegalStateException("boom");
         });
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create());
+        AssertSubscriber<String> subscriber1 = multi.subscribe().withSubscriber(AssertSubscriber.create());
         subscriber1.assertTerminated().assertHasFailedWith(IllegalStateException.class, "boom");
     }
 
@@ -75,7 +75,7 @@ public class MultiCreateFromOptionalTest {
     @Test
     public void testWithNullReturnedBySupplier() {
         Multi<String> multi = Multi.createFrom().optional(() -> null);
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe().withSubscriber(MultiAssertSubscriber.create());
+        AssertSubscriber<String> subscriber1 = multi.subscribe().withSubscriber(AssertSubscriber.create());
         subscriber1.assertTerminated();
 
         assertThat(subscriber1.failures()).hasSize(1)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromPublisherTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromPublisherTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCreateFromPublisherTest {
 
@@ -22,16 +22,16 @@ public class MultiCreateFromPublisherTest {
 
     @Test
     public void testWithFailedPublisher() {
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().<String> publisher(
+        AssertSubscriber<String> subscriber = Multi.createFrom().<String> publisher(
                 Flowable.error(new IOException("boom"))).subscribe()
-                .withSubscriber(MultiAssertSubscriber.create());
+                .withSubscriber(AssertSubscriber.create());
         subscriber.assertHasFailedWith(IOException.class, "boom");
     }
 
     @Test
     public void testWithEmptyPublisher() {
-        MultiAssertSubscriber<String> subscriber = Multi.createFrom().<String> publisher(Flowable.empty()).subscribe()
-                .withSubscriber(MultiAssertSubscriber.create());
+        AssertSubscriber<String> subscriber = Multi.createFrom().<String> publisher(Flowable.empty()).subscribe()
+                .withSubscriber(AssertSubscriber.create());
         subscriber.assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
 
@@ -46,7 +46,7 @@ public class MultiCreateFromPublisherTest {
 
         Multi<Integer> multi = Multi.createFrom().publisher(flowable);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create()).assertHasNotReceivedAnyItem()
+        multi.subscribe().withSubscriber(AssertSubscriber.create()).assertHasNotReceivedAnyItem()
                 .request(2)
                 .assertReceived(1, 2)
                 .run(() -> assertThat(requests).hasValue(2))
@@ -59,7 +59,7 @@ public class MultiCreateFromPublisherTest {
 
         assertThat(count).hasValue(1);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create()).assertHasNotReceivedAnyItem()
+        multi.subscribe().withSubscriber(AssertSubscriber.create()).assertHasNotReceivedAnyItem()
                 .request(2)
                 .assertReceived(1, 2)
                 .request(1)
@@ -80,7 +80,7 @@ public class MultiCreateFromPublisherTest {
 
         Multi<Integer> multi = Multi.createFrom().publisher(flowable);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create()).assertHasNotReceivedAnyItem()
+        multi.subscribe().withSubscriber(AssertSubscriber.create()).assertHasNotReceivedAnyItem()
                 .request(2)
                 .assertReceived(1, 2)
                 .run(() -> assertThat(cancellation).isFalse())

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromRangeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromRangeTest.java
@@ -3,14 +3,14 @@ package io.smallrye.mutiny.operators;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCreateFromRangeTest {
 
     @Test
     public void testARangeFrom0to10() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
-        Multi.createFrom().range(1, 10).subscribe().withSubscriber(ts)
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
+        Multi.createFrom().range(1, 10).subscribe().withSubscriber(subscriber)
                 .request(3)
                 .assertReceived(1, 2, 3)
                 .assertHasNotCompleted()
@@ -21,8 +21,8 @@ public class MultiCreateFromRangeTest {
 
     @Test
     public void testARangeFrom0to10WithFullConsumptionAtSubscription() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create(9);
-        Multi.createFrom().range(1, 10).subscribe().withSubscriber(ts)
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(9);
+        Multi.createFrom().range(1, 10).subscribe().withSubscriber(subscriber)
                 .assertReceived(1, 2, 3, 4, 5, 6, 7, 8, 9)
                 .assertCompletedSuccessfully()
                 .request(3)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
@@ -13,11 +13,11 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCreateFromTimePeriodTest {
 
-    private ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
     @AfterTest
     public void cleanup() {
@@ -26,24 +26,24 @@ public class MultiCreateFromTimePeriodTest {
 
     @Test
     public void testIntervalOfAFewMillis() {
-        MultiAssertSubscriber<Long> ts = MultiAssertSubscriber.create(Long.MAX_VALUE);
+        AssertSubscriber<Long> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
         // Add a fake item with the beginning time
-        ts.items().add(System.currentTimeMillis());
+        subscriber.items().add(System.currentTimeMillis());
 
         Multi.createFrom().ticks()
                 .startingAfter(Duration.ofMillis(100)).onExecutor(executor).every(Duration.ofMillis(100))
                 .onItem().transform(l -> System.currentTimeMillis())
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        await().until(() -> ts.items().size() >= 10);
-        ts.cancel();
+        await().until(() -> subscriber.items().size() >= 10);
+        subscriber.cancel();
 
-        ts
+        subscriber
                 .assertHasNotCompleted()
                 .assertHasNotFailed();
 
-        List<Long> list = ts.items();
+        List<Long> list = subscriber.items();
         for (int i = 0; i < list.size() - 1; i++) {
             long delta = list.get(i + 1) - list.get(i);
             assertThat(delta).isBetween(20L, 350L);
@@ -52,10 +52,10 @@ public class MultiCreateFromTimePeriodTest {
 
     @Test
     public void testWithInfraExecutorAndNoDelay() throws InterruptedException {
-        MultiAssertSubscriber<Long> ts = MultiAssertSubscriber.create(Long.MAX_VALUE);
+        AssertSubscriber<Long> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
         // Add a fake item with the beginning time
-        ts.items().add(System.currentTimeMillis());
+        subscriber.items().add(System.currentTimeMillis());
 
         // No initial delay, so introduce a fake delay
         Thread.sleep(100);
@@ -63,16 +63,16 @@ public class MultiCreateFromTimePeriodTest {
         Multi.createFrom().ticks()
                 .every(Duration.ofMillis(100))
                 .onItem().transform(l -> System.currentTimeMillis())
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        await().until(() -> ts.items().size() >= 10);
-        ts.cancel();
+        await().until(() -> subscriber.items().size() >= 10);
+        subscriber.cancel();
 
-        ts
+        subscriber
                 .assertHasNotCompleted()
                 .assertHasNotFailed();
 
-        List<Long> list = ts.items();
+        List<Long> list = subscriber.items();
         for (int i = 0; i < list.size() - 1; i++) {
             long delta = list.get(i + 1) - list.get(i);
             assertThat(delta).isBetween(20L, 350L);
@@ -81,16 +81,16 @@ public class MultiCreateFromTimePeriodTest {
 
     @Test(timeOut = 1000)
     public void testBackPressureOverflow() {
-        MultiAssertSubscriber<Long> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Long> subscriber = AssertSubscriber.create();
 
-        ts.items().add(System.currentTimeMillis());
+        subscriber.items().add(System.currentTimeMillis());
 
         Multi.createFrom().ticks()
                 .startingAfter(Duration.ofMillis(50)).onExecutor(executor).every(Duration.ofMillis(50))
                 .onItem().transform(l -> System.currentTimeMillis())
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts
+        subscriber
                 .request(2) // request only 2
                 .await() // wait until failure
                 .assertHasFailedWith(BackPressureFailure.class, "lack of requests");

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiDistinctTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiDistinctTest.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiDistinctTest {
 
@@ -13,7 +13,7 @@ public class MultiDistinctTest {
     public void testDistinctWithUpstreamFailure() {
         Multi.createFrom().<Integer> failure(new IOException("boom"))
                 .transform().byDroppingDuplicates()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(IOException.class, "boom");
     }
 
@@ -21,7 +21,7 @@ public class MultiDistinctTest {
     public void testDistinct() {
         Multi.createFrom().items(1, 2, 3, 4, 2, 4, 2, 4)
                 .transform().byDroppingDuplicates()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
     }
@@ -30,7 +30,7 @@ public class MultiDistinctTest {
     public void testDistinctOnAStreamWithoutDuplicates() {
         Multi.createFrom().range(1, 5)
                 .transform().byDroppingDuplicates()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
     }
@@ -39,7 +39,7 @@ public class MultiDistinctTest {
     public void testDropRepetitionsWithUpstreamFailure() {
         Multi.createFrom().<Integer> failure(new IOException("boom"))
                 .transform().byDroppingRepetitions()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(IOException.class, "boom");
     }
 
@@ -47,7 +47,7 @@ public class MultiDistinctTest {
     public void testDropRepetitions() {
         Multi.createFrom().items(1, 2, 3, 4, 4, 2, 2, 4, 1, 1, 2, 4)
                 .transform().byDroppingRepetitions()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4, 2, 4, 1, 2, 4);
     }
@@ -56,7 +56,7 @@ public class MultiDistinctTest {
     public void testDropRepetitionsOnAStreamWithoutDuplicates() {
         Multi.createFrom().range(1, 5)
                 .transform().byDroppingRepetitions()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmitOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmitOnTest.java
@@ -10,7 +10,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiEmitOnTest {
 
@@ -28,9 +28,9 @@ public class MultiEmitOnTest {
 
     @Test
     public void testWithSequenceOfItems() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
                 .emitOn(executor)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(2);
         await().until(() -> subscriber.items().size() == 2);
@@ -42,9 +42,9 @@ public class MultiEmitOnTest {
 
     @Test
     public void testWithRequest0() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
                 .emitOn(executor)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(0);
         subscriber.await()

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmptyAndNeverTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmptyAndNeverTest.java
@@ -3,14 +3,14 @@ package io.smallrye.mutiny.operators;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiEmptyAndNeverTest {
 
     @Test
     public void testEmpty() {
         Multi<String> nothing = Multi.createFrom().empty();
-        nothing.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        nothing.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -18,7 +18,7 @@ public class MultiEmptyAndNeverTest {
     @Test
     public void testNever() {
         Multi<String> nothing = Multi.createFrom().nothing();
-        nothing.subscribe().withSubscriber(MultiAssertSubscriber.create())
+        nothing.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertNotTerminated()
                 .request(2)
                 .assertNotTerminated();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.GroupedMulti;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiGroupTest {
 
@@ -38,8 +38,8 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupIntoListsOfTwoElements() {
-        MultiAssertSubscriber<List<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoLists().of(2)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100));
+        AssertSubscriber<List<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoLists().of(2)
+                .subscribe().withSubscriber(AssertSubscriber.create(100));
         subscriber.assertCompletedSuccessfully();
         assertThat(subscriber.items()).containsExactly(
                 Arrays.asList(1, 2), Arrays.asList(3, 4), Arrays.asList(5, 6), Arrays.asList(7, 8),
@@ -48,8 +48,8 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupIntoListsOfTwoElementsWithRequests() {
-        MultiAssertSubscriber<List<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoLists().of(2)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+        AssertSubscriber<List<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoLists().of(2)
+                .subscribe().withSubscriber(AssertSubscriber.create());
         subscriber
                 .assertSubscribed().assertHasNotReceivedAnyItem()
                 .request(3);
@@ -67,9 +67,9 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupIntoListsOfTwoElementsWithSkip() {
-        MultiAssertSubscriber<List<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoLists()
+        AssertSubscriber<List<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoLists()
                 .of(2, 3)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100));
+                .subscribe().withSubscriber(AssertSubscriber.create(100));
         subscriber.assertCompletedSuccessfully();
         assertThat(subscriber.items()).containsExactly(
                 Arrays.asList(1, 2), Arrays.asList(4, 5), Arrays.asList(7, 8));
@@ -77,9 +77,9 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupIntoListsOfTwoElementsWithSkipSmallerThanSize() {
-        MultiAssertSubscriber<List<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoLists()
+        AssertSubscriber<List<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoLists()
                 .of(2, 1)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100));
+                .subscribe().withSubscriber(AssertSubscriber.create(100));
         subscriber.assertCompletedSuccessfully();
         assertThat(subscriber.items()).containsExactly(
                 Arrays.asList(1, 2), Arrays.asList(2, 3), Arrays.asList(3, 4),
@@ -89,9 +89,9 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupIntoListsOfTwoElementsWithRequestsAndSkip() {
-        MultiAssertSubscriber<List<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoLists()
+        AssertSubscriber<List<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoLists()
                 .of(2, 3)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
         subscriber
                 .assertSubscribed().assertHasNotReceivedAnyItem()
                 .request(2);
@@ -133,9 +133,9 @@ public class MultiGroupTest {
     @Test
     public void testAsListsWithDuration() {
         Multi<Long> publisher = Multi.createFrom().publisher(Multi.createFrom().ticks().every(Duration.ofMillis(2)));
-        MultiAssertSubscriber<List<Long>> subscriber = publisher.groupItems().intoLists().every(Duration.ofMillis(100))
+        AssertSubscriber<List<Long>> subscriber = publisher.groupItems().intoLists().every(Duration.ofMillis(100))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(100));
+                .withSubscriber(AssertSubscriber.create(100));
 
         await().until(() -> subscriber.items().size() > 3);
         subscriber.cancel();
@@ -158,9 +158,9 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupIntoMultisOfTwoElements() {
-        MultiAssertSubscriber<Multi<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoMultis()
+        AssertSubscriber<Multi<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoMultis()
                 .of(2)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100));
+                .subscribe().withSubscriber(AssertSubscriber.create(100));
         subscriber.assertCompletedSuccessfully();
         List<List<Integer>> flatten = flatten(subscriber.items());
         assertThat(flatten).containsExactly(
@@ -178,9 +178,9 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupIntoMultisOfTwoElementsWithRequests() {
-        MultiAssertSubscriber<Multi<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoMultis()
+        AssertSubscriber<Multi<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoMultis()
                 .of(2)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
         subscriber
                 .assertSubscribed().assertHasNotReceivedAnyItem()
                 .request(3);
@@ -197,9 +197,9 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupIntoMultisOfTwoElementsWithSkip() {
-        MultiAssertSubscriber<Multi<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoMultis()
+        AssertSubscriber<Multi<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoMultis()
                 .of(2, 3)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100));
+                .subscribe().withSubscriber(AssertSubscriber.create(100));
         subscriber.assertCompletedSuccessfully();
         assertThat(flatten(subscriber.items())).containsExactly(
                 Arrays.asList(1, 2), Arrays.asList(4, 5), Arrays.asList(7, 8));
@@ -207,9 +207,9 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupIntoMultisOfTwoElementsWithSkipSmallerThanSize() {
-        MultiAssertSubscriber<Multi<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoMultis()
+        AssertSubscriber<Multi<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoMultis()
                 .of(2, 1)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100));
+                .subscribe().withSubscriber(AssertSubscriber.create(100));
         subscriber.assertCompletedSuccessfully();
         assertThat(flatten(subscriber.items())).containsExactly(
                 Arrays.asList(1, 2), Arrays.asList(2, 3), Arrays.asList(3, 4),
@@ -219,9 +219,9 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupIntoMultisOfTwoElementsWithRequestsAndSkip() {
-        MultiAssertSubscriber<Multi<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoMultis()
+        AssertSubscriber<Multi<Integer>> subscriber = Multi.createFrom().range(1, 10).groupItems().intoMultis()
                 .of(2, 3)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
         subscriber
                 .assertSubscribed().assertHasNotReceivedAnyItem()
                 .request(2);
@@ -264,10 +264,10 @@ public class MultiGroupTest {
     @Test
     public void testAsMultisWithDuration() {
         Multi<Long> publisher = Multi.createFrom().publisher(Multi.createFrom().ticks().every(Duration.ofMillis(2)));
-        MultiAssertSubscriber<Multi<Long>> subscriber = publisher.groupItems().intoMultis()
+        AssertSubscriber<Multi<Long>> subscriber = publisher.groupItems().intoMultis()
                 .every(Duration.ofMillis(100))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(100));
+                .withSubscriber(AssertSubscriber.create(100));
 
         await().until(() -> subscriber.items().size() > 3);
         subscriber.cancel();
@@ -287,7 +287,7 @@ public class MultiGroupTest {
 
     @Test
     public void testThatWindowWithDurationEmitsEmptyLists() {
-        MultiAssertSubscriber<List<Object>> subscriber = MultiAssertSubscriber.create(3);
+        AssertSubscriber<List<Object>> subscriber = AssertSubscriber.create(3);
         Multi.createFrom().nothing()
                 .groupItems().intoMultis().every(Duration.ofMillis(10))
                 .onItem().transformToUniAndMerge(m -> m.collectItems().asList())
@@ -301,9 +301,9 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupByWithKeyMapperOnly() {
-        MultiAssertSubscriber<GroupedMulti<Integer, Integer>> subscriber = Multi.createFrom().range(1, 10)
+        AssertSubscriber<GroupedMulti<Integer, Integer>> subscriber = Multi.createFrom().range(1, 10)
                 .groupItems().by(i -> i % 2)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100));
+                .subscribe().withSubscriber(AssertSubscriber.create(100));
 
         subscriber.assertCompletedSuccessfully();
         assertThat(subscriber.items()).hasSize(2);
@@ -320,9 +320,9 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupByWithKeyMapperAndValueMapper() {
-        MultiAssertSubscriber<GroupedMulti<Integer, String>> subscriber = Multi.createFrom().range(1, 10)
+        AssertSubscriber<GroupedMulti<Integer, String>> subscriber = Multi.createFrom().range(1, 10)
                 .groupItems().by(i -> i % 2, t -> Integer.toString(t))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100));
+                .subscribe().withSubscriber(AssertSubscriber.create(100));
 
         subscriber.assertCompletedSuccessfully();
         assertThat(subscriber.items()).hasSize(2);
@@ -339,9 +339,9 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupByProducingASingleGroup() {
-        MultiAssertSubscriber<GroupedMulti<Integer, Integer>> subscriber = Multi.createFrom().range(1, 10)
+        AssertSubscriber<GroupedMulti<Integer, Integer>> subscriber = Multi.createFrom().range(1, 10)
                 .groupItems().by(i -> 0)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100));
+                .subscribe().withSubscriber(AssertSubscriber.create(100));
 
         subscriber.assertCompletedSuccessfully();
         assertThat(subscriber.items()).hasSize(1);
@@ -362,10 +362,10 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupByOnFailingMulti() {
-        MultiAssertSubscriber<GroupedMulti<Integer, Integer>> subscriber = Multi.createFrom()
+        AssertSubscriber<GroupedMulti<Integer, Integer>> subscriber = Multi.createFrom()
                 .<Integer> failure(new IOException("boom"))
                 .groupItems().by(i -> i % 2)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100));
+                .subscribe().withSubscriber(AssertSubscriber.create(100));
 
         subscriber.assertHasFailedWith(IOException.class, "boom");
         assertThat(subscriber.items()).hasSize(0);
@@ -373,19 +373,19 @@ public class MultiGroupTest {
 
     @Test
     public void testGroupByOnEmptyMulti() {
-        MultiAssertSubscriber<GroupedMulti<Integer, Integer>> subscriber = Multi.createFrom().<Integer> empty()
+        AssertSubscriber<GroupedMulti<Integer, Integer>> subscriber = Multi.createFrom().<Integer> empty()
                 .groupItems().by(i -> i % 2)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100));
+                .subscribe().withSubscriber(AssertSubscriber.create(100));
 
         subscriber.assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
 
     @Test
     public void testGroupByFollowedWithAFlatMap() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().range(1, 10)
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().range(1, 10)
                 .groupItems().by(i -> 1)
                 .flatMap(gm -> gm)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(100));
+                .subscribe().withSubscriber(AssertSubscriber.create(100));
 
         subscriber.assertCompletedSuccessfully();
         assertThat(subscriber.items()).hasSize(9);
@@ -393,14 +393,14 @@ public class MultiGroupTest {
 
     @Test
     public void requestingIsResumedAfterCancellationOfAGroupedMulti() {
-        final List<MultiAssertSubscriber<Integer>> subscribers = new ArrayList<>();
+        final List<AssertSubscriber<Integer>> subscribers = new ArrayList<>();
         final AtomicInteger counter = new AtomicInteger();
         final AtomicBoolean done = new AtomicBoolean();
         Multi.createFrom().range(0, 1001)
                 .onItem().invoke(x -> counter.getAndIncrement())
                 .groupItems().intoMultis().of(1)
                 .subscribe().with(multi -> {
-                    MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(0L);
+                    AssertSubscriber<Integer> subscriber = AssertSubscriber.create(0L);
                     subscribers.add(subscriber);
                     multi.subscribe(subscriber);
                 },

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIfEmptyTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIfEmptyTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiIfEmptyTest {
 
@@ -19,7 +19,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyContinueWith() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().continueWith(6, 7, 8)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertReceived(6, 7, 8);
 
@@ -29,7 +29,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyContinueWithOnNonEmpty() {
         Multi.createFrom().item(1)
                 .onCompletion().ifEmpty().continueWith(6, 7, 8)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertReceived(1);
 
@@ -39,7 +39,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyContinueWithAndUpstreamFailure() {
         Multi.createFrom().<Integer> failure(new IOException("boom"))
                 .onCompletion().ifEmpty().continueWith(6, 7, 8)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertHasFailedWith(IOException.class, "boom");
 
     }
@@ -48,7 +48,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyContinueWithEmpty() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().continueWith()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -57,7 +57,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyContinueWithOne() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().continueWith(25)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertReceived(25);
     }
@@ -66,7 +66,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyBecauseOfSkipContinueWithOne() {
         Multi.createFrom().items(1, 2, 3).transform().bySkippingFirstItems(5)
                 .onCompletion().ifEmpty().continueWith(25)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertReceived(25);
     }
@@ -75,7 +75,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyContinueWithIterable() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().continueWith(Arrays.asList(5, 6))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertReceived(5, 6);
     }
@@ -84,7 +84,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyContinueWithEmptyIterable() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().continueWith(Collections.emptyList())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -123,7 +123,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyContinueWithSupplier() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().continueWith(() -> Arrays.asList(25, 26))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+                .subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertCompletedSuccessfully()
                 .assertReceived(25, 26);
     }
@@ -132,7 +132,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyContinueWithSupplierReturningEmpty() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().continueWith((Supplier<Iterable<? extends Integer>>) Collections::emptyList)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+                .subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -141,7 +141,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyContinueWithSupplierContainingNullItem() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().continueWith(() -> Arrays.asList(25, null, 26))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+                .subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertHasFailedWith(NullPointerException.class, null)
                 .assertReceived(25);
     }
@@ -150,7 +150,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyContinueWithSupplierReturningNull() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().continueWith(() -> (Iterable<Integer>) null)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+                .subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertHasFailedWith(NullPointerException.class, null);
     }
 
@@ -160,7 +160,7 @@ public class MultiIfEmptyTest {
                 .onCompletion().ifEmpty().continueWith((Supplier<? extends Iterable<? extends Integer>>) () -> {
                     throw new IllegalStateException("BOOM!");
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+                .subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertHasFailedWith(IllegalStateException.class, "BOOM!")
                 .assertHasNotReceivedAnyItem();
     }
@@ -169,7 +169,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyFail() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().fail()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertHasFailedWith(NoSuchElementException.class, null)
                 .assertHasNotReceivedAnyItem();
     }
@@ -178,7 +178,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyFailWithException() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().failWith(new IOException("boom"))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertHasFailedWith(IOException.class, "boom")
                 .assertHasNotReceivedAnyItem();
     }
@@ -194,7 +194,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyFailWithSupplier() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().failWith(() -> new IOException("boom"))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertHasFailedWith(IOException.class, "boom")
                 .assertHasNotReceivedAnyItem();
     }
@@ -211,7 +211,7 @@ public class MultiIfEmptyTest {
                 .onCompletion().ifEmpty().failWith(() -> {
                     throw new IllegalStateException("BOOM!");
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertHasFailedWith(IllegalStateException.class, "BOOM!");
     }
 
@@ -219,7 +219,7 @@ public class MultiIfEmptyTest {
     public void testIfEmptyFailWithSupplierReturningNull() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().failWith(() -> null)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertHasFailedWith(NullPointerException.class, null);
     }
 
@@ -227,7 +227,7 @@ public class MultiIfEmptyTest {
     public void testSwitchTo() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().switchTo(Flowable.just(20))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(20);
     }
@@ -236,7 +236,7 @@ public class MultiIfEmptyTest {
     public void testSwitchToSupplier() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().switchTo(() -> Multi.createFrom().range(5, 8))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(5, 6, 7);
     }
@@ -245,7 +245,7 @@ public class MultiIfEmptyTest {
     public void testSwitchToSupplierReturningNull() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().switchTo(() -> null)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(NullPointerException.class, null)
                 .assertHasNotReceivedAnyItem();
     }
@@ -266,7 +266,7 @@ public class MultiIfEmptyTest {
     public void testSwitchToWithConsumer() {
         Multi.createFrom().empty()
                 .onCompletion().ifEmpty().switchToEmitter(e -> e.emit(5).emit(6).complete())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(5, 6);
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIgnoreTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIgnoreTest.java
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletionException;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiIgnoreTest {
 
@@ -16,7 +16,7 @@ public class MultiIgnoreTest {
     public void test() {
         Multi.createFrom().items(1, 2, 3, 4)
                 .onItem().ignore()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -45,9 +45,9 @@ public class MultiIgnoreTest {
 
     @Test
     public void testWithNever() {
-        MultiAssertSubscriber<Void> subscriber = Multi.createFrom().nothing()
+        AssertSubscriber<Void> subscriber = Multi.createFrom().nothing()
                 .onItem().ignore()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .assertNotTerminated();
 
         subscriber.cancel();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiMergeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiMergeTest.java
@@ -9,17 +9,17 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiMergeTest {
 
     @Test
     public void testMergeOfSeveralMultis() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
+        AssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
                 Multi.createFrom().item(5),
                 Multi.createFrom().range(1, 3),
                 Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)).subscribe()
-                .withSubscriber(new MultiAssertSubscriber<>(100));
+                .withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(5, 1, 2, 9, 10, 11);
@@ -27,11 +27,11 @@ public class MultiMergeTest {
 
     @Test
     public void testMergeOfSeveralMultisWithDeprecatedApiApply() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
+        AssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
                 Multi.createFrom().item(5),
                 Multi.createFrom().range(1, 3),
                 Multi.createFrom().items(8, 9, 10).onItem().apply(i -> i + 1)).subscribe()
-                .withSubscriber(new MultiAssertSubscriber<>(100));
+                .withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(5, 1, 2, 9, 10, 11);
@@ -39,12 +39,12 @@ public class MultiMergeTest {
 
     @Test
     public void testMergeOfSeveralMultisWithConcurrencyAndRequests() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().merging().withConcurrency(2).withRequests(1)
+        AssertSubscriber<Integer> subscriber = Multi.createBy().merging().withConcurrency(2).withRequests(1)
                 .streams(
                         Multi.createFrom().item(5),
                         Multi.createFrom().range(1, 3),
                         Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1))
-                .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
+                .subscribe().withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(5, 1, 2, 9, 10, 11);
@@ -52,12 +52,12 @@ public class MultiMergeTest {
 
     @Test
     public void testMergeOfSeveralMultisAsIterable() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
+        AssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
                 Arrays.asList(
                         Multi.createFrom().item(5),
                         Multi.createFrom().range(1, 3),
                         Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)))
-                .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
+                .subscribe().withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(5, 1, 2, 9, 10, 11);
@@ -65,11 +65,11 @@ public class MultiMergeTest {
 
     @Test
     public void testMergeOfSeveralPublishers() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
+        AssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
                 Flowable.just(5),
                 Multi.createFrom().range(1, 3),
                 Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)).subscribe()
-                .withSubscriber(new MultiAssertSubscriber<>(100));
+                .withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(5, 1, 2, 9, 10, 11);
@@ -77,12 +77,12 @@ public class MultiMergeTest {
 
     @Test
     public void testMergeOfSeveralPublishersAsIterable() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
+        AssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
                 Arrays.asList(
                         Flowable.just(5),
                         Multi.createFrom().range(1, 3),
                         Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)))
-                .subscribe().withSubscriber(new MultiAssertSubscriber<>(100));
+                .subscribe().withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(5, 1, 2, 9, 10, 11);
@@ -91,14 +91,14 @@ public class MultiMergeTest {
     @Test
     public void testMergingEmpty() {
         Multi.createBy().merging().streams(Multi.createFrom().empty())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
 
     @Test
     public void testMergingWithEmpty() {
         Multi.createBy().merging().streams(Multi.createFrom().empty(), Multi.createFrom().item(2))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully().assertReceived(2);
     }
 
@@ -107,11 +107,11 @@ public class MultiMergeTest {
         IllegalStateException boom = new IllegalStateException("boom");
         IllegalStateException boom2 = new IllegalStateException("boom2");
 
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().collectFailures().streams(
+        AssertSubscriber<Integer> subscriber = Multi.createBy().concatenating().collectFailures().streams(
                 Multi.createFrom().item(5),
                 Multi.createFrom().failure(boom),
                 Multi.createFrom().item(6),
-                Multi.createFrom().failure(boom2)).subscribe().withSubscriber(new MultiAssertSubscriber<>(5));
+                Multi.createFrom().failure(boom2)).subscribe().withSubscriber(new AssertSubscriber<>(5));
 
         subscriber.assertTerminated()
                 .assertReceived(5, 6)
@@ -126,7 +126,7 @@ public class MultiMergeTest {
                 Multi.createFrom().item(5),
                 Multi.createFrom().failure(boom),
                 Multi.createFrom().item(6),
-                Multi.createFrom().failure(boom)).subscribe().withSubscriber(new MultiAssertSubscriber<>(5));
+                Multi.createFrom().failure(boom)).subscribe().withSubscriber(new AssertSubscriber<>(5));
 
         subscriber.assertTerminated()
                 .assertReceived(5)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnCancellationInvokeUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnCancellationInvokeUniTest.java
@@ -10,13 +10,13 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiOnCancellationInvokeUniTest {
 
     @Test
     public void testCancellationWithNoRequestedItem() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicReference<Integer> item = new AtomicReference<>();
         AtomicBoolean cancellation = new AtomicBoolean();
@@ -27,9 +27,9 @@ public class MultiOnCancellationInvokeUniTest {
                     cancellation.set(true);
                     return Uni.createFrom().item("value");
                 })
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.cancel()
+        subscriber.cancel()
                 .assertHasNotReceivedAnyItem()
                 .assertHasNotCompleted();
 
@@ -39,7 +39,7 @@ public class MultiOnCancellationInvokeUniTest {
 
     @Test
     public void testCancellationWithNoRequestedItemAndFailedUni() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicReference<Integer> item = new AtomicReference<>();
         AtomicBoolean cancellation = new AtomicBoolean();
@@ -50,9 +50,9 @@ public class MultiOnCancellationInvokeUniTest {
                     cancellation.set(true);
                     return Uni.createFrom().failure(new RuntimeException("bam"));
                 })
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.cancel()
+        subscriber.cancel()
                 .assertHasNotReceivedAnyItem()
                 .assertHasNotCompleted();
 
@@ -62,7 +62,7 @@ public class MultiOnCancellationInvokeUniTest {
 
     @Test
     public void testCancellationWithNoRequestedItemAndThrowingInvokeUni() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicReference<Integer> item = new AtomicReference<>();
         AtomicBoolean cancellation = new AtomicBoolean();
@@ -73,9 +73,9 @@ public class MultiOnCancellationInvokeUniTest {
                     cancellation.set(true);
                     throw new RuntimeException("bam");
                 })
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.cancel()
+        subscriber.cancel()
                 .assertHasNotReceivedAnyItem()
                 .assertHasNotCompleted();
 
@@ -85,7 +85,7 @@ public class MultiOnCancellationInvokeUniTest {
 
     @Test
     public void testCancellationAfterOneItem() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
 
         AtomicReference<Object> item = new AtomicReference<>();
         AtomicBoolean cancellation = new AtomicBoolean();
@@ -100,22 +100,22 @@ public class MultiOnCancellationInvokeUniTest {
                     cancellation.set(true);
                     return Uni.createFrom().item("value");
                 })
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.request(10);
+        subscriber.request(10);
 
         assertThat(item.get()).isEqualTo(1);
         assertThat(cancellation.get()).isFalse();
         assertThat(counter.get()).isEqualTo(0);
 
-        ts.cancel()
+        subscriber.cancel()
                 .assertHasNotCompleted()
                 .assertHasNotFailed();
 
         assertThat(cancellation.get()).isTrue();
         assertThat(counter.get()).isEqualTo(1);
 
-        ts.cancel();
+        subscriber.cancel();
         assertThat(counter.get()).isEqualTo(1);
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnCompletionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnCompletionTest.java
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiOnCompletionTest {
 
@@ -26,7 +26,7 @@ public class MultiOnCompletionTest {
         Multi.createFrom().range(1, 5)
                 .onCompletion().invoke(() -> called.set(true))
                 .onCompletion().continueWith(6, 7, 8)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4, 6, 7, 8);
 
@@ -39,7 +39,7 @@ public class MultiOnCompletionTest {
         Multi.createFrom().emitter(e -> e.emit(1).emit(2).fail(new IOException("boom")))
                 .onCompletion().invoke(() -> called.set(true))
                 .onCompletion().continueWith(6, 7, 8)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertHasFailedWith(IOException.class, "boom")
                 .assertReceived(1, 2);
 
@@ -50,7 +50,7 @@ public class MultiOnCompletionTest {
     public void testOnCompletionContinueWithEmpty() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().continueWith()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
     }
@@ -61,7 +61,7 @@ public class MultiOnCompletionTest {
         Multi.createFrom().range(1, 5)
                 .onCompletion().invoke(() -> called.set(true))
                 .onCompletion().continueWith(25)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4, 25);
 
@@ -74,7 +74,7 @@ public class MultiOnCompletionTest {
         Multi.createFrom().range(1, 5)
                 .onCompletion().invoke(() -> called.set(true))
                 .onCompletion().continueWith(Arrays.asList(5, 6))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4, 5, 6);
 
@@ -87,7 +87,7 @@ public class MultiOnCompletionTest {
         Multi.createFrom().range(1, 5)
                 .onCompletion().invoke(() -> called.set(true))
                 .onCompletion().continueWith(Collections.emptyList())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
 
@@ -102,7 +102,7 @@ public class MultiOnCompletionTest {
                     called.set(true);
                     throw new RuntimeException("bam");
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertHasFailedWith(RuntimeException.class, "bam");
 
         assertThat(called).isTrue();
@@ -142,7 +142,7 @@ public class MultiOnCompletionTest {
     public void testOnCompletionContinueWithSupplier() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().continueWith(() -> Arrays.asList(25, 26))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+                .subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4, 25, 26);
     }
@@ -151,7 +151,7 @@ public class MultiOnCompletionTest {
     public void testOnCompletionContinueWithSupplierReturningEmpty() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().continueWith((Supplier<Iterable<? extends Integer>>) Collections::emptyList)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+                .subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
     }
@@ -160,7 +160,7 @@ public class MultiOnCompletionTest {
     public void testOnCompletionContinueWithSupplierContainingNullItem() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().continueWith(() -> Arrays.asList(25, null, 26))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+                .subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertHasFailedWith(NullPointerException.class, null)
                 .assertReceived(1, 2, 3, 4, 25);
     }
@@ -169,7 +169,7 @@ public class MultiOnCompletionTest {
     public void testOnCompletionContinueWithSupplierReturningNull() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().continueWith(() -> (Iterable<Integer>) null)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+                .subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertHasFailedWith(NullPointerException.class, null)
                 .assertReceived(1, 2, 3, 4);
     }
@@ -180,7 +180,7 @@ public class MultiOnCompletionTest {
                 .onCompletion().continueWith((Supplier<? extends Iterable<? extends Integer>>) () -> {
                     throw new IllegalStateException("BOOM!");
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+                .subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertHasFailedWith(IllegalStateException.class, "BOOM!")
                 .assertReceived(1, 2, 3, 4);
     }
@@ -189,7 +189,7 @@ public class MultiOnCompletionTest {
     public void testOnCompletionFail() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().fail()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertReceived(1, 2, 3, 4)
                 .assertHasFailedWith(NoSuchElementException.class, null);
     }
@@ -198,7 +198,7 @@ public class MultiOnCompletionTest {
     public void testOnCompletionFailWithException() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().failWith(new IOException("boom"))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertReceived(1, 2, 3, 4)
                 .assertHasFailedWith(IOException.class, "boom");
     }
@@ -214,7 +214,7 @@ public class MultiOnCompletionTest {
     public void testOnCompletionFailWithSupplier() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().failWith(() -> new IOException("boom"))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertReceived(1, 2, 3, 4)
                 .assertHasFailedWith(IOException.class, "boom");
     }
@@ -231,7 +231,7 @@ public class MultiOnCompletionTest {
                 .onCompletion().failWith(() -> {
                     throw new IllegalStateException("BOOM!");
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertReceived(1, 2, 3, 4)
                 .assertHasFailedWith(IllegalStateException.class, "BOOM!");
     }
@@ -240,7 +240,7 @@ public class MultiOnCompletionTest {
     public void testOnCompletionFailWithSupplierReturningNull() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().failWith(() -> null)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .assertReceived(1, 2, 3, 4)
                 .assertHasFailedWith(NullPointerException.class, null);
     }
@@ -249,7 +249,7 @@ public class MultiOnCompletionTest {
     public void testSwitchTo() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().switchTo(Flowable.just(20))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4, 20);
     }
@@ -258,7 +258,7 @@ public class MultiOnCompletionTest {
     public void testSwitchToSupplier() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().switchTo(() -> Multi.createFrom().range(5, 8))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4, 5, 6, 7);
     }
@@ -267,7 +267,7 @@ public class MultiOnCompletionTest {
     public void testSwitchToSupplierReturningNull() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().switchTo(() -> null)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(NullPointerException.class, null)
                 .assertReceived(1, 2, 3, 4);
     }
@@ -288,7 +288,7 @@ public class MultiOnCompletionTest {
     public void testSwitchToWithConsumer() {
         Multi.createFrom().range(1, 5)
                 .onCompletion().switchToEmitter(e -> e.emit(5).emit(6).complete())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4, 5, 6);
     }
@@ -302,7 +302,7 @@ public class MultiOnCompletionTest {
                     called.set(true);
                     return Uni.createFrom().item(69);
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
 
@@ -318,13 +318,14 @@ public class MultiOnCompletionTest {
                     called.set(true);
                     return Uni.createFrom().failure(new RuntimeException("bam"));
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertReceived(1, 2, 3, 4)
                 .assertHasFailedWith(RuntimeException.class, "bam");
 
         assertThat(called).isTrue();
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void testInvokeUniThatThrowsException() {
         AtomicBoolean called = new AtomicBoolean();
@@ -334,7 +335,7 @@ public class MultiOnCompletionTest {
                     called.set(true);
                     throw new RuntimeException("bam");
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7))
+                .subscribe().withSubscriber(AssertSubscriber.create(7))
                 .assertReceived(1, 2, 3, 4)
                 .assertHasFailedWith(RuntimeException.class, "bam");
 
@@ -347,7 +348,7 @@ public class MultiOnCompletionTest {
         AtomicBoolean uniCancelled = new AtomicBoolean();
         AtomicInteger counter = new AtomicInteger();
 
-        MultiAssertSubscriber<Integer> ts = Multi.createFrom().range(1, 5)
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().range(1, 5)
                 .onCompletion().invokeUni(() -> {
                     called.set(true);
                     counter.incrementAndGet();
@@ -359,20 +360,20 @@ public class MultiOnCompletionTest {
                                 uniCancelled.set(true);
                             });
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(7));
+                .subscribe().withSubscriber(AssertSubscriber.create(7));
 
-        ts.assertReceived(1, 2, 3, 4);
-        ts.assertHasNotCompleted();
+        subscriber.assertReceived(1, 2, 3, 4);
+        subscriber.assertHasNotCompleted();
         assertThat(called.get()).isTrue();
         assertThat(uniCancelled.get()).isFalse();
         assertThat(counter.get()).isEqualTo(1);
 
-        ts.cancel();
-        ts.assertHasNotCompleted();
+        subscriber.cancel();
+        subscriber.assertHasNotCompleted();
         assertThat(uniCancelled.get()).isTrue();
         assertThat(counter.get()).isEqualTo(2);
 
-        ts.cancel();
+        subscriber.cancel();
         assertThat(counter.get()).isEqualTo(2);
     }
 
@@ -380,7 +381,7 @@ public class MultiOnCompletionTest {
     public void rogueEmittersInvoke() {
         AtomicInteger counter = new AtomicInteger();
 
-        MultiAssertSubscriber<Object> ts = Multi.createFrom()
+        AssertSubscriber<Object> subscriber = Multi.createFrom()
                 .emitter(e -> {
                     Thread t1 = new Thread(e::complete);
                     Thread t2 = new Thread(e::complete);
@@ -394,9 +395,9 @@ public class MultiOnCompletionTest {
                     }
                 })
                 .onCompletion().invoke(counter::incrementAndGet)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
 
-        ts.assertCompletedSuccessfully();
+        subscriber.assertCompletedSuccessfully();
         assertThat(counter.get()).isEqualTo(1);
     }
 
@@ -404,7 +405,7 @@ public class MultiOnCompletionTest {
     public void rogueEmittersInvokeUni() {
         AtomicInteger counter = new AtomicInteger();
 
-        MultiAssertSubscriber<Object> ts = Multi.createFrom()
+        AssertSubscriber<Object> subscriber = Multi.createFrom()
                 .emitter(e -> {
                     Thread t1 = new Thread(e::complete);
                     Thread t2 = new Thread(e::complete);
@@ -421,9 +422,9 @@ public class MultiOnCompletionTest {
                     counter.incrementAndGet();
                     return Uni.createFrom().item(69);
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
 
-        ts.assertCompletedSuccessfully();
+        subscriber.assertCompletedSuccessfully();
         assertThat(counter.get()).isEqualTo(1);
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnEventTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnEventTest.java
@@ -20,14 +20,14 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 import io.smallrye.mutiny.subscription.Cancellable;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 @SuppressWarnings("deprecation")
 public class MultiOnEventTest {
 
     @Test
     public void testCallbacksWhenItemIsEmitted() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicReference<Integer> item = new AtomicReference<>();
@@ -47,9 +47,9 @@ public class MultiOnEventTest {
                 .onTermination().invoke(() -> termination2.set(true))
                 .onRequest().invoke(requests::set)
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe(ts);
+                .subscribe(subscriber);
 
-        ts
+        subscriber
                 .request(20)
                 .assertCompletedSuccessfully()
                 .assertReceived(1);
@@ -66,7 +66,7 @@ public class MultiOnEventTest {
 
     @Test
     public void testCallbacksWhenItemIsEmittedUsingOnAndThenGroup() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicReference<Integer> item = new AtomicReference<>();
@@ -86,9 +86,9 @@ public class MultiOnEventTest {
                 .on().termination().invoke(() -> termination2.set(true))
                 .on().request().invoke(requests::set)
                 .on().cancellation().invoke(() -> cancellation.set(true))
-                .subscribe(ts);
+                .subscribe(subscriber);
 
-        ts
+        subscriber
                 .request(20)
                 .assertCompletedSuccessfully()
                 .assertReceived(1);
@@ -105,7 +105,7 @@ public class MultiOnEventTest {
 
     @Test
     public void testCallbacksWhenItemIsEmittedWithDeprecatedApis() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicReference<Integer> item = new AtomicReference<>();
@@ -125,9 +125,9 @@ public class MultiOnEventTest {
                 .onTermination().invoke(() -> termination2.set(true))
                 .on().request(requests::set)
                 .on().cancellation(() -> cancellation.set(true))
-                .subscribe(ts);
+                .subscribe(subscriber);
 
-        ts
+        subscriber
                 .request(20)
                 .assertCompletedSuccessfully()
                 .assertReceived(1);
@@ -144,7 +144,7 @@ public class MultiOnEventTest {
 
     @Test
     public void testCallbacksWhenItemIsEmittedWithDeprecatedOnTermination() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicReference<Integer> item = new AtomicReference<>();
@@ -164,9 +164,9 @@ public class MultiOnEventTest {
                 .on().termination(() -> termination2.set(true))
                 .on().request(requests::set)
                 .on().cancellation(() -> cancellation.set(true))
-                .subscribe(ts);
+                .subscribe(subscriber);
 
-        ts
+        subscriber
                 .request(20)
                 .assertCompletedSuccessfully()
                 .assertReceived(1);
@@ -201,7 +201,7 @@ public class MultiOnEventTest {
                 .onTermination().invoke(() -> termination2.set(true))
                 .onRequest().invoke(requests::set)
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create())
+                .subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasFailedWith(IOException.class, "boom");
 
         assertThat(subscription.get()).isNotNull();
@@ -234,7 +234,7 @@ public class MultiOnEventTest {
                 .on().termination(() -> termination2.set(true))
                 .on().request(requests::set)
                 .on().cancellation(() -> cancellation.set(true))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create())
+                .subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasFailedWith(IOException.class, "boom");
 
         assertThat(subscription.get()).isNotNull();
@@ -265,7 +265,7 @@ public class MultiOnEventTest {
                 .onTermination().invoke((f, c) -> termination.set(f != null))
                 .onRequest().invoke(requests::set)
                 .on().cancellation(() -> cancellation.set(true))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create())
+                .subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasFailedWith(IOException.class, "boom");
 
         assertThat(subscription.get()).isNotNull();
@@ -295,7 +295,7 @@ public class MultiOnEventTest {
                 .onTermination().invoke((f, c) -> termination.set(f != null))
                 .onRequest().invoke(requests::set)
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create())
+                .subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasFailedWith(IOException.class, "boom");
 
         assertThat(subscription.get()).isNotNull();
@@ -329,7 +329,7 @@ public class MultiOnEventTest {
                 .onTermination().invoke((f, c) -> termination.set(f != null))
                 .onRequest().invoke(requests::set)
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create())
+                .subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasFailedWith(CompositeException.class, "bigboom")
                 .assertHasFailedWith(CompositeException.class, "smallboom");
 
@@ -362,7 +362,7 @@ public class MultiOnEventTest {
                 .onTermination().invoke(() -> termination2.set(true))
                 .onRequest().invoke(requests::set)
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create())
+                .subscribe().withSubscriber(AssertSubscriber.create())
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
 
@@ -387,7 +387,7 @@ public class MultiOnEventTest {
         AtomicBoolean termination2 = new AtomicBoolean();
         AtomicBoolean cancellation = new AtomicBoolean();
 
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> nothing()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> nothing()
                 .on().subscribed(subscription::set)
                 .on().item().invoke(item::set)
                 .on().failure().invoke(failure::set)
@@ -396,7 +396,7 @@ public class MultiOnEventTest {
                 .onTermination().invoke(() -> termination2.set(true))
                 .onRequest().invoke(requests::set)
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertNotTerminated()
                 .assertHasNotReceivedAnyItem();
 
@@ -417,26 +417,26 @@ public class MultiOnEventTest {
 
     @Test
     public void testWhenOnItemPeekThrowsExceptions() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
 
         Multi.createFrom().item(1)
                 .on().item().invoke(i -> {
                     throw new IllegalArgumentException("boom");
                 })
-                .subscribe().withSubscriber(ts)
+                .subscribe().withSubscriber(subscriber)
                 .assertTerminated()
                 .assertHasFailedWith(IllegalArgumentException.class, "boom");
     }
 
     @Test
     public void testWhenOnFailurePeekThrowsExceptions() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
 
         Multi.createFrom().<Integer> failure(new IOException("source"))
                 .on().failure().invoke(f -> {
                     throw new IllegalArgumentException("boom");
                 })
-                .subscribe().withSubscriber(ts)
+                .subscribe().withSubscriber(subscriber)
                 .assertTerminated()
                 .assertHasFailedWith(CompositeException.class, "boom")
                 .assertHasFailedWith(CompositeException.class, "source");
@@ -444,13 +444,13 @@ public class MultiOnEventTest {
 
     @Test
     public void testWhenOnCompletionPeekThrowsExceptions() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
 
         Multi.createFrom().items(1, 2)
                 .onCompletion().invoke(() -> {
                     throw new IllegalArgumentException("boom");
                 })
-                .subscribe().withSubscriber(ts)
+                .subscribe().withSubscriber(subscriber)
                 .assertNotTerminated()
                 .assertReceived(1)
                 .request(1)
@@ -466,7 +466,7 @@ public class MultiOnEventTest {
                     throw new IllegalArgumentException("boom1");
                 }).on().failure().invoke(t -> {
                     throw new IllegalArgumentException("boom2");
-                }).subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                }).subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertTerminated()
                 .assertHasFailedWith(CompositeException.class, "boom1")
                 .assertHasFailedWith(CompositeException.class, "boom2");
@@ -479,7 +479,7 @@ public class MultiOnEventTest {
                 .onTermination().invoke((f, c) -> {
                     called.incrementAndGet();
                     throw new IllegalArgumentException("boom");
-                }).subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                }).subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertHasFailedWith(IllegalArgumentException.class, "boom");
 
         assertThat(called).hasValue(1);
@@ -492,7 +492,7 @@ public class MultiOnEventTest {
                 .onTermination().invoke((f, c) -> {
                     called.incrementAndGet();
                     throw new IllegalArgumentException("boom");
-                }).subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                }).subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertHasFailedWith(CompositeException.class, "boom")
                 .assertHasFailedWith(CompositeException.class, "IO");
 
@@ -506,7 +506,7 @@ public class MultiOnEventTest {
                 .onTermination().invoke(() -> {
                     called.incrementAndGet();
                     throw new IllegalArgumentException("boom");
-                }).subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                }).subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertHasFailedWith(IllegalArgumentException.class, "boom");
 
         assertThat(called).hasValue(1);
@@ -519,8 +519,8 @@ public class MultiOnEventTest {
         Multi<Integer> multi = Multi.createFrom().publisher(processor)
                 .onTermination().invoke(invocations::incrementAndGet);
 
-        MultiAssertSubscriber<Integer> subscriber = multi
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> subscriber = multi
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
         assertThat(invocations).hasValue(0);
         processor.onNext(1);
         assertThat(invocations).hasValue(0);
@@ -539,8 +539,8 @@ public class MultiOnEventTest {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
         Multi<Integer> multi = Multi.createFrom().publisher(processor)
                 .onTermination().invoke(invocations::incrementAndGet);
-        MultiAssertSubscriber<Integer> subscriber = multi
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> subscriber = multi
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
         assertThat(invocations).hasValue(0);
         processor.onNext(1);
         assertThat(invocations).hasValue(0);
@@ -559,8 +559,8 @@ public class MultiOnEventTest {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
         Multi<Integer> multi = Multi.createFrom().publisher(processor)
                 .onTermination().invoke(invocations::incrementAndGet);
-        MultiAssertSubscriber<Integer> subscriber = multi
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> subscriber = multi
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
         assertThat(invocations).hasValue(0);
         processor.onNext(1);
         assertThat(invocations).hasValue(0);
@@ -579,8 +579,8 @@ public class MultiOnEventTest {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
         Multi<Integer> multi = Multi.createFrom().publisher(processor)
                 .onTermination().invoke(invocations::incrementAndGet);
-        MultiAssertSubscriber<Integer> subscriber = multi
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> subscriber = multi
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
         assertThat(invocations).hasValue(0);
         processor.onNext(1);
         subscriber.cancel();
@@ -595,11 +595,11 @@ public class MultiOnEventTest {
     @Test
     public void testThatPredicateFailureProduceCompositeException() {
         AtomicBoolean called = new AtomicBoolean();
-        MultiAssertSubscriber<Object> subscriber = Multi.createFrom().failure(new IOException("boom"))
+        AssertSubscriber<Object> subscriber = Multi.createFrom().failure(new IOException("boom"))
                 .onFailure(t -> {
                     throw new NullPointerException();
                 }).invoke(t -> called.set(true))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1));
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(CompositeException.class, "boom");
         CompositeException failure = (CompositeException) subscriber.failures().get(0);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureInvokeUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureInvokeUniTest.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiOnFailureInvokeUniTest {
 
@@ -27,10 +27,10 @@ public class MultiOnFailureInvokeUniTest {
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicInteger twoGotCalled = new AtomicInteger();
 
-        MultiAssertSubscriber<Integer> subscriber = numbers.onFailure().invokeUni(i -> {
+        AssertSubscriber<Integer> subscriber = numbers.onFailure().invokeUni(i -> {
             failure.set(i);
             return sub.onItem().invoke(c -> twoGotCalled.incrementAndGet());
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        }).subscribe().withSubscriber(AssertSubscriber.create(10));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(1, 2);
@@ -43,10 +43,10 @@ public class MultiOnFailureInvokeUniTest {
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicInteger twoGotCalled = new AtomicInteger();
 
-        MultiAssertSubscriber<Integer> subscriber = failed.onFailure().invokeUni(i -> {
+        AssertSubscriber<Integer> subscriber = failed.onFailure().invokeUni(i -> {
             failure.set(i);
             return sub.onItem().invoke(c -> twoGotCalled.incrementAndGet());
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        }).subscribe().withSubscriber(AssertSubscriber.create(10));
 
         subscriber.assertHasFailedWith(IOException.class, "boom")
                 .assertReceived(1, 2);
@@ -58,10 +58,10 @@ public class MultiOnFailureInvokeUniTest {
     public void testFailureInAsyncCallback() {
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
-        MultiAssertSubscriber<Integer> subscriber = failed.onFailure().invokeUni(i -> {
+        AssertSubscriber<Integer> subscriber = failed.onFailure().invokeUni(i -> {
             failure.set(i);
             throw new RuntimeException("kaboom");
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        }).subscribe().withSubscriber(AssertSubscriber.create(10));
 
         subscriber
                 .assertHasFailedWith(CompositeException.class, "boom")
@@ -74,10 +74,10 @@ public class MultiOnFailureInvokeUniTest {
     public void testNullReturnedByAsyncCallback() {
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
-        MultiAssertSubscriber<Integer> subscriber = failed.onFailure().invokeUni(i -> {
+        AssertSubscriber<Integer> subscriber = failed.onFailure().invokeUni(i -> {
             failure.set(i);
             return null;
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        }).subscribe().withSubscriber(AssertSubscriber.create(10));
 
         subscriber
                 .assertHasFailedWith(CompositeException.class, "boom")
@@ -90,10 +90,10 @@ public class MultiOnFailureInvokeUniTest {
     public void testInvokeUniWithSubFailure() {
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
-        MultiAssertSubscriber<Integer> subscriber = failed.onFailure().invokeUni(i -> {
+        AssertSubscriber<Integer> subscriber = failed.onFailure().invokeUni(i -> {
             failure.set(i);
             return Uni.createFrom().failure(new IllegalStateException("d'oh"));
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        }).subscribe().withSubscriber(AssertSubscriber.create(10));
 
         subscriber
                 .assertHasFailedWith(CompositeException.class, "boom")
@@ -107,8 +107,8 @@ public class MultiOnFailureInvokeUniTest {
         AtomicBoolean terminated = new AtomicBoolean();
         Uni<Object> uni = Uni.createFrom().emitter(e -> e.onTermination(() -> terminated.set(true)));
 
-        MultiAssertSubscriber<Integer> subscriber = failed.onFailure().invokeUni(i -> uni)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> subscriber = failed.onFailure().invokeUni(i -> uni)
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
 
         subscriber.cancel();
         //noinspection ConstantConditions

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryTest.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.groups.MultiRetry;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiOnFailureRetryTest {
 
@@ -46,7 +46,7 @@ public class MultiOnFailureRetryTest {
 
     @Test
     public void testNoRetryOnNoFailure() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(5);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(5);
 
         Multi.createFrom().range(1, 4)
                 .onFailure().retry().atMost(5)
@@ -59,7 +59,7 @@ public class MultiOnFailureRetryTest {
 
     @Test
     public void testWithASingleRetry() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
 
         failing
                 .onFailure().retry().atMost(1)
@@ -75,7 +75,7 @@ public class MultiOnFailureRetryTest {
 
     @Test
     public void testWithASingleRetryAndRequests() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(0);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(0);
 
         failing
                 .onFailure().retry().atMost(1)
@@ -96,7 +96,7 @@ public class MultiOnFailureRetryTest {
 
     @Test
     public void testRetryIndefinitely() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(20);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(20);
 
         failing.onFailure().retry().indefinitely()
                 .subscribe().withSubscriber(subscriber);
@@ -118,7 +118,7 @@ public class MultiOnFailureRetryTest {
                     }
                 })
                 .onFailure().retry().atMost(2)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryUntilTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryUntilTest.java
@@ -10,7 +10,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiOnFailureRetryUntilTest {
 
@@ -29,7 +29,7 @@ public class MultiOnFailureRetryUntilTest {
     @Test
     public void testWithoutFailure() {
         Multi<Integer> upstream = Multi.createFrom().range(0, 4);
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
         upstream
                 .onFailure().retry().until(t -> true)
                 .subscribe().withSubscriber(subscriber);
@@ -52,7 +52,7 @@ public class MultiOnFailureRetryUntilTest {
             em.complete();
         });
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
         upstream
                 .onFailure().retry().until(t -> true)
                 .subscribe(subscriber);
@@ -67,7 +67,7 @@ public class MultiOnFailureRetryUntilTest {
             em.emit(1);
             em.fail(new Exception("boom"));
         });
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
 
         upstream
                 .onFailure().retry().until(retryTwice)
@@ -91,7 +91,7 @@ public class MultiOnFailureRetryUntilTest {
             em.complete();
         });
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
         upstream
                 .onFailure().retry().until(retryOnIoException).subscribe().withSubscriber(subscriber);
 
@@ -117,7 +117,7 @@ public class MultiOnFailureRetryUntilTest {
             em.emit(3);
             em.fail(ise);
         });
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
         upstream
                 .onFailure().retry().until(retryOnIoException)
                 .subscribe().withSubscriber(subscriber);
@@ -131,9 +131,9 @@ public class MultiOnFailureRetryUntilTest {
     public void testUnsubscribeFromRetry() {
         UnicastProcessor<Integer> processor = UnicastProcessor.create();
 
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().publisher(processor)
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().publisher(processor)
                 .onFailure().retry().until(retryTwice)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext(1);
         subscriber.cancel();
@@ -158,7 +158,7 @@ public class MultiOnFailureRetryUntilTest {
             em.complete();
         });
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
         upstream
                 .onFailure().retry().until(t -> {
                     throw new IllegalStateException("boom");
@@ -183,7 +183,7 @@ public class MultiOnFailureRetryUntilTest {
             em.complete();
         });
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
         upstream
                 .onFailure().retry().until(t -> false)
                 .subscribe().withSubscriber(subscriber);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureTest.java
@@ -12,13 +12,13 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiEmitter;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiOnFailureTest {
 
     @Test
     public void testThatRecoverWithMultiNotCalledWhenNoFailure() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(20);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(20);
 
         Multi.createFrom().range(1, 10)
                 .onFailure().recoverWithMulti(v -> Multi.createFrom().range(50, 100))
@@ -31,7 +31,7 @@ public class MultiOnFailureTest {
 
     @Test
     public void testRecoverWithMultiWithFailure() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(20);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(20);
 
         Multi.createFrom().<Integer> failure(new IllegalStateException("boom"))
                 .onFailure().recoverWithMulti(v -> Multi.createFrom().range(50, 52))
@@ -44,7 +44,7 @@ public class MultiOnFailureTest {
 
     @Test
     public void testRecoverWithMultiWithPredicate() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
 
         Multi.createFrom().<Integer> failure(new IllegalStateException("boom"))
                 .onFailure(IllegalStateException.class).recoverWithMulti(v -> Multi.createFrom().item(42))
@@ -57,7 +57,7 @@ public class MultiOnFailureTest {
 
     @Test
     public void testRecoverWithMultiWithPredicateNotPassing() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
 
         Multi.createFrom().<Integer> failure(new IllegalStateException("boom"))
                 .onFailure(IOException.class).recoverWithMulti(v -> Multi.createFrom().item(42))
@@ -68,7 +68,7 @@ public class MultiOnFailureTest {
 
     @Test
     public void testRecoverWithMultiWithPredicateThrowingException() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
 
         Multi.createFrom().<Integer> failure(new IllegalStateException("boom"))
                 .onFailure(f -> {
@@ -83,7 +83,7 @@ public class MultiOnFailureTest {
 
     @Test
     public void testOnFailureMap() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         Multi.createFrom().<Integer> failure(new IllegalStateException("boom"))
                 .onFailure().transform(f -> new IOException("kaboom!"))
@@ -96,7 +96,7 @@ public class MultiOnFailureTest {
 
     @Test
     public void testOnFailureMapWithDeprecatedApiApply() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         Multi.createFrom().<Integer> failure(new IllegalStateException("boom"))
                 .onFailure().apply(f -> new IOException("kaboom!"))
@@ -109,7 +109,7 @@ public class MultiOnFailureTest {
 
     @Test
     public void testRequestOnTheMultiReturnedByRecoverWithMulti() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(0);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(0);
 
         Multi.createFrom()
                 .<Integer> failure(new IllegalStateException("boom"))
@@ -138,7 +138,7 @@ public class MultiOnFailureTest {
 
     @Test
     public void testRecoverWithMultiWithSomeResulsubscriberBeforeFailing() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(20);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(20);
 
         AtomicReference<MultiEmitter<? super Integer>> reference = new AtomicReference<>();
         Multi.createFrom().<Integer> emitter(reference::set)
@@ -161,7 +161,7 @@ public class MultiOnFailureTest {
 
     @Test
     public void testRecoverWithMultiWithSomeResulsubscriberBeforeFailingWithRequessubscriber() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(3);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(3);
 
         AtomicReference<MultiEmitter<? super Integer>> reference = new AtomicReference<>();
         Multi.createFrom().<Integer> emitter(reference::set)
@@ -187,7 +187,7 @@ public class MultiOnFailureTest {
 
     @Test
     public void testWhenRecoverWithMultiIsAlsoAFailure() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(0);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(0);
 
         Multi.createFrom().<Integer> failure(new IOException("karambar"))
                 .onFailure().recoverWithMulti(v -> {
@@ -203,7 +203,7 @@ public class MultiOnFailureTest {
 
     @Test
     public void testWhenRecoverWithMultiReturnsNull() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(0);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(0);
 
         Multi.createFrom().<Integer> failure(new IOException("karambar"))
                 .onFailure().recoverWithMulti(v -> null)
@@ -218,7 +218,7 @@ public class MultiOnFailureTest {
     public void testRecoverWithItem() {
         Multi.createFrom().<Integer> failure(new IllegalStateException("boom"))
                 .onFailure().recoverWithItem(42)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully()
                 .assertReceived(42);
     }
@@ -229,12 +229,12 @@ public class MultiOnFailureTest {
         Multi<Integer> multi = Multi.createFrom().<Integer> failure(new IllegalStateException("boom"))
                 .onFailure().recoverWithItem(count::incrementAndGet);
         multi
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully()
                 .assertReceived(1);
 
         multi
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully()
                 .assertReceived(2);
     }
@@ -255,7 +255,7 @@ public class MultiOnFailureTest {
     public void testRecoverWithItemAndSupplierReturningNull() {
         Multi.createFrom().<Integer> failure(new IllegalStateException("boom"))
                 .onFailure().recoverWithItem(() -> null)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertHasFailedWith(CompositeException.class, "boom")
                 .assertHasFailedWith(CompositeException.class, "supplier");
     }
@@ -264,7 +264,7 @@ public class MultiOnFailureTest {
     public void testRecoverWithCompletion() {
         Multi.createFrom().<Integer> failure(new IllegalStateException("boom"))
                 .onFailure().recoverWithCompletion()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -284,7 +284,7 @@ public class MultiOnFailureTest {
 
         multi.onFailure()
                 .recoverWithMulti(fallback)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(0))
+                .subscribe().withSubscriber(AssertSubscriber.create(0))
                 .assertSubscribed()
                 .assertHasNotReceivedAnyItem()
                 .request(2)
@@ -313,7 +313,7 @@ public class MultiOnFailureTest {
 
         multi.onFailure()
                 .recoverWithMulti(fallback)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(0))
+                .subscribe().withSubscriber(AssertSubscriber.create(0))
                 .assertSubscribed()
                 .assertHasNotReceivedAnyItem()
                 .request(2)
@@ -330,7 +330,7 @@ public class MultiOnFailureTest {
         Multi.createFrom().<Integer> failure(new IOException())
                 .onFailure(IOException.class::isInstance)
                 .transform(e -> new Exception("BOOM!!!"))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(0))
+                .subscribe().withSubscriber(AssertSubscriber.create(0))
                 .assertHasFailedWith(Exception.class, "BOOM!!!");
     }
 
@@ -339,18 +339,18 @@ public class MultiOnFailureTest {
         Multi.createFrom().<Integer> failure(new RuntimeException("first"))
                 .onFailure(IOException.class::isInstance)
                 .transform(e -> new Exception("BOOM!!!"))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(0))
+                .subscribe().withSubscriber(AssertSubscriber.create(0))
                 .assertHasFailedWith(RuntimeException.class, "first");
     }
 
     @Test
     public void testOnFailureMapWithPredicateThrowingException() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> failure(new RuntimeException("first"))
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> failure(new RuntimeException("first"))
                 .onFailure(f -> {
                     throw new IllegalArgumentException("bad");
                 })
                 .transform(e -> new Exception("BOOM"))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(0))
+                .subscribe().withSubscriber(AssertSubscriber.create(0))
                 .assertHasFailedWith(CompositeException.class, "first")
                 .assertHasFailedWith(CompositeException.class, "bad");
 
@@ -361,7 +361,7 @@ public class MultiOnFailureTest {
     public void testOnFailureRecoverWithItemAndPredicate() {
         Multi.createFrom().<Integer> failure(new IOException())
                 .onFailure(IOException.class::isInstance).recoverWithItem(42)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully()
                 .assertReceived(42);
     }
@@ -370,7 +370,7 @@ public class MultiOnFailureTest {
     public void testOnFailureRecoverWithItemAndPredicateNotPassing() {
         Multi.createFrom().<Integer> failure(new IOException("boom"))
                 .onFailure(IllegalStateException.class::isInstance).recoverWithItem(42)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertHasFailedWith(IOException.class, "boom");
     }
 
@@ -378,7 +378,7 @@ public class MultiOnFailureTest {
     public void testOnFailureRecoverWithCompletionAndPredicate() {
         Multi.createFrom().<Integer> failure(new IOException())
                 .onFailure(IOException.class::isInstance).recoverWithCompletion()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnOverflowTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnOverflowTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
 import io.smallrye.mutiny.subscription.MultiEmitter;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiOnOverflowTest {
 
@@ -25,7 +25,7 @@ public class MultiOnOverflowTest {
 
     @Test
     public void testDropStrategy() {
-        MultiAssertSubscriber<Integer> sub = MultiAssertSubscriber.create(20);
+        AssertSubscriber<Integer> sub = AssertSubscriber.create(20);
         Multi.createFrom().range(1, 10)
                 .onOverflow().drop()
                 .subscribe(sub);
@@ -37,13 +37,13 @@ public class MultiOnOverflowTest {
     public void testDropStrategyWithUpstreamFailure() {
         Multi.createFrom().<Integer> failure(new IOException("boom"))
                 .onOverflow().drop()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertHasFailedWith(IOException.class, "boom");
     }
 
     @Test
     public void testDropStrategyWithBackPressure() {
-        MultiAssertSubscriber<Integer> sub = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> sub = AssertSubscriber.create();
         Multi.createFrom().range(1, 10)
                 .onOverflow().drop()
                 .subscribe(sub);
@@ -53,7 +53,7 @@ public class MultiOnOverflowTest {
 
     @Test
     public void testDropStrategyWithEmitter() {
-        MultiAssertSubscriber<Integer> sub = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> sub = AssertSubscriber.create();
         AtomicReference<MultiEmitter<? super Integer>> emitter = new AtomicReference<>();
         List<Integer> list = new CopyOnWriteArrayList<>();
         Multi<Integer> multi = Multi.createFrom().emitter((Consumer<MultiEmitter<? super Integer>>) emitter::set)
@@ -72,7 +72,7 @@ public class MultiOnOverflowTest {
 
     @Test
     public void testDropStrategyWithEmitterWithoutCallback() {
-        MultiAssertSubscriber<Integer> sub = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> sub = AssertSubscriber.create();
         AtomicReference<MultiEmitter<? super Integer>> emitter = new AtomicReference<>();
         Multi<Integer> multi = Multi.createFrom().emitter((Consumer<MultiEmitter<? super Integer>>) emitter::set)
                 .onOverflow().drop();
@@ -93,7 +93,7 @@ public class MultiOnOverflowTest {
                 .onOverflow().drop(i -> {
                     throw new IllegalStateException("boom");
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create())
+                .subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasFailedWith(IllegalStateException.class, "boom");
 
     }
@@ -101,14 +101,14 @@ public class MultiOnOverflowTest {
     @Test
     public void testDropStrategyWithRequests() {
         Multi.createFrom().range(1, 10).onOverflow().drop()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(5))
+                .subscribe().withSubscriber(AssertSubscriber.create(5))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4, 5);
     }
 
     @Test
     public void testDropPreviousStrategy() {
-        MultiAssertSubscriber<Integer> sub = MultiAssertSubscriber.create(20);
+        AssertSubscriber<Integer> sub = AssertSubscriber.create(20);
         Multi.createFrom().range(1, 10)
                 .onOverflow().dropPreviousItems()
                 .subscribe(sub);
@@ -118,7 +118,7 @@ public class MultiOnOverflowTest {
 
     @Test
     public void testDropPreviousStrategyWithBackPressure() {
-        MultiAssertSubscriber<Integer> sub = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> sub = AssertSubscriber.create(1);
         Multi.createFrom().range(1, 1000)
                 .onOverflow().dropPreviousItems()
                 .subscribe(sub);
@@ -128,7 +128,7 @@ public class MultiOnOverflowTest {
         sub.assertCompletedSuccessfully();
         assertThat(sub.items()).containsExactly(1, 999);
 
-        sub = MultiAssertSubscriber.create(0);
+        sub = AssertSubscriber.create(0);
         Multi.createFrom().range(1, 1000)
                 .onOverflow().dropPreviousItems()
                 .subscribe(sub);
@@ -141,7 +141,7 @@ public class MultiOnOverflowTest {
 
     @Test
     public void testDropPreviousStrategyWithEmitter() {
-        MultiAssertSubscriber<Integer> sub = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> sub = AssertSubscriber.create();
         AtomicReference<MultiEmitter<? super Integer>> emitter = new AtomicReference<>();
         Multi<Integer> multi = Multi.createFrom().emitter((Consumer<MultiEmitter<? super Integer>>) emitter::set)
                 .onOverflow().dropPreviousItems();
@@ -172,13 +172,13 @@ public class MultiOnOverflowTest {
     public void testDropPreviousStrategyWithUpstreamFailure() {
         Multi.createFrom().<Integer> failure(new IOException("boom"))
                 .onOverflow().dropPreviousItems()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertHasFailedWith(IOException.class, "boom");
     }
 
     @Test
     public void testBufferStrategy() {
-        MultiAssertSubscriber<Integer> sub = MultiAssertSubscriber.create(20);
+        AssertSubscriber<Integer> sub = AssertSubscriber.create(20);
         Multi.createFrom().range(1, 10)
                 .onOverflow().buffer()
                 .subscribe(sub);
@@ -190,7 +190,7 @@ public class MultiOnOverflowTest {
     public void testBufferStrategyWithUpstreamFailure() {
         Multi.createFrom().<Integer> failure(new IOException("boom"))
                 .onOverflow().buffer()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertHasFailedWith(IOException.class, "boom");
     }
 
@@ -204,7 +204,7 @@ public class MultiOnOverflowTest {
 
     @Test
     public void testBufferStrategyWithBackPressure() {
-        MultiAssertSubscriber<Integer> sub = MultiAssertSubscriber.create(0);
+        AssertSubscriber<Integer> sub = AssertSubscriber.create(0);
         Multi.createFrom().range(1, 100)
                 .onOverflow().buffer()
                 .subscribe(sub);
@@ -218,7 +218,7 @@ public class MultiOnOverflowTest {
 
     @Test
     public void testBufferStrategyWithBufferTooSmall() {
-        MultiAssertSubscriber<Integer> sub = MultiAssertSubscriber.create(5);
+        AssertSubscriber<Integer> sub = AssertSubscriber.create(5);
         Multi.createFrom().range(1, 100)
                 .onOverflow().buffer(20)
                 .subscribe(sub);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnRequestTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnRequestTest.java
@@ -9,30 +9,30 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiOnRequestTest {
 
     @Test
     public void testInvoke() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicLong requested = new AtomicLong();
 
         Multi.createFrom().item(1)
                 .onRequest().invoke(requested::set)
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.request(10);
+        subscriber.request(10);
 
-        ts.assertCompletedSuccessfully();
-        assertThat(ts.items()).containsExactly(1);
+        subscriber.assertCompletedSuccessfully();
+        assertThat(subscriber.items()).containsExactly(1);
         assertThat(requested.get()).isEqualTo(10);
     }
 
     @Test
     public void testInvokeThrowingException() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicLong requested = new AtomicLong();
 
@@ -41,17 +41,17 @@ public class MultiOnRequestTest {
                     requested.set(count);
                     throw new RuntimeException("woops");
                 })
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.request(10);
-        ts.assertHasFailedWith(RuntimeException.class, "woops");
-        ts.assertHasNotReceivedAnyItem();
+        subscriber.request(10);
+        subscriber.assertHasFailedWith(RuntimeException.class, "woops");
+        subscriber.assertHasNotReceivedAnyItem();
         assertThat(requested.get()).isEqualTo(10);
     }
 
     @Test
     public void testInvokeUni() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicLong requested = new AtomicLong();
 
@@ -60,18 +60,18 @@ public class MultiOnRequestTest {
                     requested.set(count);
                     return Uni.createFrom().item("ok");
                 })
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.request(10);
+        subscriber.request(10);
 
-        ts.assertCompletedSuccessfully();
-        assertThat(ts.items()).containsExactly(1);
+        subscriber.assertCompletedSuccessfully();
+        assertThat(subscriber.items()).containsExactly(1);
         assertThat(requested.get()).isEqualTo(10);
     }
 
     @Test
     public void testInvokeUniError() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicLong requested = new AtomicLong();
 
@@ -80,19 +80,19 @@ public class MultiOnRequestTest {
                     requested.set(count);
                     return Uni.createFrom().failure(new RuntimeException("woops"));
                 })
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.request(10);
+        subscriber.request(10);
 
-        ts.request(10);
-        ts.assertHasFailedWith(RuntimeException.class, "woops");
-        ts.assertHasNotReceivedAnyItem();
+        subscriber.request(10);
+        subscriber.assertHasFailedWith(RuntimeException.class, "woops");
+        subscriber.assertHasNotReceivedAnyItem();
         assertThat(requested.get()).isEqualTo(10);
     }
 
     @Test
     public void testInvokeUniThrowingException() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicLong requested = new AtomicLong();
 
@@ -101,19 +101,19 @@ public class MultiOnRequestTest {
                     requested.set(count);
                     throw new RuntimeException("woops");
                 })
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.request(10);
+        subscriber.request(10);
 
-        ts.request(10);
-        ts.assertHasFailedWith(RuntimeException.class, "woops");
-        ts.assertHasNotReceivedAnyItem();
+        subscriber.request(10);
+        subscriber.assertHasFailedWith(RuntimeException.class, "woops");
+        subscriber.assertHasNotReceivedAnyItem();
         assertThat(requested.get()).isEqualTo(10);
     }
 
     @Test
     public void testInvokeUniAndCancellation() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
 
         AtomicLong requested = new AtomicLong();
         AtomicBoolean cancellation = new AtomicBoolean();
@@ -127,13 +127,13 @@ public class MultiOnRequestTest {
                         // Do nothing
                     })
                             .onCancellation().invoke(() -> cancellation.set(true));
-                }).subscribe().withSubscriber(ts);
+                }).subscribe().withSubscriber(subscriber);
 
-        ts.request(10);
-        ts.cancel();
+        subscriber.request(10);
+        subscriber.cancel();
 
-        ts.assertHasNotCompleted();
-        ts.assertHasNotReceivedAnyItem();
+        subscriber.assertHasNotCompleted();
+        subscriber.assertHasNotReceivedAnyItem();
         assertThat(requested.get()).isEqualTo(10);
         assertThat(cancellation.get()).isTrue();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnSubscribeTest.java
@@ -18,7 +18,7 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.multi.MultiOnSubscribeInvokeOp;
 import io.smallrye.mutiny.operators.multi.MultiOnSubscribeInvokeUniOp;
 import io.smallrye.mutiny.subscription.UniEmitter;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiOnSubscribeTest {
 
@@ -32,7 +32,7 @@ public class MultiOnSubscribeTest {
                     count.incrementAndGet();
                 });
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
 
         assertThat(count).hasValue(0);
         assertThat(reference).hasValue(null);
@@ -42,7 +42,7 @@ public class MultiOnSubscribeTest {
         assertThat(count).hasValue(1);
         assertThat(reference).doesNotHaveValue(null);
 
-        MultiAssertSubscriber<Integer> subscriber2 = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber2 = AssertSubscriber.create(10);
         multi.subscribe().withSubscriber(subscriber2).assertCompletedSuccessfully().assertReceived(1, 2, 3);
 
         assertThat(count).hasValue(2);
@@ -60,7 +60,7 @@ public class MultiOnSubscribeTest {
                     count.incrementAndGet();
                 });
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
 
         assertThat(count).hasValue(0);
         assertThat(reference).hasValue(null);
@@ -70,7 +70,7 @@ public class MultiOnSubscribeTest {
         assertThat(count).hasValue(1);
         assertThat(reference).doesNotHaveValue(null);
 
-        MultiAssertSubscriber<Integer> subscriber2 = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber2 = AssertSubscriber.create(10);
         multi.subscribe().withSubscriber(subscriber2).assertCompletedSuccessfully().assertReceived(1, 2, 3);
 
         assertThat(count).hasValue(2);
@@ -90,7 +90,7 @@ public class MultiOnSubscribeTest {
                             .onSubscribe().invoke(sub::set);
                 });
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
 
         assertThat(count).hasValue(0);
         assertThat(reference).hasValue(null);
@@ -100,7 +100,7 @@ public class MultiOnSubscribeTest {
         assertThat(count).hasValue(1);
         assertThat(reference).doesNotHaveValue(null);
 
-        MultiAssertSubscriber<Integer> subscriber2 = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber2 = AssertSubscriber.create(10);
         multi.subscribe().withSubscriber(subscriber2).assertCompletedSuccessfully().assertReceived(1, 2, 3);
 
         assertThat(count).hasValue(2);
@@ -115,7 +115,7 @@ public class MultiOnSubscribeTest {
                     throw new IllegalStateException("boom");
                 });
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         multi.subscribe().withSubscriber(subscriber)
                 .assertHasFailedWith(IllegalStateException.class, "boom");
@@ -129,7 +129,7 @@ public class MultiOnSubscribeTest {
                     throw new IllegalStateException("boom");
                 });
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         multi.subscribe().withSubscriber(subscriber)
                 .assertHasFailedWith(IllegalStateException.class, "boom");
@@ -141,7 +141,7 @@ public class MultiOnSubscribeTest {
         Multi<Integer> multi = Multi.createFrom().items(1, 2, 3)
                 .onSubscribe().invokeUni(s -> Uni.createFrom().failure(new IOException("boom")));
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         multi.subscribe().withSubscriber(subscriber)
                 .assertHasFailedWith(IOException.class, "boom");
@@ -153,7 +153,7 @@ public class MultiOnSubscribeTest {
         Multi<Integer> multi = Multi.createFrom().items(1, 2, 3)
                 .onSubscribe().invokeUni(s -> null);
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         multi.subscribe().withSubscriber(subscriber)
                 .assertHasFailedWith(NullPointerException.class, "`null`");
@@ -185,7 +185,7 @@ public class MultiOnSubscribeTest {
     @Test
     public void testThatSubscriptionIsNotPassedDownstreamUntilInvokeCallbackCompletes() {
         CountDownLatch latch = new CountDownLatch(1);
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3)
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3)
                 .onSubscribe().invoke(s -> {
                     try {
                         latch.await();
@@ -195,7 +195,7 @@ public class MultiOnSubscribeTest {
                     }
                 })
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(3));
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
 
         subscriber.assertNotSubscribed();
         latch.countDown();
@@ -207,9 +207,9 @@ public class MultiOnSubscribeTest {
     @Test
     public void testThatSubscriptionIsNotPassedDownstreamUntilProducedUniCompletes() {
         AtomicReference<UniEmitter<? super Integer>> emitter = new AtomicReference<>();
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3)
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3)
                 .onSubscribe().invokeUni(s -> Uni.createFrom().emitter((Consumer<UniEmitter<? super Integer>>) emitter::set))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(3));
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
 
         subscriber.assertNotSubscribed();
 
@@ -225,10 +225,10 @@ public class MultiOnSubscribeTest {
     @Test
     public void testThatSubscriptionIsNotPassedDownstreamUntilProducedUniCompletesWithDifferentThread() {
         AtomicReference<UniEmitter<? super Integer>> emitter = new AtomicReference<>();
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3)
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3)
                 .onSubscribe().invokeUni(s -> Uni.createFrom().emitter((Consumer<UniEmitter<? super Integer>>) emitter::set))
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(3));
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
 
         subscriber.assertNotSubscribed();
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnTerminationUniInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnTerminationUniInvokeTest.java
@@ -14,13 +14,13 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiOnTerminationUniInvokeTest {
 
     @Test
     public void testTerminationWhenErrorIsEmitted() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
 
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicReference<Object> item = new AtomicReference<>();
@@ -47,9 +47,9 @@ public class MultiOnTerminationUniInvokeTest {
                 })
                 .onRequest().invoke(requests::set)
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts
+        subscriber
                 .request(20)
                 .assertHasNotReceivedAnyItem()
                 .assertHasFailedWith(IOException.class, "boom");
@@ -69,7 +69,7 @@ public class MultiOnTerminationUniInvokeTest {
 
     @Test
     public void testTerminationWhenItemIsEmittedButUniInvokeIsFailed() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicReference<Integer> item = new AtomicReference<>();
@@ -95,9 +95,9 @@ public class MultiOnTerminationUniInvokeTest {
                 })
                 .onRequest().invoke(requests::set)
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts
+        subscriber
                 .request(20)
                 .assertReceived(1)
                 .assertHasFailedWith(IOException.class, "bam");
@@ -116,7 +116,7 @@ public class MultiOnTerminationUniInvokeTest {
 
     @Test
     public void testTerminationWhenItemIsEmittedButUniInvokeThrowsException() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicReference<Integer> item = new AtomicReference<>();
@@ -142,9 +142,9 @@ public class MultiOnTerminationUniInvokeTest {
                 })
                 .onRequest().invoke(requests::set)
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts
+        subscriber
                 .request(20)
                 .assertReceived(1)
                 .assertHasFailedWith(RuntimeException.class, "bam");
@@ -163,7 +163,7 @@ public class MultiOnTerminationUniInvokeTest {
 
     @Test
     public void testTerminationWhenErrorIsEmittedButUniInvokeIsFailed() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
 
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicReference<Object> item = new AtomicReference<>();
@@ -189,15 +189,15 @@ public class MultiOnTerminationUniInvokeTest {
                 })
                 .onRequest().invoke(requests::set)
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts
+        subscriber
                 .request(20)
                 .assertHasNotReceivedAnyItem()
                 .assertHasFailedWith(CompositeException.class, "boom");
 
-        assertThat(ts.failures()).hasSize(1);
-        CompositeException compositeException = (CompositeException) ts.failures().get(0);
+        assertThat(subscriber.failures()).hasSize(1);
+        CompositeException compositeException = (CompositeException) subscriber.failures().get(0);
         assertThat(compositeException.getCauses()).hasSize(2);
         assertThat(compositeException.getCauses().get(0)).isInstanceOf(IOException.class).hasMessage("boom");
         assertThat(compositeException.getCauses().get(1)).isInstanceOf(RuntimeException.class).hasMessage("tada");
@@ -216,7 +216,7 @@ public class MultiOnTerminationUniInvokeTest {
 
     @Test
     public void testTerminationWhenErrorIsEmittedButUniInvokeThrowsException() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
 
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicReference<Object> item = new AtomicReference<>();
@@ -242,15 +242,15 @@ public class MultiOnTerminationUniInvokeTest {
                 })
                 .onRequest().invoke(requests::set)
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts
+        subscriber
                 .request(20)
                 .assertHasNotReceivedAnyItem()
                 .assertHasFailedWith(CompositeException.class, "boom");
 
-        assertThat(ts.failures()).hasSize(1);
-        CompositeException compositeException = (CompositeException) ts.failures().get(0);
+        assertThat(subscriber.failures()).hasSize(1);
+        CompositeException compositeException = (CompositeException) subscriber.failures().get(0);
         assertThat(compositeException.getCauses()).hasSize(2);
         assertThat(compositeException.getCauses().get(0)).isInstanceOf(IOException.class).hasMessage("boom");
         assertThat(compositeException.getCauses().get(1)).isInstanceOf(RuntimeException.class).hasMessage("tada");
@@ -269,7 +269,7 @@ public class MultiOnTerminationUniInvokeTest {
 
     @Test
     public void testTerminationWithCancellationAndNotItems() {
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         AtomicReference<Integer> item = new AtomicReference<>();
         AtomicBoolean cancellation = new AtomicBoolean();
@@ -296,9 +296,9 @@ public class MultiOnTerminationUniInvokeTest {
                     });
                 })
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.cancel()
+        subscriber.cancel()
                 .assertHasNotReceivedAnyItem()
                 .assertHasNotCompleted();
 
@@ -316,7 +316,7 @@ public class MultiOnTerminationUniInvokeTest {
 
     @Test
     public void testTerminationWithCancellationAfterOneItem() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
 
         AtomicReference<Object> item = new AtomicReference<>();
         AtomicBoolean cancellation = new AtomicBoolean();
@@ -358,15 +358,15 @@ public class MultiOnTerminationUniInvokeTest {
                             });
                 })
                 .onCancellation().invoke(() -> cancellation.set(true))
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.request(10);
+        subscriber.request(10);
         await().untilTrue(firstItemEmitted);
-        ts.cancel();
+        subscriber.cancel();
         cancellationSent.set(true);
         await().untilTrue(uniCompleted);
 
-        ts.assertReceived(1).assertHasNotCompleted();
+        subscriber.assertReceived(1).assertHasNotCompleted();
 
         assertThat(item.get()).isEqualTo(1);
         assertThat(cancellation.get()).isTrue();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiReceiveItemOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiReceiveItemOnTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiReceiveItemOnTest {
 
@@ -61,11 +61,11 @@ public class MultiReceiveItemOnTest {
     public void testThatItemsAreDispatchedOnTheRightThread() {
         Set<String> itemThread = ConcurrentHashMap.newKeySet();
         Set<String> completionThread = ConcurrentHashMap.newKeySet();
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3, 4)
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3, 4)
                 .emitOn(executor)
                 .onItem().invoke(i -> itemThread.add(Thread.currentThread().getName()))
                 .onCompletion().invoke(() -> completionThread.add(Thread.currentThread().getName()))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .await()
                 .assertCompletedSuccessfully();
 
@@ -82,7 +82,7 @@ public class MultiReceiveItemOnTest {
                 .emitOn(executor)
                 .onItem().invoke(i -> itemThread.add(Thread.currentThread().getName()))
                 .onFailure().invoke(f -> failureThread.add(Thread.currentThread().getName()))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .await()
                 .assertHasFailedWith(IOException.class, "boom");
 
@@ -94,16 +94,16 @@ public class MultiReceiveItemOnTest {
     public void testWithImmediate() {
         Multi.createFrom().items(1, 2, 3, 4)
                 .emitOn(Runnable::run)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .await()
                 .assertReceived(1, 2, 3, 4);
     }
 
     @Test
     public void testWithLargeNumberOfItems() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().range(0, 100_000)
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().range(0, 100_000)
                 .emitOn(executor)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .await()
                 .assertCompletedSuccessfully();
 
@@ -119,7 +119,7 @@ public class MultiReceiveItemOnTest {
     public void testSubscribeOn() {
         Multi.createFrom().items(1, 2, 3, 4)
                 .subscribeOn(executor)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .await()
                 .assertReceived(1, 2, 3, 4);
     }
@@ -128,7 +128,7 @@ public class MultiReceiveItemOnTest {
     public void testRunSubscriptionOn() {
         Multi.createFrom().items(1, 2, 3, 4)
                 .runSubscriptionOn(executor)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(4))
+                .subscribe().withSubscriber(AssertSubscriber.create(4))
                 .await()
                 .assertReceived(1, 2, 3, 4);
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiScanTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiScanTest.java
@@ -3,7 +3,7 @@ package io.smallrye.mutiny.operators;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiScanTest {
 
@@ -24,7 +24,7 @@ public class MultiScanTest {
 
     @Test
     public void testWithSimplerScanner() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
 
         Multi.createFrom().range(1, 10)
                 .onItem().scan((a, b) -> b)
@@ -37,7 +37,7 @@ public class MultiScanTest {
 
     @Test
     public void testWithSimplerScannerWithSupplier() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(Long.MAX_VALUE);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
         Multi.createFrom().range(1, 10)
                 .onItem().scan(() -> 2, (a, b) -> b)
@@ -50,7 +50,7 @@ public class MultiScanTest {
 
     @Test
     public void testWithRequests() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
         Multi.createFrom().range(1, 10)
                 .onItem().scan((a, b) -> b)
@@ -71,7 +71,7 @@ public class MultiScanTest {
 
     @Test
     public void testWithAScannerThrowingException() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(2);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(2);
 
         Multi.createFrom().range(1, 10)
                 .onItem().scan((a, b) -> {
@@ -85,7 +85,7 @@ public class MultiScanTest {
 
     @Test
     public void testWithAScannerReturningNull() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(2);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(2);
 
         Multi.createFrom().range(1, 10)
                 .onItem().scan((a, b) -> null)
@@ -97,7 +97,7 @@ public class MultiScanTest {
 
     @Test
     public void testWithAScannerThrowingExceptionWithSupplier() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(2);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(2);
 
         Multi.createFrom().range(1, 10)
                 .onItem().scan(() -> 1, (a, b) -> {
@@ -111,7 +111,7 @@ public class MultiScanTest {
 
     @Test
     public void testWithAScannerReturningNullWithSupplier() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(2);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(2);
 
         Multi.createFrom().range(1, 10)
                 .onItem().scan(() -> 1, (a, b) -> null)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipTest.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiEmitter;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiSkipTest {
 
@@ -51,7 +51,7 @@ public class MultiSkipTest {
     @Test
     public void testSkipOnUpstreamFailure() {
         Multi.createFrom().<Integer> failure(new IOException("boom")).transform().bySkippingFirstItems(1)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(IOException.class, "boom")
                 .assertHasNotReceivedAnyItem();
     }
@@ -59,7 +59,7 @@ public class MultiSkipTest {
     @Test
     public void testSkipLastOnUpstreamFailure() {
         Multi.createFrom().<Integer> failure(new IOException("boom")).transform().bySkippingLastItems(1)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(IOException.class, "boom")
                 .assertHasNotReceivedAnyItem();
     }
@@ -67,7 +67,7 @@ public class MultiSkipTest {
     @Test
     public void testSkipAll() {
         Multi.createFrom().range(1, 5).transform().bySkippingFirstItems(4)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -75,7 +75,7 @@ public class MultiSkipTest {
     @Test
     public void testSkipLastAll() {
         Multi.createFrom().range(1, 5).transform().bySkippingLastItems(4)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -91,7 +91,7 @@ public class MultiSkipTest {
 
     @Test
     public void testSkipLastWithBackPressure() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(0);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(0);
 
         AtomicReference<MultiEmitter<? super Integer>> emitter = new AtomicReference<>();
         Multi.createFrom().<Integer> emitter(emitter::set)
@@ -122,7 +122,7 @@ public class MultiSkipTest {
 
     @Test
     public void testSkipSomeLastItems() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(Long.MAX_VALUE);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
         Multi.createFrom().range(1, 11)
                 .transform().bySkippingLastItems(3)
@@ -136,7 +136,7 @@ public class MultiSkipTest {
     public void testSkipWhileWithMethodThrowingException() {
         Multi.createFrom().range(1, 10).transform().bySkippingItemsWhile(i -> {
             throw new IllegalStateException("boom");
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+        }).subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(IllegalStateException.class, "boom");
     }
 
@@ -144,7 +144,7 @@ public class MultiSkipTest {
     public void testSkipWhileWithUpstreamFailure() {
         Multi.createFrom().<Integer> failure(new IOException("boom"))
                 .transform().bySkippingItemsWhile(i -> i < 5)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(IOException.class, "boom");
     }
 
@@ -156,7 +156,7 @@ public class MultiSkipTest {
     @Test
     public void testSkipWhile() {
         Multi.createFrom().range(1, 10).transform().bySkippingItemsWhile(i -> i < 5)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(5, 6, 7, 8, 9);
     }
@@ -164,7 +164,7 @@ public class MultiSkipTest {
     @Test
     public void testSkipWhileNone() {
         Multi.createFrom().items(1, 2, 3, 4).transform().bySkippingItemsWhile(i -> false)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
     }
@@ -172,16 +172,16 @@ public class MultiSkipTest {
     @Test
     public void testSkipWhileAll() {
         Multi.createFrom().items(1, 2, 3, 4).transform().bySkippingItemsWhile(i -> true)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
 
     @Test
     public void testSkipWhileSomeWithBackPressure() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3, 4).transform()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3, 4).transform()
                 .bySkippingItemsWhile(i -> i < 3)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(0));
+                .subscribe().withSubscriber(AssertSubscriber.create(0));
 
         subscriber.assertNotTerminated()
                 .assertHasNotReceivedAnyItem();
@@ -201,7 +201,7 @@ public class MultiSkipTest {
     public void testSkipByTime() {
         Multi.createFrom().range(1, 100)
                 .transform().bySkippingItemsFor(Duration.ofMillis(2000))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTakeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTakeTest.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiEmitter;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiTakeTest {
 
@@ -51,7 +51,7 @@ public class MultiTakeTest {
     @Test
     public void testTakeOnUpstreamFailure() {
         Multi.createFrom().<Integer> failure(new IOException("boom")).transform().byTakingFirstItems(1)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(IOException.class, "boom")
                 .assertHasNotReceivedAnyItem();
     }
@@ -59,7 +59,7 @@ public class MultiTakeTest {
     @Test
     public void testTakeLastOnUpstreamFailure() {
         Multi.createFrom().<Integer> failure(new IOException("boom")).transform().byTakingLastItems(1)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(IOException.class, "boom")
                 .assertHasNotReceivedAnyItem();
     }
@@ -67,7 +67,7 @@ public class MultiTakeTest {
     @Test
     public void testTakeAll() {
         Multi.createFrom().range(1, 5).transform().byTakingFirstItems(4)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
     }
@@ -75,7 +75,7 @@ public class MultiTakeTest {
     @Test
     public void testTakeLastAll() {
         Multi.createFrom().range(1, 5).transform().byTakingLastItems(4)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
     }
@@ -91,7 +91,7 @@ public class MultiTakeTest {
 
     @Test
     public void testTakeLastWithBackPressure() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(0);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(0);
 
         AtomicReference<MultiEmitter<? super Integer>> emitter = new AtomicReference<>();
         Multi.createFrom().<Integer> emitter(emitter::set)
@@ -122,7 +122,7 @@ public class MultiTakeTest {
 
     @Test
     public void testTakeSomeLastItems() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(Long.MAX_VALUE);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
         Multi.createFrom().range(1, 11)
                 .transform().byTakingLastItems(3)
@@ -136,7 +136,7 @@ public class MultiTakeTest {
     public void testTakeWhileWithMethodThrowingException() {
         Multi.createFrom().range(1, 10).transform().byTakingItemsWhile(i -> {
             throw new IllegalStateException("boom");
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+        }).subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(IllegalStateException.class, "boom");
     }
 
@@ -144,7 +144,7 @@ public class MultiTakeTest {
     public void testTakeWhileWithUpstreamFailure() {
         Multi.createFrom().<Integer> failure(new IOException("boom"))
                 .transform().byTakingItemsWhile(i -> i < 5)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertHasFailedWith(IOException.class, "boom");
     }
 
@@ -156,7 +156,7 @@ public class MultiTakeTest {
     @Test
     public void testTakeWhile() {
         Multi.createFrom().range(1, 10).transform().byTakingItemsWhile(i -> i < 5)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
     }
@@ -164,7 +164,7 @@ public class MultiTakeTest {
     @Test
     public void testTakeWhileNone() {
         Multi.createFrom().items(1, 2, 3, 4).transform().byTakingItemsWhile(i -> false)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
     }
@@ -172,16 +172,16 @@ public class MultiTakeTest {
     @Test
     public void testTakeWhileAll() {
         Multi.createFrom().items(1, 2, 3, 4).transform().byTakingItemsWhile(i -> true)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
     }
 
     @Test
     public void testTakeWhileSomeWithBackPressure() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3, 4).transform()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3, 4).transform()
                 .byTakingItemsWhile(i -> i < 3)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(0));
+                .subscribe().withSubscriber(AssertSubscriber.create(0));
 
         subscriber.assertNotTerminated()
                 .assertHasNotReceivedAnyItem();
@@ -201,7 +201,7 @@ public class MultiTakeTest {
     public void testLimitingInfiniteStream() {
         Multi.createFrom().ticks().every(Duration.ofMillis(2))
                 .transform().byTakingFirstItems(5)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .await()
                 .assertCompletedSuccessfully()
                 .assertReceived(0L, 1L, 2L, 3L, 4L);
@@ -209,9 +209,9 @@ public class MultiTakeTest {
 
     @Test
     public void testTakeByTime() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().range(1, 100).transform()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().range(1, 100).transform()
                 .byTakingItemsFor(Duration.ofMillis(1000))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .await()
                 .assertCompletedSuccessfully();
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformByMergingTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformByMergingTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiTransformByMergingTest {
 
@@ -64,8 +64,8 @@ public class MultiTransformByMergingTest {
         Multi<Integer> m3 = Multi.createFrom().range(150, 200).emitOn(service).emitOn(service);
 
         Multi<Integer> merged = m1.transform().byMergingWith(m2, m3);
-        MultiAssertSubscriber<Integer> subscriber = merged.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1000));
+        AssertSubscriber<Integer> subscriber = merged.subscribe()
+                .withSubscriber(AssertSubscriber.create(1000));
 
         subscriber.await();
         List<Integer> items = subscriber.items();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToUniTest.java
@@ -10,7 +10,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiTransformToUniTest {
 
@@ -27,33 +27,33 @@ public class MultiTransformToUniTest {
 
     @Test
     public void testTransformToUniAndConcatenateWithFailure() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
 
         Multi.createFrom().range(1, 4)
                 .onItem()
                 .transformToUni(i -> Uni.createFrom().failure(new RuntimeException("boom")))
                 .concatenate()
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.assertHasFailedWith(RuntimeException.class, "boom");
+        subscriber.assertHasFailedWith(RuntimeException.class, "boom");
     }
 
     @Test
     public void testTransformToUniAndConcatenateWithNull() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
 
         Multi.createFrom().range(1, 4)
                 .onItem()
                 .transformToUni(i -> Uni.createFrom().nullItem())
                 .concatenate()
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.assertHasNotReceivedAnyItem().assertCompletedSuccessfully();
+        subscriber.assertHasNotReceivedAnyItem().assertCompletedSuccessfully();
     }
 
     @Test
     public void testTransformToUniAndConcatenateWithException() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
 
         Multi.createFrom().range(1, 4)
                 .onItem()
@@ -61,14 +61,14 @@ public class MultiTransformToUniTest {
                     throw new RuntimeException("boom");
                 })
                 .concatenate()
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.assertHasFailedWith(RuntimeException.class, "boom");
+        subscriber.assertHasFailedWith(RuntimeException.class, "boom");
     }
 
     @Test
     public void testTransformToUniAndConcatenateWithCancellation() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
         AtomicBoolean uniCancelled = new AtomicBoolean();
 
         Multi.createFrom().items(1, 2, 3)
@@ -77,10 +77,10 @@ public class MultiTransformToUniTest {
                         .completionStage(CompletableFuture.supplyAsync(this::delayedHello))
                         .onCancellation().invoke(() -> uniCancelled.set(true)))
                 .concatenate()
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.request(1).cancel();
-        ts.assertHasNotCompleted().assertHasNotFailed().assertHasNotReceivedAnyItem();
+        subscriber.request(1).cancel();
+        subscriber.assertHasNotCompleted().assertHasNotFailed().assertHasNotReceivedAnyItem();
         assertThat(uniCancelled.get()).isTrue();
     }
 
@@ -116,20 +116,20 @@ public class MultiTransformToUniTest {
 
     @Test
     public void testTransformToUniAndMergeWithFailure() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
 
         Multi.createFrom().range(1, 4)
                 .onItem()
                 .transformToUni(i -> Uni.createFrom().failure(new RuntimeException("boom")))
                 .merge()
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.assertHasFailedWith(RuntimeException.class, "boom");
+        subscriber.assertHasFailedWith(RuntimeException.class, "boom");
     }
 
     @Test
     public void testTransformToUniAndMergeWithException() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
 
         Multi.createFrom().range(1, 4)
                 .onItem()
@@ -137,27 +137,27 @@ public class MultiTransformToUniTest {
                     throw new RuntimeException("boom");
                 })
                 .merge()
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.assertHasFailedWith(RuntimeException.class, "boom");
+        subscriber.assertHasFailedWith(RuntimeException.class, "boom");
     }
 
     @Test
     public void testTransformToUniAndMergeWithNull() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
 
         Multi.createFrom().range(1, 4)
                 .onItem()
                 .transformToUni(i -> Uni.createFrom().nullItem())
                 .merge()
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.assertHasNotReceivedAnyItem().assertCompletedSuccessfully();
+        subscriber.assertHasNotReceivedAnyItem().assertCompletedSuccessfully();
     }
 
     @Test
     public void testTransformToUniAndMergeWithCancellation() {
-        MultiAssertSubscriber<Object> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create();
         AtomicBoolean uniCancelled = new AtomicBoolean();
 
         Multi.createFrom().items(1, 2, 3)
@@ -166,10 +166,10 @@ public class MultiTransformToUniTest {
                         .completionStage(CompletableFuture.supplyAsync(this::delayedHello))
                         .onCancellation().invoke(() -> uniCancelled.set(true)))
                 .merge()
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.request(1).cancel();
-        ts.assertHasNotCompleted().assertHasNotFailed().assertHasNotReceivedAnyItem();
+        subscriber.request(1).cancel();
+        subscriber.assertHasNotCompleted().assertHasNotFailed().assertHasNotReceivedAnyItem();
         assertThat(uniCancelled.get()).isTrue();
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromCompletionStageTest.java
@@ -13,86 +13,87 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Uni;
 
+@SuppressWarnings("ConstantConditions")
 public class UniCreateFromCompletionStageTest {
 
     @Test
     public void testThatNullValueAreAccepted() {
-        UniAssertSubscriber<String> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<String> subscriber = UniAssertSubscriber.create();
         CompletionStage<String> cs = new CompletableFuture<>();
-        Uni.createFrom().completionStage(cs).subscribe().withSubscriber(ts);
+        Uni.createFrom().completionStage(cs).subscribe().withSubscriber(subscriber);
         cs.toCompletableFuture().complete(null);
-        ts.assertCompletedSuccessfully().assertItem(null);
+        subscriber.assertCompletedSuccessfully().assertItem(null);
     }
 
     @Test
     public void testWithNonNullValue() {
-        UniAssertSubscriber<String> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<String> subscriber = UniAssertSubscriber.create();
         CompletionStage<String> cs = new CompletableFuture<>();
-        Uni.createFrom().completionStage(cs).subscribe().withSubscriber(ts);
+        Uni.createFrom().completionStage(cs).subscribe().withSubscriber(subscriber);
         cs.toCompletableFuture().complete("1");
-        ts.assertCompletedSuccessfully().assertItem("1");
+        subscriber.assertCompletedSuccessfully().assertItem("1");
     }
 
     @Test
     public void testWithException() {
-        UniAssertSubscriber<String> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<String> subscriber = UniAssertSubscriber.create();
         CompletionStage<String> cs = new CompletableFuture<>();
-        Uni.createFrom().completionStage(cs).subscribe().withSubscriber(ts);
+        Uni.createFrom().completionStage(cs).subscribe().withSubscriber(subscriber);
         cs.toCompletableFuture().completeExceptionally(new IOException("boom"));
-        ts.assertFailure(IOException.class, "boom");
+        subscriber.assertFailure(IOException.class, "boom");
     }
 
     @Test
     public void testWithExceptionThrownByAStage() {
-        UniAssertSubscriber<String> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<String> subscriber = UniAssertSubscriber.create();
         CompletionStage<String> cs = new CompletableFuture<>();
         Uni.createFrom().completionStage(() -> cs
                 .thenApply(String::toUpperCase)
                 .<String> thenApply(s -> {
                     throw new IllegalStateException("boom");
-                })).subscribe().withSubscriber(ts);
+                })).subscribe().withSubscriber(subscriber);
         cs.toCompletableFuture().complete("bonjour");
-        ts.assertFailure(IllegalStateException.class, "boom");
+        subscriber.assertFailure(IllegalStateException.class, "boom");
     }
 
     @Test
     public void testThatNullValueAreAcceptedWithSupplier() {
-        UniAssertSubscriber<Void> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Void> subscriber = UniAssertSubscriber.create();
         Uni.createFrom().<Void> completionStage(() -> CompletableFuture.completedFuture(null)).subscribe()
-                .withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(null);
+                .withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(null);
     }
 
     @Test
     public void testWithNonNullValueWithSupplier() {
-        UniAssertSubscriber<String> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<String> subscriber = UniAssertSubscriber.create();
         CompletionStage<String> cs = new CompletableFuture<>();
-        Uni.createFrom().completionStage(() -> cs).subscribe().withSubscriber(ts);
+        Uni.createFrom().completionStage(() -> cs).subscribe().withSubscriber(subscriber);
         cs.toCompletableFuture().complete("1");
-        ts.assertCompletedSuccessfully().assertItem("1");
+        subscriber.assertCompletedSuccessfully().assertItem("1");
     }
 
     @Test
     public void testWithExceptionWithSupplier() {
-        UniAssertSubscriber<String> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<String> subscriber = UniAssertSubscriber.create();
         CompletionStage<String> cs = new CompletableFuture<>();
-        Uni.createFrom().completionStage(() -> cs).subscribe().withSubscriber(ts);
+        Uni.createFrom().completionStage(() -> cs).subscribe().withSubscriber(subscriber);
         cs.toCompletableFuture().completeExceptionally(new IOException("boom"));
-        ts.assertFailure(IOException.class, "boom");
+        subscriber.assertFailure(IOException.class, "boom");
     }
 
     @Test
     public void testWithExceptionInSupplier() {
-        UniAssertSubscriber<String> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<String> subscriber = UniAssertSubscriber.create();
         Uni.createFrom().<String> completionStage(() -> {
             throw new NullPointerException("boom");
-        }).subscribe().withSubscriber(ts);
-        ts.assertFailure(NullPointerException.class, "boom");
+        }).subscribe().withSubscriber(subscriber);
+        subscriber.assertFailure(NullPointerException.class, "boom");
     }
 
     @Test
     public void testThatValueIsNotEmittedBeforeSubscription() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         AtomicBoolean called = new AtomicBoolean();
         CompletableFuture<Integer> cs = new CompletableFuture<>();
         cs.complete(1);
@@ -101,14 +102,14 @@ public class UniCreateFromCompletionStageTest {
 
         assertThat(called).isFalse();
 
-        uni.subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(1);
+        uni.subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(1);
         assertThat(called).isTrue();
     }
 
     @Test
     public void testThatValueIsNotEmittedBeforeSubscriptionWithSupplier() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         AtomicBoolean called = new AtomicBoolean();
         CompletableFuture<Integer> cs = new CompletableFuture<>();
 
@@ -124,93 +125,93 @@ public class UniCreateFromCompletionStageTest {
 
         assertThat(called).isFalse();
 
-        uni.subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(1);
+        uni.subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(1);
         assertThat(called).isTrue();
     }
 
     @Test
     public void testThatSubscriberIsIncompleteIfTheStageDoesNotEmit() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         AtomicBoolean called = new AtomicBoolean();
         CompletableFuture<Integer> cs = new CompletableFuture<>();
         Uni<Integer> uni = Uni.createFrom().completionStage(cs)
                 .onItem().invoke(i -> called.set(true));
 
         assertThat(called).isFalse();
-        uni.subscribe().withSubscriber(ts);
+        uni.subscribe().withSubscriber(subscriber);
         assertThat(called).isFalse();
-        ts.assertNotCompleted();
+        subscriber.assertNotCompleted();
     }
 
     @Test
     public void testThatSubscriberIsIncompleteIfTheStageDoesNotEmitFromSupplier() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         AtomicBoolean called = new AtomicBoolean();
         CompletableFuture<Integer> cs = new CompletableFuture<>();
         Uni<Integer> uni = Uni.createFrom().completionStage(() -> cs)
                 .onItem().invoke(i -> called.set(true));
 
         assertThat(called).isFalse();
-        uni.subscribe().withSubscriber(ts);
+        uni.subscribe().withSubscriber(subscriber);
         assertThat(called).isFalse();
-        ts.assertNotCompleted();
+        subscriber.assertNotCompleted();
     }
 
     @Test
     public void testThatSubscriberCanCancelBeforeEmission() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         CompletableFuture<Integer> cs = new CompletableFuture<>();
         Uni<Integer> uni = Uni.createFrom().completionStage(cs)
                 .onItem().invoke(i -> {
                 });
 
-        uni.subscribe().withSubscriber(ts);
-        ts.cancel();
+        uni.subscribe().withSubscriber(subscriber);
+        subscriber.cancel();
 
         cs.complete(1);
 
-        ts.assertNotCompleted();
+        subscriber.assertNotCompleted();
     }
 
     @Test
     public void testThatSubscriberCanCancelBeforeEmissionWithSupplier() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         CompletableFuture<Integer> cs = new CompletableFuture<>();
         Uni<Integer> uni = Uni.createFrom().completionStage(() -> cs);
-        uni.subscribe().withSubscriber(ts);
-        ts.cancel();
+        uni.subscribe().withSubscriber(subscriber);
+        subscriber.cancel();
 
         cs.complete(1);
-        ts.assertNotCompleted();
+        subscriber.assertNotCompleted();
     }
 
     @Test
     public void testThatSubscriberCanCancelAfterEmission() {
         AtomicBoolean called = new AtomicBoolean();
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         CompletableFuture<Integer> cs = new CompletableFuture<>();
         Uni<Integer> uni = Uni.createFrom().completionStage(cs)
                 .onItem().invoke(i -> called.set(true));
 
-        uni.subscribe().withSubscriber(ts);
+        uni.subscribe().withSubscriber(subscriber);
         cs.complete(1);
-        ts.cancel();
+        subscriber.cancel();
         assertThat(called).isTrue();
-        ts.assertItem(1);
+        subscriber.assertItem(1);
     }
 
     @Test
     public void testThatSubscriberCanCancelAfterEmissionWithSupplier() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         CompletableFuture<Integer> cs = new CompletableFuture<>();
         Uni<Integer> uni = Uni.createFrom().completionStage(() -> cs);
 
-        uni.subscribe().withSubscriber(ts);
+        uni.subscribe().withSubscriber(subscriber);
         cs.complete(1);
-        ts.cancel();
+        subscriber.cancel();
 
-        ts.assertItem(1);
+        subscriber.assertItem(1);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -225,34 +226,34 @@ public class UniCreateFromCompletionStageTest {
 
     @Test
     public void testThatCompletionStageSupplierCannotReturnNull() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         Uni<Integer> uni = Uni.createFrom().completionStage(() -> null);
 
-        uni.subscribe().withSubscriber(ts);
-        ts.assertFailure(NullPointerException.class, "");
+        uni.subscribe().withSubscriber(subscriber);
+        subscriber.assertFailure(NullPointerException.class, "");
     }
 
     @Test
     public void testWithSharedState() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber2 = UniAssertSubscriber.create();
         AtomicInteger shared = new AtomicInteger();
         Uni<Integer> uni = Uni.createFrom().completionStage(() -> shared,
                 state -> CompletableFuture.completedFuture(state.incrementAndGet()));
 
         assertThat(shared).hasValue(0);
-        uni.subscribe().withSubscriber(ts1);
+        uni.subscribe().withSubscriber(subscriber1);
         assertThat(shared).hasValue(1);
-        ts1.assertCompletedSuccessfully().assertItem(1);
-        uni.subscribe().withSubscriber(ts2);
+        subscriber1.assertCompletedSuccessfully().assertItem(1);
+        uni.subscribe().withSubscriber(subscriber2);
         assertThat(shared).hasValue(2);
-        ts2.assertCompletedSuccessfully().assertItem(2);
+        subscriber2.assertCompletedSuccessfully().assertItem(2);
     }
 
     @Test
     public void testWithSharedStateProducingFailure() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber2 = UniAssertSubscriber.create();
         Supplier<AtomicInteger> boom = () -> {
             throw new IllegalStateException("boom");
         };
@@ -260,25 +261,25 @@ public class UniCreateFromCompletionStageTest {
         Uni<Integer> uni = Uni.createFrom().completionStage(boom,
                 state -> CompletableFuture.completedFuture(state.incrementAndGet()));
 
-        uni.subscribe().withSubscriber(ts1);
-        ts1.assertFailure(IllegalStateException.class, "boom");
-        uni.subscribe().withSubscriber(ts2);
-        ts2.assertFailure(IllegalStateException.class, "Invalid shared state");
+        uni.subscribe().withSubscriber(subscriber1);
+        subscriber1.assertFailure(IllegalStateException.class, "boom");
+        uni.subscribe().withSubscriber(subscriber2);
+        subscriber2.assertFailure(IllegalStateException.class, "Invalid shared state");
     }
 
     @Test
     public void testWithSharedStateProducingNull() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s2 = UniAssertSubscriber.create();
         Supplier<AtomicInteger> boom = () -> null;
 
         Uni<Integer> uni = Uni.createFrom().completionStage(boom,
                 state -> CompletableFuture.completedFuture(state.incrementAndGet()));
 
-        uni.subscribe().withSubscriber(ts1);
-        ts1.assertFailure(NullPointerException.class, "supplier");
-        uni.subscribe().withSubscriber(ts2);
-        ts2.assertFailure(IllegalStateException.class, "Invalid shared state");
+        uni.subscribe().withSubscriber(s1);
+        s1.assertFailure(NullPointerException.class, "supplier");
+        uni.subscribe().withSubscriber(s2);
+        s2.assertFailure(IllegalStateException.class, "Invalid shared state");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplierTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplierTest.java
@@ -46,25 +46,25 @@ public class UniCreateFromDeferredSupplierTest {
 
     @Test
     public void testWithSharedState() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s2 = UniAssertSubscriber.create();
         AtomicInteger shared = new AtomicInteger();
         Uni<Integer> uni = Uni.createFrom().deferred(() -> shared,
                 state -> Uni.createFrom().item(state.incrementAndGet()));
 
         assertThat(shared).hasValue(0);
-        uni.subscribe().withSubscriber(ts1);
+        uni.subscribe().withSubscriber(s1);
         assertThat(shared).hasValue(1);
-        ts1.assertCompletedSuccessfully().assertItem(1);
-        uni.subscribe().withSubscriber(ts2);
+        s1.assertCompletedSuccessfully().assertItem(1);
+        uni.subscribe().withSubscriber(s2);
         assertThat(shared).hasValue(2);
-        ts2.assertCompletedSuccessfully().assertItem(2);
+        s2.assertCompletedSuccessfully().assertItem(2);
     }
 
     @Test
     public void testWithSharedStateProducingFailure() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s2 = UniAssertSubscriber.create();
         Supplier<AtomicInteger> boom = () -> {
             throw new IllegalStateException("boom");
         };
@@ -72,25 +72,25 @@ public class UniCreateFromDeferredSupplierTest {
         Uni<Integer> uni = Uni.createFrom().deferred(boom,
                 page -> Uni.createFrom().item(page.getAndIncrement()));
 
-        uni.subscribe().withSubscriber(ts1);
-        ts1.assertFailure(IllegalStateException.class, "boom");
-        uni.subscribe().withSubscriber(ts2);
-        ts2.assertFailure(IllegalStateException.class, "Invalid shared state");
+        uni.subscribe().withSubscriber(s1);
+        s1.assertFailure(IllegalStateException.class, "boom");
+        uni.subscribe().withSubscriber(s2);
+        s2.assertFailure(IllegalStateException.class, "Invalid shared state");
     }
 
     @Test
     public void testWithSharedStateProducingNull() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s2 = UniAssertSubscriber.create();
         Supplier<AtomicInteger> boom = () -> null;
 
         Uni<Integer> uni = Uni.createFrom().deferred(boom,
                 page -> Uni.createFrom().item(page.getAndIncrement()));
 
-        uni.subscribe().withSubscriber(ts1);
-        ts1.assertFailure(NullPointerException.class, "supplier");
-        uni.subscribe().withSubscriber(ts2);
-        ts2.assertFailure(IllegalStateException.class, "Invalid shared state");
+        uni.subscribe().withSubscriber(s1);
+        s1.assertFailure(NullPointerException.class, "supplier");
+        uni.subscribe().withSubscriber(s2);
+        s2.assertFailure(IllegalStateException.class, "Invalid shared state");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromEmitterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromEmitterTest.java
@@ -210,25 +210,25 @@ public class UniCreateFromEmitterTest {
 
     @Test
     public void testWithSharedState() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s2 = UniAssertSubscriber.create();
         AtomicInteger shared = new AtomicInteger();
         Uni<Integer> uni = Uni.createFrom().emitter(() -> shared,
                 (state, emitter) -> emitter.complete(state.incrementAndGet()));
 
         assertThat(shared).hasValue(0);
-        uni.subscribe().withSubscriber(ts1);
+        uni.subscribe().withSubscriber(s1);
         assertThat(shared).hasValue(1);
-        ts1.assertCompletedSuccessfully().assertItem(1);
-        uni.subscribe().withSubscriber(ts2);
+        s1.assertCompletedSuccessfully().assertItem(1);
+        uni.subscribe().withSubscriber(s2);
         assertThat(shared).hasValue(2);
-        ts2.assertCompletedSuccessfully().assertItem(2);
+        s2.assertCompletedSuccessfully().assertItem(2);
     }
 
     @Test
     public void testWithSharedStateProducingFailure() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s2 = UniAssertSubscriber.create();
         Supplier<AtomicInteger> boom = () -> {
             throw new IllegalStateException("boom");
         };
@@ -236,25 +236,25 @@ public class UniCreateFromEmitterTest {
         Uni<Integer> uni = Uni.createFrom().emitter(boom,
                 (state, emitter) -> emitter.complete(state.incrementAndGet()));
 
-        uni.subscribe().withSubscriber(ts1);
-        ts1.assertFailure(IllegalStateException.class, "boom");
-        uni.subscribe().withSubscriber(ts2);
-        ts2.assertFailure(IllegalStateException.class, "Invalid shared state");
+        uni.subscribe().withSubscriber(s1);
+        s1.assertFailure(IllegalStateException.class, "boom");
+        uni.subscribe().withSubscriber(s2);
+        s2.assertFailure(IllegalStateException.class, "Invalid shared state");
     }
 
     @Test
     public void testWithSharedStateProducingNull() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s2 = UniAssertSubscriber.create();
         Supplier<AtomicInteger> boom = () -> null;
 
         Uni<Integer> uni = Uni.createFrom().emitter(boom,
                 (state, emitter) -> emitter.complete(state.incrementAndGet()));
 
-        uni.subscribe().withSubscriber(ts1);
-        ts1.assertFailure(NullPointerException.class, "supplier");
-        uni.subscribe().withSubscriber(ts2);
-        ts2.assertFailure(IllegalStateException.class, "Invalid shared state");
+        uni.subscribe().withSubscriber(s1);
+        s1.assertFailure(NullPointerException.class, "supplier");
+        uni.subscribe().withSubscriber(s2);
+        s2.assertFailure(IllegalStateException.class, "Invalid shared state");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromFailureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromFailureTest.java
@@ -18,42 +18,45 @@ public class UniCreateFromFailureTest {
         Uni<Object> boom = Uni.createFrom().failure(() -> new IOException("boom"));
         try {
             boom.await().indefinitely();
-            fail("Exception expected");
         } catch (Exception e) {
             assertThat(e).hasCauseInstanceOf(IOException.class);
+            return;
         }
+        fail("Exception expected");
     }
 
     @Test
     public void testCreationWithCheckedException() {
-        UniAssertSubscriber<Object> ts = UniAssertSubscriber.create();
-        Uni.createFrom().failure(new Exception("boom")).subscribe().withSubscriber(ts);
-        ts.assertFailure(Exception.class, "boom");
+        UniAssertSubscriber<Object> subscriber = UniAssertSubscriber.create();
+        Uni.createFrom().failure(new Exception("boom")).subscribe().withSubscriber(subscriber);
+        subscriber.assertFailure(Exception.class, "boom");
 
         try {
             Uni.createFrom().failure(new Exception("boom")).await().asOptional().indefinitely();
-            fail("Exception expected");
         } catch (Exception e) {
             assertThat(e).hasCauseInstanceOf(Exception.class)
                     .isInstanceOf(RuntimeException.class);
+            return;
         }
-
+        fail("Exception expected");
     }
 
     @Test
     public void testCreationWithRuntimeException() {
-        UniAssertSubscriber<Object> ts = UniAssertSubscriber.create();
-        Uni.createFrom().failure(new RuntimeException("boom")).subscribe().withSubscriber(ts);
-        ts.assertFailure(RuntimeException.class, "boom");
+        UniAssertSubscriber<Object> subscriber = UniAssertSubscriber.create();
+        Uni.createFrom().failure(new RuntimeException("boom")).subscribe().withSubscriber(subscriber);
+        subscriber.assertFailure(RuntimeException.class, "boom");
 
         try {
             Uni.createFrom().failure(new RuntimeException("boom")).await().indefinitely();
-            fail("Exception expected");
         } catch (Exception e) {
             assertThat(e)
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage("boom");
+            return;
         }
+        fail("Exception expected");
+
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -71,10 +74,11 @@ public class UniCreateFromFailureTest {
         Uni<Object> boom = Uni.createFrom().failure(() -> null);
         try {
             boom.await().indefinitely();
-            fail("Exception expected");
         } catch (Exception e) {
             assertThat(e).isInstanceOf(NullPointerException.class);
+            return;
         }
+        fail("Exception expected");
     }
 
     @Test
@@ -84,10 +88,11 @@ public class UniCreateFromFailureTest {
         });
         try {
             boom.await().indefinitely();
-            fail("Exception expected");
         } catch (Exception e) {
             assertThat(e).isInstanceOf(NoSuchElementException.class);
+            return;
         }
+        fail("Exception expected");
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromItemTest.java
@@ -15,26 +15,26 @@ public class UniCreateFromItemTest {
 
     @Test
     public void testThatNullValueAreAccepted() {
-        UniAssertSubscriber<Object> ts = UniAssertSubscriber.create();
-        Uni.createFrom().item((String) null).subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(null);
+        UniAssertSubscriber<Object> subscriber = UniAssertSubscriber.create();
+        Uni.createFrom().item((String) null).subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(null);
     }
 
     @Test
     public void testWithNonNullValue() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
-        Uni.createFrom().item(1).subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(1);
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
+        Uni.createFrom().item(1).subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(1);
     }
 
     @Test
     public void testThatEmptyIsAcceptedWithFromOptional() {
-        UniAssertSubscriber<Object> ts = UniAssertSubscriber.create();
-        Uni.createFrom().optional(Optional.empty()).subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(null);
+        UniAssertSubscriber<Object> subscriber = UniAssertSubscriber.create();
+        Uni.createFrom().optional(Optional.empty()).subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(null);
     }
 
-    @SuppressWarnings({ "OptionalAssignedToNull", "unchecked" })
+    @SuppressWarnings({ "OptionalAssignedToNull", "unchecked", "rawtypes" })
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testThatNullIfNotAcceptedByFromOptional() {
         Uni.createFrom().optional((Optional) null); // Immediate failure, no need for subscription
@@ -42,14 +42,15 @@ public class UniCreateFromItemTest {
 
     @Test
     public void testThatFulfilledOptionalIsAcceptedWithFromOptional() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
-        Uni.createFrom().optional(Optional.of(1)).subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(1);
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
+        Uni.createFrom().optional(Optional.of(1)).subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(1);
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void testThatValueIsNotEmittedBeforeSubscription() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         AtomicBoolean called = new AtomicBoolean();
         Uni<Integer> uni = Uni.createFrom().item(1).map(i -> {
             called.set(true);
@@ -58,8 +59,8 @@ public class UniCreateFromItemTest {
 
         assertThat(called).isFalse();
 
-        uni.subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(2);
+        uni.subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(2);
         assertThat(called).isTrue();
     }
 
@@ -109,25 +110,25 @@ public class UniCreateFromItemTest {
 
     @Test
     public void testWithSharedState() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s2 = UniAssertSubscriber.create();
         AtomicInteger shared = new AtomicInteger();
         Uni<Integer> uni = Uni.createFrom().item(() -> shared,
                 AtomicInteger::incrementAndGet);
 
         assertThat(shared).hasValue(0);
-        uni.subscribe().withSubscriber(ts1);
+        uni.subscribe().withSubscriber(s1);
         assertThat(shared).hasValue(1);
-        ts1.assertCompletedSuccessfully().assertItem(1);
-        uni.subscribe().withSubscriber(ts2);
+        s1.assertCompletedSuccessfully().assertItem(1);
+        uni.subscribe().withSubscriber(s2);
         assertThat(shared).hasValue(2);
-        ts2.assertCompletedSuccessfully().assertItem(2);
+        s2.assertCompletedSuccessfully().assertItem(2);
     }
 
     @Test
     public void testWithSharedStateProducingFailure() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s2 = UniAssertSubscriber.create();
         Supplier<AtomicInteger> boom = () -> {
             throw new IllegalStateException("boom");
         };
@@ -135,25 +136,25 @@ public class UniCreateFromItemTest {
         Uni<Integer> uni = Uni.createFrom().item(boom,
                 AtomicInteger::incrementAndGet);
 
-        uni.subscribe().withSubscriber(ts1);
-        ts1.assertFailure(IllegalStateException.class, "boom");
-        uni.subscribe().withSubscriber(ts2);
-        ts2.assertFailure(IllegalStateException.class, "Invalid shared state");
+        uni.subscribe().withSubscriber(s1);
+        s1.assertFailure(IllegalStateException.class, "boom");
+        uni.subscribe().withSubscriber(s2);
+        s2.assertFailure(IllegalStateException.class, "Invalid shared state");
     }
 
     @Test
     public void testWithSharedStateProducingNull() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s2 = UniAssertSubscriber.create();
         Supplier<AtomicInteger> boom = () -> null;
 
         Uni<Integer> uni = Uni.createFrom().item(boom,
                 AtomicInteger::incrementAndGet);
 
-        uni.subscribe().withSubscriber(ts1);
-        ts1.assertFailure(NullPointerException.class, "supplier");
-        uni.subscribe().withSubscriber(ts2);
-        ts2.assertFailure(IllegalStateException.class, "Invalid shared state");
+        uni.subscribe().withSubscriber(s1);
+        s1.assertFailure(NullPointerException.class, "supplier");
+        uni.subscribe().withSubscriber(s2);
+        s2.assertFailure(IllegalStateException.class, "Invalid shared state");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniFromPublisherTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniFromPublisherTest.java
@@ -15,45 +15,47 @@ public class UniFromPublisherTest {
 
     @Test
     public void testWithPublisher() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
-        Uni.createFrom().publisher(Flowable.just(1)).subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(1);
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
+        Uni.createFrom().publisher(Flowable.just(1)).subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(1);
     }
 
     @Test
     public void testWithPublisherBuilder() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
-        Uni.createFrom().publisher(Flowable.just(1)).subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(1);
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
+        Uni.createFrom().publisher(Flowable.just(1)).subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(1);
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void testWithMultiValuedPublisher() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         AtomicBoolean cancelled = new AtomicBoolean();
         Uni.createFrom().publisher(Flowable.just(1, 2, 3).doOnCancel(() -> cancelled.set(true))).subscribe()
-                .withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(1);
+                .withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(1);
         assertThat(cancelled).isTrue();
     }
 
     @Test
     public void testWithException() {
-        UniAssertSubscriber<Object> ts = UniAssertSubscriber.create();
-        Uni.createFrom().publisher(Flowable.error(new IOException("boom"))).subscribe().withSubscriber(ts);
-        ts.assertFailure(IOException.class, "boom");
+        UniAssertSubscriber<Object> subscriber = UniAssertSubscriber.create();
+        Uni.createFrom().publisher(Flowable.error(new IOException("boom"))).subscribe().withSubscriber(subscriber);
+        subscriber.assertFailure(IOException.class, "boom");
     }
 
     @Test
     public void testWithEmptyStream() {
-        UniAssertSubscriber<Object> ts = UniAssertSubscriber.create();
-        Uni.createFrom().publisher(Flowable.empty()).subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(null);
+        UniAssertSubscriber<Object> subscriber = UniAssertSubscriber.create();
+        Uni.createFrom().publisher(Flowable.empty()).subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(null);
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void testThatValueIsNotEmittedBeforeSubscription() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         AtomicBoolean called = new AtomicBoolean();
         Uni<Integer> uni = Uni.createFrom().publisher(Flowable.generate(emitter -> {
             called.set(true);
@@ -62,14 +64,14 @@ public class UniFromPublisherTest {
         }));
 
         assertThat(called).isFalse();
-        uni.subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(1);
+        uni.subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(1);
         assertThat(called).isTrue();
     }
 
     @Test
     public void testThatSubscriberIsIncompleteIfThePublisherDoesNotEmit() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         AtomicBoolean called = new AtomicBoolean();
         Uni<Integer> uni = Uni.createFrom().<Integer> publisher(Flowable.never()).map(i -> {
             called.set(true);
@@ -78,14 +80,14 @@ public class UniFromPublisherTest {
 
         assertThat(called).isFalse();
 
-        uni.subscribe().withSubscriber(ts);
+        uni.subscribe().withSubscriber(subscriber);
         assertThat(called).isFalse();
-        ts.assertNotCompleted();
+        subscriber.assertNotCompleted();
     }
 
     @Test
     public void testThatSubscriberCanCancelBeforeEmission() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         Uni<Integer> uni = Uni.createFrom().publisher(Flowable.<Integer> create(emitter -> new Thread(() -> {
             try {
                 Thread.sleep(50);
@@ -95,10 +97,10 @@ public class UniFromPublisherTest {
             emitter.onNext(1);
         }).start(), BackpressureStrategy.DROP)).map(i -> i + 1);
 
-        uni.subscribe().withSubscriber(ts);
-        ts.cancel();
+        uni.subscribe().withSubscriber(subscriber);
+        subscriber.cancel();
 
-        ts.assertNotCompleted();
+        subscriber.assertNotCompleted();
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
@@ -15,59 +15,59 @@ public class UniIfNoItemTest {
 
     @Test
     public void testResultWhenTimeoutIsNotReached() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
         Uni.createFrom().item(1)
                 .ifNoItem().after(Duration.ofMillis(10)).recoverWithUni(Uni.createFrom().nothing())
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.await().assertCompletedSuccessfully().assertItem(1);
+        subscriber.await().assertCompletedSuccessfully().assertItem(1);
     }
 
     @Test
     public void testTimeout() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
         Uni.createFrom().item(1)
                 .onItem().delayIt().by(Duration.ofMillis(10))
                 .ifNoItem().after(Duration.ofMillis(1)).fail()
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.await().assertCompletedWithFailure();
-        assertThat(ts.getFailure()).isInstanceOf(TimeoutException.class);
+        subscriber.await().assertCompletedWithFailure();
+        assertThat(subscriber.getFailure()).isInstanceOf(TimeoutException.class);
 
     }
 
     @Test
     public void testRecoverWithItem() {
-        UniAssertSubscriber<Integer> ts = Uni.createFrom().<Integer> nothing()
+        UniAssertSubscriber<Integer> subscriber = Uni.createFrom().<Integer> nothing()
                 .ifNoItem().after(Duration.ofMillis(10)).recoverWithItem(5)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        ts.await().assertItem(5);
+        subscriber.await().assertItem(5);
     }
 
     @Test
     public void testRecoverWithItemSupplier() {
-        UniAssertSubscriber<Integer> ts = Uni.createFrom().<Integer> nothing()
+        UniAssertSubscriber<Integer> subscriber = Uni.createFrom().<Integer> nothing()
                 .ifNoItem().after(Duration.ofMillis(10)).recoverWithItem(() -> 23)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        ts.await().assertItem(23);
+        subscriber.await().assertItem(23);
     }
 
     @Test
     public void testRecoverWithSwitchToUni() {
-        UniAssertSubscriber<Integer> ts = Uni.createFrom().<Integer> nothing()
+        UniAssertSubscriber<Integer> subscriber = Uni.createFrom().<Integer> nothing()
                 .ifNoItem().after(Duration.ofMillis(10)).recoverWithUni(() -> Uni.createFrom().item(15))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        ts.await().assertItem(15);
+        subscriber.await().assertItem(15);
     }
 
     @Test
     public void testFailingWithAnotherException() {
-        UniAssertSubscriber<Integer> ts = Uni.createFrom().<Integer> nothing()
+        UniAssertSubscriber<Integer> subscriber = Uni.createFrom().<Integer> nothing()
                 .ifNoItem().after(Duration.ofMillis(10)).failWith(new IOException("boom"))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        ts.await().assertFailure(IOException.class, "boom");
+        subscriber.await().assertFailure(IOException.class, "boom");
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRecoveryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRecoveryTest.java
@@ -173,54 +173,54 @@ public class UniOnFailureRecoveryTest {
 
     @Test
     public void testNotCalledOnItem() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         Uni.createFrom().item(1)
                 .onFailure().recoverWithUni(v -> Uni.createFrom().item(2))
-                .subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(1);
+                .subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(1);
     }
 
     @Test
     public void testCalledOnFailure() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
         Uni.createFrom().<Integer> failure(new RuntimeException("boom"))
                 .onFailure().recoverWithUni(fail -> Uni.createFrom().item(2))
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.assertCompletedSuccessfully().assertItem(2);
+        subscriber.assertCompletedSuccessfully().assertItem(2);
     }
 
     @Test
     public void testCalledOnFailureWithDirectResult() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
         Uni.createFrom().<Integer> failure(new RuntimeException("boom"))
                 .onFailure().recoverWithItem(fail -> 2)
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.assertCompletedSuccessfully().assertItem(2);
+        subscriber.assertCompletedSuccessfully().assertItem(2);
     }
 
     @Test
     public void testWithMappingOfFailure() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         Uni.createFrom().<Integer> failure(new Exception())
                 .onFailure().transform(f -> new RuntimeException("boom"))
-                .subscribe().withSubscriber(ts);
-        ts.assertCompletedWithFailure()
+                .subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedWithFailure()
                 .assertFailure(RuntimeException.class, "boom");
     }
 
     @Test
     public void testWithMappingOfFailureAndPredicates() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         Uni.createFrom().<Integer> failure(new IOException())
                 .onFailure().transform(t -> new IndexOutOfBoundsException())
                 .onFailure(IOException.class).recoverWithUni(Uni.createFrom().item(1))
                 .onFailure(IndexOutOfBoundsException.class).recoverWithUni(Uni.createFrom().item(2))
-                .subscribe().withSubscriber(ts);
-        ts.assertCompletedSuccessfully().assertItem(2);
+                .subscribe().withSubscriber(subscriber);
+        subscriber.assertCompletedSuccessfully().assertItem(2);
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRetryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRetryTest.java
@@ -20,17 +20,17 @@ public class UniOnFailureRetryTest {
 
     @Test
     public void testNoRetryOnItem() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         Uni.createFrom().item(1)
                 .onFailure().retry().atMost(1)
-                .subscribe().withSubscriber(ts);
-        ts.assertItem(1);
+                .subscribe().withSubscriber(subscriber);
+        subscriber.assertItem(1);
 
     }
 
     @Test
     public void testWithOneRetry() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
         Uni.createFrom().item(() -> {
@@ -41,9 +41,9 @@ public class UniOnFailureRetryTest {
             return i;
         })
                 .onFailure().retry().atMost(1)
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts
+        subscriber
                 .assertCompletedSuccessfully()
                 .assertItem(1);
 
@@ -51,7 +51,7 @@ public class UniOnFailureRetryTest {
 
     @Test
     public void testWithInfiniteRetry() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         AtomicInteger count = new AtomicInteger();
         Uni.createFrom().item(() -> {
             int i = count.getAndIncrement();
@@ -61,9 +61,9 @@ public class UniOnFailureRetryTest {
             return i;
         })
                 .onFailure().retry().indefinitely()
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts
+        subscriber
                 .assertCompletedSuccessfully()
                 .assertItem(10);
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDisjointTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDisjointTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class UniOnItemDisjointTest {
 
@@ -123,10 +123,10 @@ public class UniOnItemDisjointTest {
     @Test
     public void testDisjointWithNeverPublisher() {
         AtomicBoolean cancelled = new AtomicBoolean();
-        MultiAssertSubscriber<String> subscriber = Uni.createFrom()
+        AssertSubscriber<String> subscriber = Uni.createFrom()
                 .item(Flowable.never().doOnCancel(() -> cancelled.set(true)))
                 .onItem().<String> disjoint()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
 
         subscriber.assertSubscribed()
                 .assertNotTerminated();
@@ -142,10 +142,10 @@ public class UniOnItemDisjointTest {
     @Test
     public void testDisjointWithNothing() {
         AtomicBoolean cancelled = new AtomicBoolean();
-        MultiAssertSubscriber<String> subscriber = Uni.createFrom()
+        AssertSubscriber<String> subscriber = Uni.createFrom()
                 .item(Multi.createFrom().nothing().on().cancellation(() -> cancelled.set(true)))
                 .onItem().<String> disjoint()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
 
         subscriber.assertSubscribed()
                 .assertNotTerminated();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureInvokeTest.java
@@ -40,15 +40,15 @@ public class UniOnItemOrFailureInvokeTest {
 
     @Test
     public void testCallbackOnItem() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
         one.onItemOrFailure().invoke((i, f) -> {
             assertThat(f).isNull();
             count.incrementAndGet();
-        }).subscribe().withSubscriber(ts);
+        }).subscribe().withSubscriber(subscriber);
 
-        ts.assertCompletedSuccessfully()
+        subscriber.assertCompletedSuccessfully()
                 .assertItem(1);
 
         assertThat(count).hasValue(1);
@@ -56,15 +56,15 @@ public class UniOnItemOrFailureInvokeTest {
 
     @Test
     public void testCallbackOnNullItem() {
-        UniAssertSubscriber<Void> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Void> subscriber = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
         none.onItemOrFailure().invoke((i, f) -> {
             assertThat(f).isNull();
             count.incrementAndGet();
-        }).subscribe().withSubscriber(ts);
+        }).subscribe().withSubscriber(subscriber);
 
-        ts.assertCompletedSuccessfully()
+        subscriber.assertCompletedSuccessfully()
                 .assertItem(null);
 
         assertThat(count).hasValue(1);
@@ -72,53 +72,53 @@ public class UniOnItemOrFailureInvokeTest {
 
     @Test
     public void testCallbackOnFailure() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
         failed.onItemOrFailure().invoke((i, f) -> {
             assertThat(i).isNull();
             assertThat(f).isNotNull().isInstanceOf(IOException.class).hasMessageContaining("boom");
             count.incrementAndGet();
-        }).subscribe().withSubscriber(ts);
+        }).subscribe().withSubscriber(subscriber);
 
-        ts.assertFailure(IOException.class, "boom");
+        subscriber.assertFailure(IOException.class, "boom");
 
         assertThat(count).hasValue(1);
     }
 
     @Test
     public void testCallbackOnItemThrowingException() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
         one.onItemOrFailure().invoke((i, f) -> {
             assertThat(f).isNull();
             count.incrementAndGet();
             throw new IllegalStateException("kaboom");
-        }).subscribe().withSubscriber(ts);
+        }).subscribe().withSubscriber(subscriber);
 
-        ts.assertFailure(IllegalStateException.class, "kaboom");
+        subscriber.assertFailure(IllegalStateException.class, "kaboom");
         assertThat(count).hasValue(1);
     }
 
     @Test
     public void testCallbackOnItemThrowingExceptionWithInvokeUni() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
         one.onItemOrFailure().invoke((i, f) -> {
             assertThat(f).isNull();
             count.incrementAndGet();
             throw new IllegalStateException("kaboom");
-        }).subscribe().withSubscriber(ts);
+        }).subscribe().withSubscriber(subscriber);
 
-        ts.assertFailure(IllegalStateException.class, "kaboom");
+        subscriber.assertFailure(IllegalStateException.class, "kaboom");
         assertThat(count).hasValue(1);
     }
 
     @Test
     public void testCallbackOnFailureThrowingException() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
         failed.onItemOrFailure().invoke((i, f) -> {
@@ -126,44 +126,44 @@ public class UniOnItemOrFailureInvokeTest {
             assertThat(f).isNotNull().isInstanceOf(IOException.class).hasMessageContaining("boom");
             count.incrementAndGet();
             throw new IllegalStateException("kaboom");
-        }).subscribe().withSubscriber(ts);
+        }).subscribe().withSubscriber(subscriber);
 
-        ts.assertFailure(CompositeException.class, "kaboom");
-        ts.assertFailure(CompositeException.class, "boom");
+        subscriber.assertFailure(CompositeException.class, "kaboom");
+        subscriber.assertFailure(CompositeException.class, "boom");
 
         assertThat(count).hasValue(1);
     }
 
     @Test
     public void testWithTwoSubscribers() {
-        UniAssertSubscriber<Integer> ts1 = UniAssertSubscriber.create();
-        UniAssertSubscriber<Integer> ts2 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s1 = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> s2 = UniAssertSubscriber.create();
 
         AtomicInteger count = new AtomicInteger();
         Uni<Integer> uni = one.onItemOrFailure().invoke((v, f) -> count.incrementAndGet());
-        uni.subscribe().withSubscriber(ts1);
-        uni.subscribe().withSubscriber(ts2);
+        uni.subscribe().withSubscriber(s1);
+        uni.subscribe().withSubscriber(s2);
 
-        ts1.assertCompletedSuccessfully()
+        s1.assertCompletedSuccessfully()
                 .assertItem(1);
-        ts2.assertCompletedSuccessfully()
+        s2.assertCompletedSuccessfully()
                 .assertItem(1);
     }
 
     @Test
     public void testThatCallbackIsCalledOnTheRightExecutorOnItem() {
-        UniAssertSubscriber<Integer> ts = new UniAssertSubscriber<>();
+        UniAssertSubscriber<Integer> subscriber = new UniAssertSubscriber<>();
         ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
             AtomicReference<String> threadName = new AtomicReference<>();
             one
                     .emitOn(executor)
                     .onItemOrFailure().invoke((i, f) -> threadName.set(Thread.currentThread().getName()))
-                    .subscribe().withSubscriber(ts);
+                    .subscribe().withSubscriber(subscriber);
 
-            ts.await().assertCompletedSuccessfully().assertItem(1);
+            subscriber.await().assertCompletedSuccessfully().assertItem(1);
             assertThat(threadName).isNotNull().doesNotHaveValue("main");
-            assertThat(ts.getOnItemThreadName()).isEqualTo(threadName.get());
+            assertThat(subscriber.getOnItemThreadName()).isEqualTo(threadName.get());
         } finally {
             executor.shutdown();
         }
@@ -171,7 +171,7 @@ public class UniOnItemOrFailureInvokeTest {
 
     @Test
     public void testThatCallbackIsCalledOnTheRightExecutorOnFailure() {
-        UniAssertSubscriber<Integer> ts = new UniAssertSubscriber<>();
+        UniAssertSubscriber<Integer> subscriber = new UniAssertSubscriber<>();
         ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
             AtomicReference<String> threadName = new AtomicReference<>();
@@ -183,11 +183,11 @@ public class UniOnItemOrFailureInvokeTest {
                         assertThat(f).isNotNull();
                     })
                     .onFailure().recoverWithItem(1)
-                    .subscribe().withSubscriber(ts);
+                    .subscribe().withSubscriber(subscriber);
 
-            ts.await().assertCompletedSuccessfully().assertItem(1);
+            subscriber.await().assertCompletedSuccessfully().assertItem(1);
             assertThat(threadName).isNotNull().doesNotHaveValue("main");
-            assertThat(ts.getOnItemThreadName()).isEqualTo(threadName.get());
+            assertThat(subscriber.getOnItemThreadName()).isEqualTo(threadName.get());
         } finally {
             executor.shutdown();
         }
@@ -195,16 +195,16 @@ public class UniOnItemOrFailureInvokeTest {
 
     @Test
     public void testInvokeUniOnItem() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         AtomicInteger reference = new AtomicInteger();
         AtomicInteger count = new AtomicInteger();
         one.onItemOrFailure().invokeUni((i, f) -> {
             assertThat(f).isNull();
             count.incrementAndGet();
             return two.onItem().invoke(reference::set);
-        }).subscribe().withSubscriber(ts);
+        }).subscribe().withSubscriber(subscriber);
 
-        ts.assertCompletedSuccessfully()
+        subscriber.assertCompletedSuccessfully()
                 .assertItem(1);
         assertThat(reference).hasValue(2);
         assertThat(count).hasValue(1);
@@ -212,7 +212,7 @@ public class UniOnItemOrFailureInvokeTest {
 
     @Test
     public void testInvokeUniNullOnItem() {
-        UniAssertSubscriber<Void> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Void> subscriber = UniAssertSubscriber.create();
         AtomicInteger reference = new AtomicInteger();
         AtomicInteger count = new AtomicInteger();
         none.onItemOrFailure().invokeUni((i, f) -> {
@@ -220,16 +220,16 @@ public class UniOnItemOrFailureInvokeTest {
             assertThat(i).isNull();
             count.incrementAndGet();
             return two.onItem().invoke(reference::set);
-        }).subscribe().withSubscriber(ts);
+        }).subscribe().withSubscriber(subscriber);
 
-        ts.assertCompletedSuccessfully().assertItem(null);
+        subscriber.assertCompletedSuccessfully().assertItem(null);
         assertThat(reference).hasValue(2);
         assertThat(count).hasValue(1);
     }
 
     @Test
     public void testInvokeUniOnFailure() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         AtomicInteger reference = new AtomicInteger();
         AtomicInteger count = new AtomicInteger();
         failed.onItemOrFailure().invokeUni((i, f) -> {
@@ -238,9 +238,9 @@ public class UniOnItemOrFailureInvokeTest {
             count.incrementAndGet();
             return two.onItem().invoke(reference::set);
 
-        }).subscribe().withSubscriber(ts);
+        }).subscribe().withSubscriber(subscriber);
 
-        ts.assertFailure(IOException.class, "boom");
+        subscriber.assertFailure(IOException.class, "boom");
         assertThat(reference).hasValue(2);
         assertThat(count).hasValue(1);
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToMultiTest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 @SuppressWarnings("ConstantConditions")
 public class UniOnItemTransformToMultiTest {
@@ -24,7 +24,7 @@ public class UniOnItemTransformToMultiTest {
     public void testTransformToMultiWithItem() {
         Uni.createFrom().item(1)
                 .onItem().transformToMulti(i -> Multi.createFrom().range(i, 5))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .await()
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
@@ -35,7 +35,7 @@ public class UniOnItemTransformToMultiTest {
     public void testTransformToMultiWithItemDeprecated() {
         Uni.createFrom().item(1)
                 .onItem().produceMulti(i -> Multi.createFrom().range(i, 5))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .await()
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
@@ -45,7 +45,7 @@ public class UniOnItemTransformToMultiTest {
     public void testTransformToMultiWithNull() {
         Uni.createFrom().voidItem()
                 .onItem().transformToMulti(x -> Multi.createFrom().range(1, 5))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .await()
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4);
@@ -55,7 +55,7 @@ public class UniOnItemTransformToMultiTest {
     public void testTransformToMultiWithFailure() {
         Uni.createFrom().<Integer> failure(new IOException("boom"))
                 .onItem().transformToMulti(x -> Multi.createFrom().range(1, 5))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .await()
                 .assertHasFailedWith(IOException.class, "boom")
                 .assertHasNotReceivedAnyItem();
@@ -67,7 +67,7 @@ public class UniOnItemTransformToMultiTest {
                 .onItem().transformToMulti(x -> {
                     throw new IllegalStateException("boom");
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .await()
                 .assertHasFailedWith(IllegalStateException.class, "boom")
                 .assertHasNotReceivedAnyItem();
@@ -77,7 +77,7 @@ public class UniOnItemTransformToMultiTest {
     public void testTransformToMultiWithNullReturnedByMapper() {
         Uni.createFrom().item(1)
                 .onItem().transformToMulti(x -> null)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .await()
                 .assertHasFailedWith(NullPointerException.class, "")
                 .assertHasNotReceivedAnyItem();
@@ -90,7 +90,7 @@ public class UniOnItemTransformToMultiTest {
         Uni.createFrom().<Integer> nothing()
                 .onCancellation().invoke(() -> called.set(true))
                 .onItem().transformToMulti(x -> Multi.createFrom().range(x, 10))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
 
                 .assertNotTerminated()
                 .assertHasNotReceivedAnyItem()
@@ -109,7 +109,7 @@ public class UniOnItemTransformToMultiTest {
                 .onCancellation().invoke(() -> calledUni.set(true))
                 .onItem().transformToMulti(i -> Multi.createFrom().nothing()
                         .on().cancellation(() -> called.set(true)))
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
                 .assertNotTerminated()
                 .assertHasNotReceivedAnyItem()
                 .run(() -> assertThat(called).isFalse())

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRepeatTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRepeatTest.java
@@ -21,8 +21,8 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.test.AssertSubscriber;
 import io.smallrye.mutiny.test.Mocks;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
 
 public class UniRepeatTest {
 
@@ -55,10 +55,10 @@ public class UniRepeatTest {
         Page[] pages = new Page[] { page1, page2, page3 };
         AtomicInteger cursor = new AtomicInteger();
 
-        MultiAssertSubscriber<Integer> subscriber = Multi.createBy().repeating()
+        AssertSubscriber<Integer> subscriber = Multi.createBy().repeating()
                 .uni(() -> Uni.createFrom().item(pages[cursor.getAndIncrement()])).whilst(p -> p.next != -1)
                 .onItem().transformToMulti(p -> Multi.createFrom().iterable(p.items)).concatenate()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(50));
+                .subscribe().withSubscriber(AssertSubscriber.create(50));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4, 5, 6, 7, 8);
@@ -289,10 +289,10 @@ public class UniRepeatTest {
     @Test
     public void testRequestAndCancellation() {
         final AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
                 .repeat().indefinitely()
                 .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         await().untilAsserted(subscriber::assertSubscribed);
         subscriber.assertSubscribed().assertHasNotReceivedAnyItem();
@@ -326,10 +326,10 @@ public class UniRepeatTest {
     @Test
     public void testRequestAndCancellationWithRepeatUntil() {
         final AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
                 .repeat().until(x -> false)
                 .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         await().untilAsserted(subscriber::assertSubscribed);
         subscriber.assertSubscribed().assertHasNotReceivedAnyItem();
@@ -363,10 +363,10 @@ public class UniRepeatTest {
     @Test
     public void testRequestAndCancellationWithRepeatWhilst() {
         final AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
                 .repeat().whilst(x -> true)
                 .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         await().untilAsserted(subscriber::assertSubscribed);
         subscriber.assertSubscribed().assertHasNotReceivedAnyItem();
@@ -400,10 +400,10 @@ public class UniRepeatTest {
     @Test
     public void testRequestWithAtMost() {
         final AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
                 .repeat().atMost(3)
                 .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         await().untilAsserted(subscriber::assertSubscribed);
         subscriber.assertSubscribed().assertHasNotReceivedAnyItem();
@@ -426,7 +426,7 @@ public class UniRepeatTest {
     @Test
     public void testFailurePropagationAfterFewRepeats() {
         AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
             int v = count.incrementAndGet();
             if (v == 3) {
                 throw new IllegalStateException("boom");
@@ -434,7 +434,7 @@ public class UniRepeatTest {
             return v;
         })
                 .repeat().indefinitely()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
                 .await()
@@ -446,7 +446,7 @@ public class UniRepeatTest {
     @Test
     public void testFailurePropagationAfterFewRepeatsWithRepeatUntil() {
         AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
             int v = count.incrementAndGet();
             if (v == 3) {
                 throw new IllegalStateException("boom");
@@ -454,7 +454,7 @@ public class UniRepeatTest {
             return v;
         })
                 .repeat().until(x -> false)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
                 .await()
@@ -466,7 +466,7 @@ public class UniRepeatTest {
     @Test
     public void testFailurePropagationAfterFewRepeatsWithRepeatWhilst() {
         AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
             int v = count.incrementAndGet();
             if (v == 3) {
                 throw new IllegalStateException("boom");
@@ -474,7 +474,7 @@ public class UniRepeatTest {
             return v;
         })
                 .repeat().whilst(x -> true)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
                 .await()
@@ -486,7 +486,7 @@ public class UniRepeatTest {
     @Test
     public void testFailurePropagationAfterMaxRepeats() {
         AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
             int v = count.incrementAndGet();
             if (v == 3) {
                 throw new IllegalStateException("boom");
@@ -494,7 +494,7 @@ public class UniRepeatTest {
             return v;
         })
                 .repeat().atMost(2)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
                 .await()
@@ -506,7 +506,7 @@ public class UniRepeatTest {
     @Test
     public void testEmptyUniOnceInAWhileWithAtMost() {
         AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
             int v = count.incrementAndGet();
             if (v % 3 == 0) {
                 return null;
@@ -514,7 +514,7 @@ public class UniRepeatTest {
             return v;
         })
                 .repeat().atMost(10)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(100)
                 .await()
@@ -526,7 +526,7 @@ public class UniRepeatTest {
     @Test
     public void testEmptyUniOnceInAWhileWithIndefinitely() {
         AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
             int v = count.incrementAndGet();
             if (v % 3 == 0) {
                 return null;
@@ -534,7 +534,7 @@ public class UniRepeatTest {
             return v;
         })
                 .repeat().indefinitely()
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
                 .run(() -> await().until(() -> subscriber.items().size() == 10))
@@ -546,14 +546,14 @@ public class UniRepeatTest {
     @Test
     public void testPredicateFailureWithUntil() {
         AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
                 .repeat().until(v -> {
                     if (v % 3 == 0) {
                         throw new IllegalStateException("boom");
                     }
                     return false;
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
                 .assertHasFailedWith(IllegalStateException.class, "boom")
@@ -564,14 +564,14 @@ public class UniRepeatTest {
     @Test
     public void testPredicateFailureWithWhilst() {
         AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(count::incrementAndGet)
                 .repeat().whilst(v -> {
                     if (v % 3 == 0) {
                         throw new IllegalStateException("boom");
                     }
                     return true;
                 })
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
                 .assertHasFailedWith(IllegalStateException.class, "boom")
@@ -582,7 +582,7 @@ public class UniRepeatTest {
     @Test
     public void testEmptyUniOnceInAWhileWithUntil() {
         AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
             int v = count.incrementAndGet();
             if (v % 3 == 0) {
                 return null;
@@ -590,7 +590,7 @@ public class UniRepeatTest {
             return v;
         })
                 .repeat().until(value -> value >= 1000)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
                 .run(() -> await().until(() -> subscriber.items().size() == 10))
@@ -602,7 +602,7 @@ public class UniRepeatTest {
     @Test
     public void testEmptyUniOnceInAWhileWithWhilst() {
         AtomicInteger count = new AtomicInteger();
-        MultiAssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
+        AssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> {
             int v = count.incrementAndGet();
             if (v % 3 == 0) {
                 return null;
@@ -610,7 +610,7 @@ public class UniRepeatTest {
             return v;
         })
                 .repeat().whilst(value -> value < 1000)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create());
+                .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
                 .run(() -> await().until(() -> subscriber.items().size() == 10))

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
@@ -19,30 +19,30 @@ public class UniRunSubscriptionOnTest {
 
     @Test
     public void testRunSubscriptionOnWithSupplier() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
         Uni.createFrom().item(() -> 1)
                 .runSubscriptionOn(ForkJoinPool.commonPool())
-                .subscribe().withSubscriber(ts);
-        ts.await().assertItem(1);
-        assertThat(ts.getOnSubscribeThreadName()).isNotEqualTo(Thread.currentThread().getName());
+                .subscribe().withSubscriber(subscriber);
+        subscriber.await().assertItem(1);
+        assertThat(subscriber.getOnSubscribeThreadName()).isNotEqualTo(Thread.currentThread().getName());
     }
 
     @Test
     public void testWithWithImmediateValue() {
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
         Uni.createFrom().item(1)
                 .runSubscriptionOn(ForkJoinPool.commonPool())
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.await().assertItem(1);
-        assertThat(ts.getOnSubscribeThreadName()).isNotEqualTo(Thread.currentThread().getName());
+        subscriber.await().assertItem(1);
+        assertThat(subscriber.getOnSubscribeThreadName()).isNotEqualTo(Thread.currentThread().getName());
     }
 
     @Test
     public void testWithTimeout() {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
-        UniAssertSubscriber<Integer> ts = UniAssertSubscriber.create();
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
         Uni.createFrom().item(() -> {
             try {
@@ -55,9 +55,9 @@ public class UniRunSubscriptionOnTest {
                 .ifNoItem().after(Duration.ofMillis(100)).recoverWithUni(Uni.createFrom().item(() -> 1))
                 // Should not use the default as in container you may have a single thread, blocked by the sleep statement.
                 .runSubscriptionOn(executorService)
-                .subscribe().withSubscriber(ts);
+                .subscribe().withSubscriber(subscriber);
 
-        ts.await().assertItem(1);
+        subscriber.await().assertItem(1);
 
         executorService.shutdownNow();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniToMultiTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class UniToMultiTest {
 
@@ -20,46 +20,46 @@ public class UniToMultiTest {
         Multi<Void> multi = Uni.createFrom().item((Object) null)
                 .onItem().castTo(Void.class)
                 .toMulti();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1)).assertCompletedSuccessfully();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0)).assertNotTerminated().cancel();
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1)).assertCompletedSuccessfully();
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0)).assertNotTerminated().cancel();
     }
 
     @Test
     public void testFromEmpty2() {
         Multi<Void> multi = Multi.createFrom().uni(Uni.createFrom().voidItem());
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1)).assertCompletedSuccessfully();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0)).assertNotTerminated().cancel();
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1)).assertCompletedSuccessfully();
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0)).assertNotTerminated().cancel();
     }
 
     @Test
     public void testFromEmpty3() {
         Multi<Void> multi = Uni.createFrom().voidItem().toMulti();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1)).assertCompletedSuccessfully();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0)).assertNotTerminated().cancel();
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1)).assertCompletedSuccessfully();
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0)).assertNotTerminated().cancel();
     }
 
     @Test
     public void testFromEmpty4() {
         Multi<String> multi = Uni.createFrom().<String> nullItem().toMulti();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1)).assertCompletedSuccessfully();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0)).assertNotTerminated().cancel();
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1)).assertCompletedSuccessfully();
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0)).assertNotTerminated().cancel();
     }
 
     @Test
     public void testFromEmpty5() {
         Multi<String> multi = Multi.createFrom().uni(Uni.createFrom().nullItem());
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1)).assertCompletedSuccessfully();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0)).assertNotTerminated().cancel();
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1)).assertCompletedSuccessfully();
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0)).assertNotTerminated().cancel();
     }
 
     @Test
     public void testFromResult() {
         AtomicInteger count = new AtomicInteger();
         Multi<Integer> multi = Uni.createFrom().item(count::incrementAndGet).toMulti();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertReceived(1)
                 .assertCompletedSuccessfully();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0)).assertNotTerminated()
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0)).assertNotTerminated()
                 .assertHasNotReceivedAnyItem()
                 .request(1)
                 .assertReceived(2)
@@ -70,10 +70,10 @@ public class UniToMultiTest {
     public void testFromResult2() {
         AtomicInteger count = new AtomicInteger();
         Multi<Integer> multi = Multi.createFrom().uni(Uni.createFrom().item(count::incrementAndGet));
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertReceived(1)
                 .assertCompletedSuccessfully();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0)).assertNotTerminated()
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0)).assertNotTerminated()
                 .assertHasNotReceivedAnyItem()
                 .request(1)
                 .assertReceived(2)
@@ -86,9 +86,9 @@ public class UniToMultiTest {
         Multi<Integer> multi = Uni.createFrom()
                 .<Integer> failure(() -> new IOException("boom-" + count.incrementAndGet()))
                 .toMulti();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertHasFailedWith(IOException.class, "boom-1");
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0))
                 .assertNotTerminated()
                 .request(20)
                 .assertHasFailedWith(IOException.class, "boom-2");
@@ -99,9 +99,9 @@ public class UniToMultiTest {
         AtomicInteger count = new AtomicInteger();
         Multi<Integer> multi = Multi.createFrom().uni(Uni.createFrom()
                 .failure(() -> new IOException("boom-" + count.incrementAndGet())));
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertHasFailedWith(IOException.class, "boom-1");
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0))
                 .assertNotTerminated()
                 .request(20)
                 .assertHasFailedWith(IOException.class, "boom-2");
@@ -113,7 +113,7 @@ public class UniToMultiTest {
         Multi<Void> multi = Uni.createFrom().<Void> nothing()
                 .onCancellation().invoke(() -> called.set(true))
                 .toMulti();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertNotTerminated()
                 .cancel()
                 .run(() -> assertThat(called).isTrue());
@@ -124,7 +124,7 @@ public class UniToMultiTest {
         AtomicBoolean called = new AtomicBoolean();
         Multi<Void> multi = Multi.createFrom().uni(Uni.createFrom().<Void> nothing()
                 .onCancellation().invoke(() -> called.set(true)));
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1))
                 .assertNotTerminated()
                 .cancel()
                 .run(() -> assertThat(called).isTrue());
@@ -135,11 +135,11 @@ public class UniToMultiTest {
         AtomicInteger count = new AtomicInteger();
         Multi<Integer> multi = Uni.createFrom()
                 .completionStage(() -> CompletableFuture.supplyAsync(count::incrementAndGet)).toMulti();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1))
                 .await()
                 .assertReceived(1)
                 .assertCompletedSuccessfully();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0)).assertNotTerminated()
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0)).assertNotTerminated()
                 .assertHasNotReceivedAnyItem()
                 .request(1)
                 .await()
@@ -152,11 +152,11 @@ public class UniToMultiTest {
         AtomicInteger count = new AtomicInteger();
         Multi<Integer> multi = Multi.createFrom().uni(Uni.createFrom()
                 .completionStage(() -> CompletableFuture.supplyAsync(count::incrementAndGet)));
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1))
                 .await()
                 .assertReceived(1)
                 .assertCompletedSuccessfully();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0)).assertNotTerminated()
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0)).assertNotTerminated()
                 .assertHasNotReceivedAnyItem()
                 .request(1)
                 .await()
@@ -168,11 +168,11 @@ public class UniToMultiTest {
     public void testFromAnUniSendingNullResultEventInTheFuture() {
         Multi<Integer> multi = Uni.createFrom()
                 .completionStage(() -> CompletableFuture.<Integer> supplyAsync(() -> null)).toMulti();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1))
                 .await()
                 .assertHasNotReceivedAnyItem()
                 .assertCompletedSuccessfully();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0))
                 .assertNotTerminated()
                 .request(1)
                 .await()
@@ -184,11 +184,11 @@ public class UniToMultiTest {
     public void testFromAnUniSendingNullResultEventInTheFuture2() {
         Multi<Integer> multi = Multi.createFrom()
                 .uni(Uni.createFrom().completionStage(() -> CompletableFuture.supplyAsync(() -> null)));
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(1))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(1))
                 .await()
                 .assertHasNotReceivedAnyItem()
                 .assertCompletedSuccessfully();
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(0))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(0))
                 .assertNotTerminated()
                 .request(1)
                 .await()

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiToHotStreamTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiToHotStreamTest.java
@@ -12,7 +12,7 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiToHotStreamTest {
 
@@ -21,15 +21,15 @@ public class MultiToHotStreamTest {
         UnicastProcessor<String> processor = UnicastProcessor.create();
 
         Multi<String> multi = processor.map(s -> s).transform().toHotStream();
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
         processor.onNext("two");
         processor.onNext("three");
 
-        MultiAssertSubscriber<String> subscriber2 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber2 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("four");
         processor.onComplete();
@@ -48,20 +48,20 @@ public class MultiToHotStreamTest {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
 
         Multi<String> multi = processor.map(s -> s).transform().toHotStream();
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
         processor.onNext("two");
         processor.onNext("three");
 
-        MultiAssertSubscriber<String> subscriber2 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber2 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onComplete();
 
-        MultiAssertSubscriber<String> subscriber3 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber3 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         subscriber1
                 .assertReceived("one", "two", "three")
@@ -81,20 +81,20 @@ public class MultiToHotStreamTest {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
         Multi<String> multi = processor.map(s -> s).transform().toHotStream();
 
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
         processor.onNext("two");
         processor.onNext("three");
 
-        MultiAssertSubscriber<String> subscriber2 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber2 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onError(new Exception("boom"));
 
-        MultiAssertSubscriber<String> subscriber3 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber3 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         subscriber1
                 .assertReceived("one", "two", "three")
@@ -114,8 +114,8 @@ public class MultiToHotStreamTest {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
         Multi<Integer> multi = processor.map(s -> s).transform().toHotStream();
 
-        MultiAssertSubscriber<Integer> subscriber = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext(1);
         processor.onNext(2);
@@ -130,15 +130,15 @@ public class MultiToHotStreamTest {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
         Multi<String> multi = processor.map(s -> s).transform().toHotStream();
 
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
 
         subscriber1.assertReceived("one");
 
-        MultiAssertSubscriber<String> subscriber2 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber2 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("two");
 
@@ -168,8 +168,8 @@ public class MultiToHotStreamTest {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
         Multi<String> multi = processor.map(s -> s).transform().toHotStream();
 
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
 
@@ -193,8 +193,8 @@ public class MultiToHotStreamTest {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
         Multi<String> multi = processor.map(s -> s).transform().toHotStream();
 
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
 
@@ -215,8 +215,8 @@ public class MultiToHotStreamTest {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
         Multi<String> multi = processor.map(s -> s).transform().toHotStream();
 
-        MultiAssertSubscriber<String> subscriber1 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
 
@@ -238,10 +238,10 @@ public class MultiToHotStreamTest {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
         Multi<Integer> multi = processor.map(s -> s).transform().toHotStream();
 
-        MultiAssertSubscriber<Integer> s1 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
-        MultiAssertSubscriber<Integer> s2 = multi.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(4));
+        AssertSubscriber<Integer> s1 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
+        AssertSubscriber<Integer> s2 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(4));
 
         for (int i = 0; i < 10; i++) {
             processor.onNext(i);
@@ -259,7 +259,7 @@ public class MultiToHotStreamTest {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
         Multi<Integer> multi = processor.map(s -> s).transform().toHotStream();
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
 
         multi
                 .onItem().transformToMulti(i -> processor).withRequests(10).merge()
@@ -282,8 +282,8 @@ public class MultiToHotStreamTest {
                 .transform().toHotStream();
         Thread.sleep(50); // NOSONAR
 
-        MultiAssertSubscriber<Long> subscriber = ticks.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+        AssertSubscriber<Long> subscriber = ticks.subscribe()
+                .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .await(Duration.ofSeconds(10))
                 .assertCompletedSuccessfully();
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/EmitterBasedMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/EmitterBasedMultiTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.BackPressureStrategy;
 import io.smallrye.mutiny.subscription.MultiEmitter;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class EmitterBasedMultiTest {
 
@@ -32,12 +32,12 @@ public class EmitterBasedMultiTest {
     @Test
     public void testBasicEmitterBehavior() {
         AtomicBoolean terminated = new AtomicBoolean();
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> emitter(e -> {
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> emitter(e -> {
             e.onTermination(() -> terminated.set(true));
             e.emit(1).emit(2).emit(3).complete();
 
             e.fail(new Exception("boom-1"));
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(3));
+        }).subscribe().withSubscriber(AssertSubscriber.create(3));
         subscriber.assertSubscribed()
                 .assertReceived(1, 2, 3)
                 .assertCompletedSuccessfully();
@@ -47,12 +47,12 @@ public class EmitterBasedMultiTest {
     @Test
     public void testWithConsumerThrowingException() {
         AtomicBoolean terminated = new AtomicBoolean();
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> emitter(e -> {
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> emitter(e -> {
             e.onTermination(() -> terminated.set(true));
             e.emit(1).emit(2).emit(3);
 
             throw new RuntimeException("boom");
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(3));
+        }).subscribe().withSubscriber(AssertSubscriber.create(3));
         subscriber.assertSubscribed()
                 .assertReceived(1, 2, 3)
                 .assertHasFailedWith(RuntimeException.class, "boom");
@@ -62,12 +62,12 @@ public class EmitterBasedMultiTest {
     @Test
     public void testWithAFailure() {
         AtomicBoolean terminated = new AtomicBoolean();
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> emitter(e -> {
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> emitter(e -> {
             e.onTermination(() -> terminated.set(true));
             e.emit(1).emit(2).emit(3).fail(new Exception("boom"));
 
             e.fail(new Exception("boom-1"));
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(3));
+        }).subscribe().withSubscriber(AssertSubscriber.create(3));
         subscriber.assertSubscribed()
                 .assertReceived(1, 2, 3)
                 .assertHasFailedWith(Exception.class, "boom");
@@ -77,10 +77,10 @@ public class EmitterBasedMultiTest {
     @Test
     public void testTerminationNotCalled() {
         AtomicBoolean terminated = new AtomicBoolean();
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> emitter(e -> {
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> emitter(e -> {
             e.onTermination(() -> terminated.set(true));
             e.emit(1).emit(2).emit(3);
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(3));
+        }).subscribe().withSubscriber(AssertSubscriber.create(3));
         subscriber.assertSubscribed()
                 .assertReceived(1, 2, 3)
                 .assertHasNotCompleted()
@@ -97,7 +97,7 @@ public class EmitterBasedMultiTest {
             e.onTermination(() -> terminated.set(true));
             e.emit("a");
             e.emit(null);
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+        }).subscribe().withSubscriber(AssertSubscriber.create(2))
                 .await()
                 .assertHasNotCompleted()
                 .assertHasFailedWith(NullPointerException.class, "")
@@ -108,7 +108,7 @@ public class EmitterBasedMultiTest {
             e.emit("a");
             e.emit(null);
         }, BackPressureStrategy.LATEST)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+                .subscribe().withSubscriber(AssertSubscriber.create(2))
                 .await()
                 .assertHasNotCompleted()
                 .assertHasFailedWith(NullPointerException.class, "")
@@ -118,7 +118,7 @@ public class EmitterBasedMultiTest {
             e.emit("a");
             e.emit(null);
         }, BackPressureStrategy.DROP)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+                .subscribe().withSubscriber(AssertSubscriber.create(2))
                 .await()
                 .assertHasNotCompleted()
                 .assertHasFailedWith(NullPointerException.class, "")
@@ -128,7 +128,7 @@ public class EmitterBasedMultiTest {
             e.emit("a");
             e.emit(null);
         }, BackPressureStrategy.ERROR)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+                .subscribe().withSubscriber(AssertSubscriber.create(2))
                 .await()
                 .assertHasNotCompleted()
                 .assertHasFailedWith(NullPointerException.class, "")
@@ -138,7 +138,7 @@ public class EmitterBasedMultiTest {
             e.emit("a");
             e.emit(null);
         }, BackPressureStrategy.IGNORE)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+                .subscribe().withSubscriber(AssertSubscriber.create(2))
                 .await()
                 .assertHasNotCompleted()
                 .assertHasFailedWith(NullPointerException.class, "")
@@ -153,7 +153,7 @@ public class EmitterBasedMultiTest {
             e.onTermination(() -> terminated.set(true));
             e.emit("a");
             e.fail(null);
-        }).subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+        }).subscribe().withSubscriber(AssertSubscriber.create(2))
                 .await()
                 .assertHasFailedWith(NullPointerException.class, "")
                 .assertReceived("a");
@@ -163,7 +163,7 @@ public class EmitterBasedMultiTest {
             e.emit("a");
             e.fail(null);
         }, BackPressureStrategy.LATEST)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+                .subscribe().withSubscriber(AssertSubscriber.create(2))
                 .await()
                 .assertHasFailedWith(NullPointerException.class, "")
                 .assertReceived("a");
@@ -172,7 +172,7 @@ public class EmitterBasedMultiTest {
             e.emit("a");
             e.fail(null);
         }, BackPressureStrategy.DROP)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+                .subscribe().withSubscriber(AssertSubscriber.create(2))
                 .await()
                 .assertHasNotCompleted()
                 .assertHasFailedWith(NullPointerException.class, "")
@@ -182,7 +182,7 @@ public class EmitterBasedMultiTest {
             e.emit("a");
             e.fail(null);
         }, BackPressureStrategy.ERROR)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+                .subscribe().withSubscriber(AssertSubscriber.create(2))
                 .await()
                 .assertHasNotCompleted()
                 .assertHasFailedWith(NullPointerException.class, "")
@@ -192,7 +192,7 @@ public class EmitterBasedMultiTest {
             e.emit("a");
             e.fail(null);
         }, BackPressureStrategy.IGNORE)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(2))
+                .subscribe().withSubscriber(AssertSubscriber.create(2))
                 .await()
                 .assertHasNotCompleted()
                 .assertHasFailedWith(NullPointerException.class, "")
@@ -203,8 +203,8 @@ public class EmitterBasedMultiTest {
     @Test
     public void testSerializedWithConcurrentEmissions() {
         AtomicReference<MultiEmitter<? super Integer>> reference = new AtomicReference<>();
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> emitter(reference::set).subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE));
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> emitter(reference::set).subscribe()
+                .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
         await().until(() -> reference.get() != null);
 
@@ -244,8 +244,8 @@ public class EmitterBasedMultiTest {
     @Test
     public void testSerializedWithConcurrentEmissionsAndFailure() {
         AtomicReference<MultiEmitter<? super Integer>> reference = new AtomicReference<>();
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> emitter(reference::set).subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE));
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> emitter(reference::set).subscribe()
+                .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
         await().until(() -> reference.get() != null);
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
@@ -23,8 +23,8 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.test.AbstractSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 import io.smallrye.mutiny.test.Mocks;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
 
 public class MultiFromIterableTest {
 
@@ -92,32 +92,32 @@ public class MultiFromIterableTest {
         }
         Multi<Integer> f = Multi.createFrom().iterable(list);
 
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
-        ts.assertHasNotReceivedAnyItem();
-        f.subscribe(ts);
-        ts.request(1);
-        ts.assertReceived(1);
-        ts.request(2);
-        ts.assertReceived(1, 2, 3);
-        ts.request(3);
-        ts.assertReceived(1, 2, 3, 4, 5, 6);
-        ts.request(list.size());
-        ts.assertTerminated();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
+        subscriber.assertHasNotReceivedAnyItem();
+        f.subscribe(subscriber);
+        subscriber.request(1);
+        subscriber.assertReceived(1);
+        subscriber.request(2);
+        subscriber.assertReceived(1, 2, 3);
+        subscriber.request(3);
+        subscriber.assertReceived(1, 2, 3, 4, 5, 6);
+        subscriber.request(list.size());
+        subscriber.assertTerminated();
     }
 
     @Test
     public void testWithoutBackPressure() {
         Multi<Integer> f = Multi.createFrom().iterable(Arrays.asList(1, 2, 3, 4, 5));
 
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
-        ts.assertHasNotReceivedAnyItem();
+        subscriber.assertHasNotReceivedAnyItem();
 
-        ts.request(Long.MAX_VALUE); // infinite
-        f.subscribe(ts);
+        subscriber.request(Long.MAX_VALUE); // infinite
+        f.subscribe(subscriber);
 
-        ts.assertReceived(1, 2, 3, 4, 5);
-        ts.assertTerminated();
+        subscriber.assertReceived(1, 2, 3, 4, 5);
+        subscriber.assertTerminated();
     }
 
     @Test
@@ -125,16 +125,16 @@ public class MultiFromIterableTest {
         Multi<Integer> f = Multi.createFrom().iterable(Arrays.asList(1, 2, 3));
 
         for (int i = 0; i < 10; i++) {
-            MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create(Long.MAX_VALUE);
+            AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
-            f.subscribe(ts);
+            f.subscribe(subscriber);
 
-            ts.assertReceived(1, 2, 3)
+            subscriber.assertReceived(1, 2, 3)
                     .assertCompletedSuccessfully();
         }
     }
 
-    @SuppressWarnings("SubscriberImplementation")
+    @SuppressWarnings({ "ReactiveStreamsSubscriberImplementation" })
     @Test
     public void fromIterableRequestOverflow() throws InterruptedException {
         Multi<Integer> f = Multi.createFrom().iterable(Arrays.asList(1, 2, 3, 4));
@@ -171,7 +171,7 @@ public class MultiFromIterableTest {
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
 
-    @SuppressWarnings("SubscriberImplementation")
+    @SuppressWarnings("ReactiveStreamsSubscriberImplementation")
     @Test
     public void fromEmptyIterableWhenZeroRequestedShouldStillEmitOnCompletedEagerly() {
         final AtomicBoolean completed = new AtomicBoolean(false);
@@ -229,7 +229,7 @@ public class MultiFromIterableTest {
         };
         Multi.createFrom().iterable(iterable)
                 .transform().byTakingFirstItems(1)
-                .subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
         assertFalse(called.get());
     }
 
@@ -277,11 +277,11 @@ public class MultiFromIterableTest {
             throw new IllegalStateException("BOOM");
         };
 
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
 
-        Multi.createFrom().iterable(it).subscribe(ts);
+        Multi.createFrom().iterable(it).subscribe(subscriber);
 
-        ts.assertHasNotReceivedAnyItem()
+        subscriber.assertHasNotReceivedAnyItem()
                 .assertHasFailedWith(IllegalStateException.class, "BOOM");
     }
 
@@ -298,9 +298,9 @@ public class MultiFromIterableTest {
                 return null;
             }
         };
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create();
-        Multi.createFrom().iterable(it).subscribe(ts);
-        ts.assertHasNotReceivedAnyItem()
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
+        Multi.createFrom().iterable(it).subscribe(subscriber);
+        subscriber.assertHasNotReceivedAnyItem()
                 .assertHasFailedWith(IllegalStateException.class, "BOOM");
     }
 
@@ -323,11 +323,11 @@ public class MultiFromIterableTest {
             }
         };
 
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
 
-        Multi.createFrom().iterable(it).subscribe(ts);
+        Multi.createFrom().iterable(it).subscribe(subscriber);
 
-        ts.assertReceived(1)
+        subscriber.assertReceived(1)
                 .assertHasFailedWith(IllegalStateException.class, "BOOM");
     }
 
@@ -350,9 +350,9 @@ public class MultiFromIterableTest {
             }
         };
 
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create(10);
-        Multi.createFrom().iterable(it).subscribe(ts);
-        ts.assertReceived(1)
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
+        Multi.createFrom().iterable(it).subscribe(subscriber);
+        subscriber.assertReceived(1)
                 .assertHasFailedWith(IllegalStateException.class, "BOOM");
     }
 
@@ -370,11 +370,11 @@ public class MultiFromIterableTest {
             }
         };
 
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
 
-        Multi.createFrom().iterable(it).subscribe(ts);
+        Multi.createFrom().iterable(it).subscribe(subscriber);
 
-        ts.assertHasNotReceivedAnyItem()
+        subscriber.assertHasNotReceivedAnyItem()
                 .assertHasFailedWith(IllegalStateException.class, "BOOM");
     }
 
@@ -392,11 +392,11 @@ public class MultiFromIterableTest {
             }
         };
 
-        MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
 
-        Multi.createFrom().iterable(it).subscribe(ts);
+        Multi.createFrom().iterable(it).subscribe(subscriber);
 
-        ts.assertHasNotReceivedAnyItem()
+        subscriber.assertHasNotReceivedAnyItem()
                 .assertHasFailedWith(IllegalStateException.class, "BOOM");
     }
 
@@ -419,15 +419,15 @@ public class MultiFromIterableTest {
             }
         };
 
-        MultiAssertSubscriber<Integer> ts = new MultiAssertSubscriber<>(5, true);
-        Multi.createFrom().iterable(it).subscribe(ts);
-        ts.assertHasNotReceivedAnyItem()
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(5, true);
+        Multi.createFrom().iterable(it).subscribe(subscriber);
+        subscriber.assertHasNotReceivedAnyItem()
                 .assertNotTerminated();
     }
 
     @Test
     public void hasNextCancels() {
-        final MultiAssertSubscriber<Integer> ts = MultiAssertSubscriber.create(1);
+        final AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
 
         Multi.createFrom().iterable(() -> new Iterator<Integer>() {
             int count;
@@ -435,7 +435,7 @@ public class MultiFromIterableTest {
             @Override
             public boolean hasNext() {
                 if (++count == 2) {
-                    ts.cancel();
+                    subscriber.cancel();
                 }
                 return true;
             }
@@ -450,9 +450,9 @@ public class MultiFromIterableTest {
                 throw new UnsupportedOperationException();
             }
         })
-                .subscribe(ts);
+                .subscribe(subscriber);
 
-        ts.assertReceived(1)
+        subscriber.assertReceived(1)
                 .assertNotTerminated();
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiFromResourceTest {
 
@@ -33,7 +33,7 @@ public class MultiFromResourceTest {
                 s -> Multi.createFrom().items(s))
                 .withFinalizer(r -> {
                 });
-        MultiAssertSubscriber<String> subscriber = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         subscriber
                 .assertHasFailedWith(IllegalArgumentException.class, "boom")
                 .assertHasNotReceivedAnyItem();
@@ -46,7 +46,7 @@ public class MultiFromResourceTest {
                 s -> Multi.createFrom().items(s))
                 .withFinalizer(r -> {
                 });
-        MultiAssertSubscriber<String> subscriber = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         subscriber
                 .assertHasFailedWith(IllegalArgumentException.class, "")
                 .assertHasNotReceivedAnyItem();
@@ -69,7 +69,7 @@ public class MultiFromResourceTest {
         Multi<String> multi = Multi.createFrom().resource(supplier, stream)
                 .withFinalizer(r -> {
                 });
-        MultiAssertSubscriber<String> subscriber = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         subscriber
                 .assertHasFailedWith(IllegalArgumentException.class, "boom")
                 .assertHasNotReceivedAnyItem();
@@ -82,7 +82,7 @@ public class MultiFromResourceTest {
                 s -> (Publisher<String>) null)
                 .withFinalizer(r -> {
                 });
-        MultiAssertSubscriber<String> subscriber = multi.subscribe().withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber = multi.subscribe().withSubscriber(AssertSubscriber.create(10));
         subscriber
                 .assertHasFailedWith(IllegalArgumentException.class, "")
                 .assertHasNotReceivedAnyItem();
@@ -132,7 +132,7 @@ public class MultiFromResourceTest {
 
     @Test
     public void simpleSynchronousTest() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
         AtomicInteger cleanup = new AtomicInteger();
         Multi.createFrom().resource(() -> 1, r -> Multi.createFrom().range(r, 11))
                 .withFinalizer(cleanup::set)
@@ -146,8 +146,8 @@ public class MultiFromResourceTest {
 
     @Test
     public void simpleSynchronousTestWithMultipleSubscribers() {
-        MultiAssertSubscriber<Integer> subscriber1 = MultiAssertSubscriber.create(10);
-        MultiAssertSubscriber<Integer> subscriber2 = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber1 = AssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber2 = AssertSubscriber.create(10);
         List<Integer> list = new ArrayList<>();
         AtomicInteger count = new AtomicInteger();
         Multi<Integer> multi = Multi.createFrom().resource(count::incrementAndGet,
@@ -169,7 +169,7 @@ public class MultiFromResourceTest {
 
     @Test
     public void testCleanupCalledOnCompletionWithSynchronousFinalizer() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(9);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(9);
         AtomicInteger cleanup = new AtomicInteger();
         Multi.createFrom().resource(() -> 1, r -> Multi.createFrom().range(r, 11))
                 .withFinalizer(cleanup::set)
@@ -186,7 +186,7 @@ public class MultiFromResourceTest {
 
     @Test
     public void testCleanupCalledOnCancellationWithSynchronousFinalizer() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(4);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(4);
         AtomicInteger cleanup = new AtomicInteger();
         Multi.createFrom().resource(() -> 1, r -> Multi.createFrom().range(r, 11))
                 .withFinalizer(cleanup::set)
@@ -203,7 +203,7 @@ public class MultiFromResourceTest {
 
     @Test
     public void testCleanupCalledOnFailureWithSynchronousFinalizer() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
         AtomicInteger cleanup = new AtomicInteger();
         Multi.createFrom().resource(() -> 1, r -> Multi.createFrom().<Integer> emitter(e -> {
             e.emit(1).emit(2).fail(new IOException("boom"));
@@ -221,7 +221,7 @@ public class MultiFromResourceTest {
 
     @Test
     public void testThatFinalizerIsNotCalledWhenResourceSupplierThrowsAnException() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
         Supplier<Integer> supplier = () -> {
             throw new IllegalArgumentException("boom");
         };
@@ -238,7 +238,7 @@ public class MultiFromResourceTest {
 
     @Test
     public void testThatFinalizerIsCalledWhenStreamSupplierThrowsAnException() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
         AtomicInteger cleanup = new AtomicInteger();
         Multi.createFrom().<Integer, Integer> resource(() -> 1, s -> {
             throw new IllegalArgumentException("boom");
@@ -252,7 +252,7 @@ public class MultiFromResourceTest {
 
     @Test
     public void testThatFinalizerIsCalledWhenStreamSupplierReturnsNull() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
         AtomicInteger cleanup = new AtomicInteger();
         Multi.createFrom().<Integer, Integer> resource(() -> 1, s -> null)
                 .withFinalizer(cleanup::set)
@@ -264,7 +264,7 @@ public class MultiFromResourceTest {
 
     @Test
     public void testThatFinalizerThrowingException() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(20);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(20);
         Consumer<Integer> fin = s -> {
             throw new IllegalStateException("boom");
         };
@@ -279,7 +279,7 @@ public class MultiFromResourceTest {
 
     @Test
     public void testThatFinalizerThrowingExceptionAfterStreamFailure() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(20);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(20);
         Consumer<Integer> fin = s -> {
             throw new IllegalStateException("boom");
         };
@@ -298,7 +298,7 @@ public class MultiFromResourceTest {
 
     @Test
     public void testThatOnFailureFinalizerIsNotCallIfResourceSupplierThrowsAnException() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(20);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(20);
         Supplier<Integer> supplier = () -> {
             throw new NullPointerException("boom");
         };
@@ -335,7 +335,7 @@ public class MultiFromResourceTest {
 
     @Test
     public void cancellationShouldBePossible() {
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(20);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(20);
         Supplier<Integer> supplier = () -> 1;
         AtomicInteger onFailure = new AtomicInteger();
         AtomicInteger onComplete = new AtomicInteger();
@@ -376,7 +376,7 @@ public class MultiFromResourceTest {
                 .withFinalizer(FakeTransactionalResource::commit, FakeTransactionalResource::rollback,
                         FakeTransactionalResource::cancel);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertReceived("in transaction")
                 .assertCompletedSuccessfully();
 
@@ -396,7 +396,7 @@ public class MultiFromResourceTest {
                 .withFinalizer(FakeTransactionalResource::commit, FakeTransactionalResource::rollback,
                         FakeTransactionalResource::cancel);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertHasFailedWith(IllegalStateException.class, "boom");
 
         assertThat(resource.subscribed).isFalse();
@@ -414,7 +414,7 @@ public class MultiFromResourceTest {
                 .withFinalizer(FakeTransactionalResource::commit, FakeTransactionalResource::rollback,
                         FakeTransactionalResource::cancel);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertHasFailedWith(IllegalArgumentException.class, "`null`");
 
         assertThat(resource.subscribed).isFalse();
@@ -433,7 +433,7 @@ public class MultiFromResourceTest {
                 .withFinalizer(FakeTransactionalResource::commit, FakeTransactionalResource::rollback,
                         FakeTransactionalResource::cancel);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertHasFailedWith(IOException.class, "boom");
 
         assertThat(resource.subscribed).isFalse();
@@ -452,7 +452,7 @@ public class MultiFromResourceTest {
                         FakeTransactionalResource::cancel)
                 .transform().byTakingFirstItems(3);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .await()
                 .assertReceived("0", "1", "2")
                 .assertCompletedSuccessfully();
@@ -472,7 +472,7 @@ public class MultiFromResourceTest {
                         r -> r.cancel().onItem().failWith(x -> new IOException("boom")))
                 .transform().byTakingFirstItems(3);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .await()
                 .assertReceived("0", "1", "2")
                 .assertCompletedSuccessfully();
@@ -492,7 +492,7 @@ public class MultiFromResourceTest {
                         r -> null)
                 .transform().byTakingFirstItems(3);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .await()
                 .assertReceived("0", "1", "2")
                 .assertCompletedSuccessfully();
@@ -513,7 +513,7 @@ public class MultiFromResourceTest {
                         FakeTransactionalResource::cancel)
                 .transform().byTakingFirstItems(3);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .await()
                 .assertReceived("in transaction")
                 .assertHasFailedWith(IOException.class, "boom");
@@ -534,7 +534,7 @@ public class MultiFromResourceTest {
                         FakeTransactionalResource::cancel)
                 .transform().byTakingFirstItems(3);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .await()
                 .assertReceived("in transaction")
                 .assertHasFailedWith(IOException.class, "commit failed");
@@ -556,7 +556,7 @@ public class MultiFromResourceTest {
                         FakeTransactionalResource::cancel)
                 .transform().byTakingFirstItems(3);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .await()
                 .assertReceived("in transaction")
                 .assertHasFailedWith(NullPointerException.class, "`null`");
@@ -576,7 +576,7 @@ public class MultiFromResourceTest {
                 .withFinalizer(FakeTransactionalResource::commit, FakeTransactionalResource::rollbackFailure,
                         FakeTransactionalResource::cancel);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(20))
                 .await()
                 .assertHasFailedWith(CompositeException.class, "boom")
                 .assertHasFailedWith(CompositeException.class, "rollback failed");
@@ -597,7 +597,7 @@ public class MultiFromResourceTest {
                 .withFinalizer(FakeTransactionalResource::commit, FakeTransactionalResource::rollbackReturningNull,
                         FakeTransactionalResource::cancel);
 
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(20))
                 .await()
                 .assertHasFailedWith(CompositeException.class, "boom")
                 .assertHasFailedWith(CompositeException.class, "`null`");
@@ -619,7 +619,7 @@ public class MultiFromResourceTest {
                             .onSubscribe().invoke(s -> subscribed.set(true))
                             .onItem().ignore().andContinueWithNull();
                 });
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         assertThat(subscribed).isTrue();
@@ -635,7 +635,7 @@ public class MultiFromResourceTest {
                             .onSubscribe().invoke(s -> subscribed.set(true))
                             .onItem().ignore().andContinueWithNull();
                 });
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(20))
                 .assertHasFailedWith(IOException.class, "boom")
                 .assertReceived(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         assertThat(subscribed).isTrue();
@@ -652,7 +652,7 @@ public class MultiFromResourceTest {
                             .onItem().ignore().andContinueWithNull();
                 })
                 .transform().byTakingFirstItems(5);
-        multi.subscribe().withSubscriber(MultiAssertSubscriber.create(20))
+        multi.subscribe().withSubscriber(AssertSubscriber.create(20))
                 .await()
                 .assertCompletedSuccessfully()
                 .assertReceived(0L, 1L, 2L, 3L, 4L);
@@ -662,7 +662,7 @@ public class MultiFromResourceTest {
     @Test
     public void testThatOnCancellationIsNotCalledAfterCompletion() {
         FakeTransactionalResource resource = new FakeTransactionalResource();
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create(4);
+        AssertSubscriber<String> subscriber = AssertSubscriber.create(4);
         Multi.createFrom().resource(() -> resource, FakeTransactionalResource::data)
                 .withFinalizer(
                         FakeTransactionalResource::commit,
@@ -682,7 +682,7 @@ public class MultiFromResourceTest {
     @Test
     public void testThatOnCancellationIsNotCalledAfterFailure() {
         FakeTransactionalResource resource = new FakeTransactionalResource();
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create(4);
+        AssertSubscriber<String> subscriber = AssertSubscriber.create(4);
         Multi.createFrom().resource(() -> resource, r -> r.data().onCompletion().failWith(new IOException("boom")))
                 .withFinalizer(
                         FakeTransactionalResource::commit,

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/BroadcastProcessorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/BroadcastProcessorTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class BroadcastProcessorTest {
 
@@ -37,15 +37,15 @@ public class BroadcastProcessorTest {
     public void testWithTwoSubscribers() {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
 
-        MultiAssertSubscriber<String> subscriber1 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
         processor.onNext("two");
         processor.onNext("three");
 
-        MultiAssertSubscriber<String> subscriber2 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber2 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("four");
         processor.onComplete();
@@ -63,8 +63,8 @@ public class BroadcastProcessorTest {
     public void testWithTwoSubscribersSerialized() {
         SerializedProcessor<String, String> processor = BroadcastProcessor.<String> create().serialized();
 
-        MultiAssertSubscriber<String> subscriber1 = MultiAssertSubscriber.create(10);
-        MultiAssertSubscriber<String> subscriber2 = MultiAssertSubscriber.create(10);
+        AssertSubscriber<String> subscriber1 = AssertSubscriber.create(10);
+        AssertSubscriber<String> subscriber2 = AssertSubscriber.create(10);
 
         processor.subscribe(subscriber1);
 
@@ -90,20 +90,20 @@ public class BroadcastProcessorTest {
     public void testSubscriptionAfterCompletion() {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
 
-        MultiAssertSubscriber<String> subscriber1 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
         processor.onNext("two");
         processor.onNext("three");
 
-        MultiAssertSubscriber<String> subscriber2 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber2 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onComplete();
 
-        MultiAssertSubscriber<String> subscriber3 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber3 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         subscriber1
                 .assertReceived("one", "two", "three")
@@ -122,20 +122,20 @@ public class BroadcastProcessorTest {
     public void testSubscriptionAfterFailure() {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
 
-        MultiAssertSubscriber<String> subscriber1 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
         processor.onNext("two");
         processor.onNext("three");
 
-        MultiAssertSubscriber<String> subscriber2 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber2 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onError(new Exception("boom"));
 
-        MultiAssertSubscriber<String> subscriber3 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber3 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         subscriber1
                 .assertReceived("one", "two", "three")
@@ -153,8 +153,8 @@ public class BroadcastProcessorTest {
     @Test
     public void testFailureAfterCompletion() {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
-        MultiAssertSubscriber<Integer> subscriber = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> subscriber = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext(1);
         processor.onNext(2);
@@ -168,15 +168,15 @@ public class BroadcastProcessorTest {
     public void testNoITemAfterCancellation() {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
 
-        MultiAssertSubscriber<String> subscriber1 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
 
         subscriber1.assertReceived("one");
 
-        MultiAssertSubscriber<String> subscriber2 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber2 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("two");
 
@@ -205,8 +205,8 @@ public class BroadcastProcessorTest {
     public void testResubscription() {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
 
-        MultiAssertSubscriber<String> subscriber1 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
 
@@ -229,8 +229,8 @@ public class BroadcastProcessorTest {
     public void testResubscriptionAfterCompletion() {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
 
-        MultiAssertSubscriber<String> subscriber1 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
 
@@ -251,8 +251,8 @@ public class BroadcastProcessorTest {
     public void testResubscriptionAfterFailure() {
         BroadcastProcessor<String> processor = BroadcastProcessor.create();
 
-        MultiAssertSubscriber<String> subscriber1 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<String> subscriber1 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         processor.onNext("one");
 
@@ -274,10 +274,10 @@ public class BroadcastProcessorTest {
         Multi<Integer> upstream = Multi.createFrom().range(0, 10);
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
 
-        MultiAssertSubscriber<Integer> s1 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
-        MultiAssertSubscriber<Integer> s2 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s1 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
+        AssertSubscriber<Integer> s2 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         upstream.subscribe(processor);
 
@@ -292,8 +292,8 @@ public class BroadcastProcessorTest {
         Multi<Integer> upstream = Multi.createFrom().range(0, 10);
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
         upstream.subscribe(processor);
-        MultiAssertSubscriber<Integer> s1 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s1 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         s1.assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
@@ -304,8 +304,8 @@ public class BroadcastProcessorTest {
         Multi<Integer> upstream = Multi.createFrom().empty();
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
         upstream.subscribe(processor);
-        MultiAssertSubscriber<Integer> s1 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s1 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
 
         s1.assertCompletedSuccessfully()
                 .assertHasNotReceivedAnyItem();
@@ -316,10 +316,10 @@ public class BroadcastProcessorTest {
         Multi<Integer> upstream = Multi.createFrom().failure(new Exception("boom"));
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
         upstream.subscribe(processor);
-        MultiAssertSubscriber<Integer> s1 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
-        MultiAssertSubscriber<Integer> s2 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
+        AssertSubscriber<Integer> s1 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
+        AssertSubscriber<Integer> s2 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
         s1.assertHasFailedWith(Exception.class, "boom");
         s2.assertHasFailedWith(Exception.class, "boom");
     }
@@ -327,10 +327,10 @@ public class BroadcastProcessorTest {
     @Test
     public void testWhenSubscriberDoesNotHaveRequestedEnough() {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
-        MultiAssertSubscriber<Integer> s1 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(10));
-        MultiAssertSubscriber<Integer> s2 = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(4));
+        AssertSubscriber<Integer> s1 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(10));
+        AssertSubscriber<Integer> s2 = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(4));
 
         for (int i = 0; i < 10; i++) {
             processor.onNext(i);
@@ -345,8 +345,8 @@ public class BroadcastProcessorTest {
 
     @Test
     public void testCrossCancellation() {
-        MultiAssertSubscriber<Integer> subscriber1 = MultiAssertSubscriber.create(10);
-        MultiAssertSubscriber<Integer> subscriber2 = new MultiAssertSubscriber<Integer>(10) {
+        AssertSubscriber<Integer> subscriber1 = AssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber2 = new AssertSubscriber<Integer>(10) {
             @Override
             public synchronized void onNext(Integer o) {
                 super.onNext(o);
@@ -363,8 +363,8 @@ public class BroadcastProcessorTest {
 
     @Test
     public void testCrossCancellationOnFailure() {
-        MultiAssertSubscriber<Integer> subscriber1 = MultiAssertSubscriber.create(10);
-        MultiAssertSubscriber<Integer> subscriber2 = new MultiAssertSubscriber<Integer>(10) {
+        AssertSubscriber<Integer> subscriber1 = AssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber2 = new AssertSubscriber<Integer>(10) {
             @Override
             public synchronized void onError(Throwable failure) {
                 super.onError(failure);
@@ -382,7 +382,7 @@ public class BroadcastProcessorTest {
     @Test(invocationCount = 100)
     public void testCompletionRace() {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
-        MultiAssertSubscriber<Object> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create(1);
         processor.subscribe(subscriber);
 
         final AtomicInteger count = new AtomicInteger(2);
@@ -403,7 +403,7 @@ public class BroadcastProcessorTest {
     @Test(invocationCount = 100)
     public void testCompletionVsSubscriptionRace() throws InterruptedException {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
-        MultiAssertSubscriber<Object> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create(1);
 
         CountDownLatch latch = new CountDownLatch(2);
         final AtomicInteger count = new AtomicInteger(2);
@@ -434,7 +434,7 @@ public class BroadcastProcessorTest {
     @Test
     public void testWithTransformToMultiAndMerge() {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
 
         processor
                 .onItem().transformToMulti(i -> processor).withRequests(10).merge()
@@ -458,8 +458,8 @@ public class BroadcastProcessorTest {
         ticks.subscribe().withSubscriber(processor);
         Thread.sleep(50); // NOSONAR
 
-        MultiAssertSubscriber<Long> subscriber = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(Long.MAX_VALUE))
+        AssertSubscriber<Long> subscriber = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
                 .await(Duration.ofSeconds(10))
                 .assertCompletedSuccessfully();
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/SerializedProcessorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/SerializedProcessorTest.java
@@ -17,14 +17,14 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.Subscriptions;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class SerializedProcessorTest {
 
     @Test
     public void testAPI() {
         SerializedProcessor<String, String> processor = new SerializedProcessor<>(UnicastProcessor.create());
-        MultiAssertSubscriber<String> subscriber = new MultiAssertSubscriber<>(10);
+        AssertSubscriber<String> subscriber = new AssertSubscriber<>(10);
         processor.subscribe(subscriber);
         processor.onNext("hello");
         processor.onComplete();
@@ -41,7 +41,7 @@ public class SerializedProcessorTest {
         unicast.onComplete();
         SerializedProcessor<Integer, Integer> serialized = unicast.serialized();
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
         serialized.subscribe(subscriber);
         subscriber.await()
                 .assertReceived(1)
@@ -54,7 +54,7 @@ public class SerializedProcessorTest {
         unicast.onComplete();
         SerializedProcessor<Integer, Integer> serialized = unicast.serialized();
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
         serialized.subscribe(subscriber);
         subscriber.await()
                 .assertHasNotReceivedAnyItem()
@@ -68,7 +68,7 @@ public class SerializedProcessorTest {
         unicast.onError(new Exception("boom"));
         SerializedProcessor<Integer, Integer> serialized = unicast.serialized();
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
         serialized.subscribe(subscriber);
         subscriber.await()
                 .assertReceived(1)
@@ -81,7 +81,7 @@ public class SerializedProcessorTest {
         unicast.onNext(1);
         SerializedProcessor<Integer, Integer> serialized = unicast.serialized();
 
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
         serialized.subscribe(subscriber);
         subscriber
                 .assertReceived(1)
@@ -91,7 +91,7 @@ public class SerializedProcessorTest {
     @Test
     public void testWithMultipleItems() {
         Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
         processor.subscribe(subscriber);
 
         Multi.createFrom().range(1, 11).subscribe(processor);
@@ -107,7 +107,7 @@ public class SerializedProcessorTest {
     @Test(invocationCount = 100)
     public void verifyOnNextThreadSafety() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(100);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
         processor.subscribe(subscriber);
 
         Runnable r1 = () -> processor.onNext(1);
@@ -133,7 +133,7 @@ public class SerializedProcessorTest {
     public void verifyOnErrorThreadSafety() {
         Exception failure = new Exception("boom");
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(100);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
         processor.subscribe(subscriber);
 
         Runnable r1 = () -> processor.onError(failure);
@@ -155,7 +155,7 @@ public class SerializedProcessorTest {
     public void verifyOnNextOnErrorThreadSafety() {
         Exception failure = new Exception("boom");
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(100);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
         processor.subscribe(subscriber);
 
         Runnable r1 = () -> {
@@ -186,7 +186,7 @@ public class SerializedProcessorTest {
     @Test(invocationCount = 100)
     public void verifyOnNextOnCompleteThreadSafety() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(100);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
         processor.subscribe(subscriber);
 
         Runnable r1 = () -> {
@@ -214,7 +214,7 @@ public class SerializedProcessorTest {
     @Test(invocationCount = 100)
     public void verifyOnSubscribeOnCompleteThreadSafety() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(100);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
         processor.subscribe(subscriber);
 
         Runnable r1 = () -> {
@@ -242,7 +242,7 @@ public class SerializedProcessorTest {
     @Test(invocationCount = 100)
     public void verifyOnSubscribeOnSubscribeThreadSafety() throws InterruptedException {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(100);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
         processor.subscribe(subscriber);
 
         CountDownLatch latch = new CountDownLatch(2);
@@ -270,7 +270,7 @@ public class SerializedProcessorTest {
     @Test(invocationCount = 100)
     public void verifyOnFailureOnCompleteThreadSafety() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(100);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
         processor.subscribe(subscriber);
 
         Runnable r1 = () -> {
@@ -298,7 +298,7 @@ public class SerializedProcessorTest {
     @Test(invocationCount = 100)
     public void verifyOnFailureOnFailureThreadSafety() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(100);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
         processor.subscribe(subscriber);
 
         Runnable r1 = () -> processor.onError(new Exception("boom"));
@@ -329,7 +329,7 @@ public class SerializedProcessorTest {
     @Test(invocationCount = 100)
     public void testRaceBetweenOnNextAndOnComplete() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(100);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
         processor.subscribe(subscriber);
 
         Runnable r1 = () -> {
@@ -361,7 +361,7 @@ public class SerializedProcessorTest {
     @Test(invocationCount = 100)
     public void testRaceBetweenOnNextAndOnSubscribe() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
-        MultiAssertSubscriber<Integer> subscriber = MultiAssertSubscriber.create(100);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
 
         Runnable r1 = () -> {
             processor.onNext(1);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessorTest.java
@@ -7,7 +7,7 @@ import java.util.concurrent.Executors;
 
 import org.testng.annotations.Test;
 
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class UnicastProcessorTest {
 
@@ -15,9 +15,9 @@ public class UnicastProcessorTest {
     public void testTheProcessorCanGetOnlyOneSubscriber() {
         UnicastProcessor<Integer> processor = UnicastProcessor.create();
         processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create());
-        MultiAssertSubscriber<Integer> second = processor.subscribe()
-                .withSubscriber(MultiAssertSubscriber.create());
+                .withSubscriber(AssertSubscriber.create());
+        AssertSubscriber<Integer> second = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create());
 
         second.assertHasNotReceivedAnyItem()
                 .assertHasFailedWith(IllegalStateException.class, null)
@@ -38,7 +38,7 @@ public class UnicastProcessorTest {
             executor.submit(produce);
         }
 
-        MultiAssertSubscriber<Object> subscriber = MultiAssertSubscriber.create(Long.MAX_VALUE);
+        AssertSubscriber<Object> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
         processor.subscribe(subscriber);
 
         await().until(() -> subscriber.items().size() == 5 * 10000);

--- a/implementation/src/test/java/tck/MultiSkipItemsWhileTckTest.java
+++ b/implementation/src/test/java/tck/MultiSkipItemsWhileTckTest.java
@@ -14,7 +14,7 @@ import org.reactivestreams.Publisher;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiSkipItemsWhileTckTest extends AbstractPublisherTck<Long> {
 
@@ -91,7 +91,7 @@ public class MultiSkipItemsWhileTckTest extends AbstractPublisherTck<Long> {
         infiniteStream()
                 .onTermination().invoke(() -> cancelled.complete(null))
                 .transform().bySkippingItemsWhile(i -> i < 3)
-                .subscribe().withSubscriber(new MultiAssertSubscriber<>(10, true));
+                .subscribe().withSubscriber(new AssertSubscriber<>(10, true));
         await(cancelled);
     }
 

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FailedPublisherStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FailedPublisherStageFactoryTest.java
@@ -3,7 +3,7 @@ package io.smallrye.mutiny.streams.stages;
 import org.junit.Test;
 
 import io.smallrye.mutiny.streams.operators.PublisherStage;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 /**
  * Checks the behavior of {@link FailedPublisherStageFactory}.
@@ -18,7 +18,7 @@ public class FailedPublisherStageFactoryTest extends StageTestBase {
     public void createWithError() {
         Exception failure = new Exception("Boom");
         PublisherStage<Object> boom = factory.create(null, () -> failure);
-        boom.get().subscribe().withSubscriber(MultiAssertSubscriber.create())
+        boom.get().subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasFailedWith(Exception.class, "Boom");
     }
 

--- a/reactor/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
+++ b/reactor/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.converters.multi.MultiReactorConverters;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -14,50 +14,50 @@ public class MultiConvertFromTest {
 
     @Test
     public void testCreatingFromAMono() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiReactorConverters.fromMono(), Mono.just(1))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertReceived(1);
     }
 
     @Test
     public void testCreatingFromAnEmptyMono() {
-        MultiAssertSubscriber<Void> subscriber = Multi.createFrom()
+        AssertSubscriber<Void> subscriber = Multi.createFrom()
                 .converter(MultiReactorConverters.fromMono(), Mono.<Void> empty())
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
 
     @Test
     public void testCreatingFromAMonoWithFailure() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiReactorConverters.fromMono(), Mono.<Integer> error(new IOException("boom")))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(IOException.class, "boom");
     }
 
     @Test
     public void testCreatingFromAFlux() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiReactorConverters.fromFlux(), Flux.just(1))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertReceived(1);
     }
 
     @Test
     public void testCreatingFromAMultiValuedFlux() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiReactorConverters.fromFlux(), Flux.just(1, 2, 3))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(3));
+                .withSubscriber(AssertSubscriber.create(3));
 
         subscriber.assertCompletedSuccessfully()
                 .assertReceived(1, 2, 3);
@@ -65,20 +65,20 @@ public class MultiConvertFromTest {
 
     @Test
     public void testCreatingFromAnEmptyFlux() {
-        MultiAssertSubscriber<Void> subscriber = Multi.createFrom()
+        AssertSubscriber<Void> subscriber = Multi.createFrom()
                 .converter(MultiReactorConverters.fromFlux(), Flux.<Void> empty())
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
 
     @Test
     public void testCreatingFromAFluxWithFailure() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiReactorConverters.fromFlux(), Flux.<Integer> error(new IOException("boom")))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(IOException.class, "boom");
     }

--- a/rxjava/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
+++ b/rxjava/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
@@ -11,156 +11,156 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.converters.multi.MultiRxConverters;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiConvertFromTest {
 
     @Test
     public void testCreatingFromACompletable() {
-        MultiAssertSubscriber<Void> subscriber = Multi.createFrom()
+        AssertSubscriber<Void> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromCompletable(), Completable.complete())
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
 
     @Test
     public void testCreatingFromACompletableFromVoid() {
-        MultiAssertSubscriber<Void> subscriber = Multi.createFrom()
+        AssertSubscriber<Void> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromCompletable(), Completable.error(new IOException("boom")))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(IOException.class, "boom");
     }
 
     @Test
     public void testCreatingFromASingle() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromSingle(), Single.just(1))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertReceived(1);
     }
 
     @Test
     public void testCreatingFromASingleWithFailure() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromSingle(), Single.<Integer> error(new IOException("boom")))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(IOException.class, "boom");
     }
 
     @Test
     public void testCreatingFromAMaybe() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromMaybe(), Maybe.just(1))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertReceived(1);
     }
 
     @Test
     public void testCreatingFromAnEmptyMaybe() {
-        MultiAssertSubscriber<Void> subscriber = Multi.createFrom()
+        AssertSubscriber<Void> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromMaybe(), Maybe.<Void> empty())
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
 
     @Test
     public void testCreatingFromAMaybeWithFailure() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromMaybe(), Maybe.<Integer> error(new IOException("boom")))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(IOException.class, "boom");
     }
 
     @Test
     public void testCreatingFromAFlowable() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromFlowable(), Flowable.just(1))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertReceived(1);
     }
 
     @Test
     public void testCreatingFromAMultiValuedFlowable() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromFlowable(), Flowable.just(1, 2, 3))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(3));
+                .withSubscriber(AssertSubscriber.create(3));
 
         subscriber.assertCompletedSuccessfully().assertReceived(1, 2, 3);
     }
 
     @Test
     public void testCreatingFromAnEmptyFlowable() {
-        MultiAssertSubscriber<Void> subscriber = Multi.createFrom()
+        AssertSubscriber<Void> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromFlowable(), Flowable.<Void> empty())
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
 
     @Test
     public void testCreatingFromAFlowableWithFailure() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromFlowable(), Flowable.<Integer> error(new IOException("boom")))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(IOException.class, "boom");
     }
 
     @Test
     public void testCreatingFromAnObserver() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromObservable(), Observable.just(1))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertReceived(1);
     }
 
     @Test
     public void testCreatingFromAMultiValuedObservable() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromObservable(), Observable.just(1, 2, 3))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(3));
+                .withSubscriber(AssertSubscriber.create(3));
 
         subscriber.assertCompletedSuccessfully().assertReceived(1, 2, 3);
     }
 
     @Test
     public void testCreatingFromAnEmptyObservable() {
-        MultiAssertSubscriber<Void> subscriber = Multi.createFrom()
+        AssertSubscriber<Void> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromObservable(), Observable.<Void> empty())
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
 
     @Test
     public void testCreatingFromAnObservableWithFailure() {
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .converter(MultiRxConverters.fromObservable(), Observable.<Integer> error(new IOException("boom")))
                 .subscribe()
-                .withSubscriber(MultiAssertSubscriber.create(1));
+                .withSubscriber(AssertSubscriber.create(1));
 
         subscriber.assertHasFailedWith(IOException.class, "boom");
     }

--- a/rxjava/src/test/java/io/smallrye/mutiny/converters/MultiConvertToTest.java
+++ b/rxjava/src/test/java/io/smallrye/mutiny/converters/MultiConvertToTest.java
@@ -16,7 +16,7 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.converters.multi.MultiRxConverters;
-import io.smallrye.mutiny.test.MultiAssertSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiConvertToTest {
 
@@ -184,10 +184,10 @@ public class MultiConvertToTest {
     @Test
     public void testCreatingAFlowableWithRequest() {
         AtomicBoolean called = new AtomicBoolean();
-        MultiAssertSubscriber<Integer> subscriber = Multi.createFrom()
+        AssertSubscriber<Integer> subscriber = Multi.createFrom()
                 .deferred(() -> Multi.createFrom().item(1).onItem().invoke((item) -> called.set(true)))
                 .convert().with(MultiRxConverters.toFlowable())
-                .subscribeWith(MultiAssertSubscriber.create(0));
+                .subscribeWith(AssertSubscriber.create(0));
 
         assertThat(called).isFalse();
         subscriber.assertHasNotReceivedAnyItem().assertSubscribed();

--- a/test-utils/src/main/java/io/smallrye/mutiny/test/Mocks.java
+++ b/test-utils/src/main/java/io/smallrye/mutiny/test/Mocks.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -12,21 +11,30 @@ public class Mocks {
 
     /**
      * Mocks a subscriber and prepares it to request {@code Long.MAX_VALUE}.
-     * 
+     *
+     * @param <T> the value type
+     * @return the mocked subscriber
+     */
+    public static <T> Subscriber<T> subscriber() {
+        return subscriber(Long.MAX_VALUE);
+    }
+
+    /**
+     * Mocks a subscriber and prepares it to request {@code req}.
+     *
      * @param <T> the value type
      * @return the mocked subscriber
      */
     @SuppressWarnings("unchecked")
-    public static <T> Subscriber<T> subscriber() {
-        Subscriber<T> w = mock(Subscriber.class);
-
-        Mockito.doAnswer((Answer<Object>) a -> {
-            Subscription s = a.getArgument(0);
-            s.request(Long.MAX_VALUE);
+    public static <T> Subscriber<T> subscriber(long req) {
+        Subscriber<T> subscriber = mock(Subscriber.class);
+        Mockito.doAnswer(invocation -> {
+            Subscription subscription = invocation.getArgument(0, Subscription.class);
+            if (req != 0) {
+                subscription.request(req);
+            }
             return null;
-        }).when(w).onSubscribe(any());
-
-        return w;
+        }).when(subscriber).onSubscribe(any(Subscription.class));
+        return subscriber;
     }
-
 }

--- a/test-utils/src/test/java/io/smallrye/mutiny/test/AbstractSubscriberTest.java
+++ b/test-utils/src/test/java/io/smallrye/mutiny/test/AbstractSubscriberTest.java
@@ -2,15 +2,18 @@ package io.smallrye.mutiny.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.*;
 
+import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 public class AbstractSubscriberTest {
@@ -99,6 +102,147 @@ public class AbstractSubscriberTest {
         AbstractSubscriber<String> subscriber = new AbstractSubscriber<>(2);
         subscriber.onSubscribe(subscription);
         assertThatThrownBy(() -> subscriber.onSubscribe(subscription)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testIsCancelledWithUpfrontCancellation() {
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(10, true);
+        assertThat(subscriber.isCancelled()).isFalse();
+
+        Subscription subscription = mock(Subscription.class);
+        subscriber.onSubscribe(subscription);
+
+        assertThat(subscriber.isCancelled()).isTrue();
+        verify(subscription).cancel();
+        verify(subscription, never()).request(anyLong());
+    }
+
+    @Test
+    public void testIsCancelledWithCancellation() {
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(10, false);
+        assertThat(subscriber.isCancelled()).isFalse();
+
+        subscriber.assertNotSubscribed()
+                .assertNotTerminated();
+        assertThat(subscriber.isCancelled()).isFalse();
+
+        Subscription subscription = mock(Subscription.class);
+        subscriber.onSubscribe(subscription);
+
+        assertThat(subscriber.isCancelled()).isFalse();
+        verify(subscription).request(10);
+
+        subscriber.cancel();
+        verify(subscription).cancel();
+        assertThat(subscriber.isCancelled()).isTrue();
+    }
+
+    @Test
+    public void testSpyWithItemAndCompletion() {
+        Subscriber<Integer> spy = Mocks.subscriber(20);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(spy);
+
+        Subscription subscription = mock(Subscription.class);
+        subscriber.onSubscribe(subscription);
+        verify(spy).onSubscribe(subscription);
+        verify(subscription).request(20);
+
+        subscriber.onNext(1);
+        subscriber.onNext(2);
+        subscriber.onNext(3);
+        subscriber.onComplete();
+
+        verify(spy).onNext(1);
+        verify(spy).onNext(2);
+        verify(spy).onNext(3);
+        verify(spy).onComplete();
+        verify(spy, never()).onError(any(Throwable.class));
+
+        assertThat(subscriber.failures()).isEmpty();
+    }
+
+    @Test
+    public void testSpyWithItemAndFailure() {
+        Subscriber<Integer> spy = Mocks.subscriber(20);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(spy);
+
+        Subscription subscription = mock(Subscription.class);
+        subscriber.onSubscribe(subscription);
+        verify(spy).onSubscribe(subscription);
+        verify(subscription).request(20);
+
+        subscriber.onNext(1);
+        subscriber.onNext(2);
+        subscriber.onNext(3);
+        subscriber.onError(new IOException("boom"));
+
+        verify(spy).onNext(1);
+        verify(spy).onNext(2);
+        verify(spy).onNext(3);
+        verify(spy, never()).onComplete();
+        verify(spy).onError(any(IOException.class));
+
+        assertThat(subscriber.failures()).hasSize(1);
+    }
+
+    @Test
+    public void testAwaitWithTimeout() {
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
+
+        assertThatThrownBy(() -> subscriber.await(Duration.ofMillis(1))).isInstanceOf(AssertionError.class);
+
+        assertThatThrownBy(() -> await()
+                .pollDelay(Duration.ofMillis(1))
+                .atMost(Duration.ofMillis(2)).untilAsserted(subscriber::await)).isInstanceOf(ConditionTimeoutException.class);
+    }
+
+    @Test
+    public void testAwaitWithInterruption() {
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
+
+        AtomicBoolean unblocked = new AtomicBoolean();
+        Thread thread = new Thread(() -> {
+            subscriber.await(Duration.ofSeconds(100));
+            unblocked.set(true);
+        });
+        thread.start();
+        thread.interrupt();
+
+        await().untilTrue(unblocked);
+
+        unblocked.set(false);
+        thread = new Thread(() -> {
+            subscriber.await();
+            unblocked.set(true);
+        });
+        thread.start();
+        thread.interrupt();
+
+        await().untilTrue(unblocked);
+    }
+
+    @Test(timeout = 10)
+    public void testAwaitWhenAlreadyCompleted() {
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
+        subscriber.onComplete();
+
+        subscriber.await(Duration.ofSeconds(100));
+        subscriber.await();
+
+        subscriber.assertCompletedSuccessfully();
+
+    }
+
+    @Test(timeout = 10)
+    public void testAwaitWhenAlreadyFailed() {
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
+        subscriber.onError(new IOException("boom"));
+
+        subscriber.await(Duration.ofSeconds(100));
+        subscriber.await();
+
+        subscriber.assertHasFailedWith(IOException.class, "boom");
+
     }
 
 }

--- a/test-utils/src/test/java/io/smallrye/mutiny/test/AssertSubscriberTest.java
+++ b/test-utils/src/test/java/io/smallrye/mutiny/test/AssertSubscriberTest.java
@@ -12,11 +12,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.reactivestreams.Subscription;
 
-public class MultiAssertSubscriberTest {
+public class AssertSubscriberTest {
 
     @Test
     public void testItemsAndCompletion() {
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<String> subscriber = AssertSubscriber.create();
         Subscription subscription = mock(Subscription.class);
         subscriber.assertNotTerminated();
         subscriber.onSubscribe(subscription);
@@ -34,7 +34,7 @@ public class MultiAssertSubscriberTest {
 
     @Test
     public void testItemsAndFailure() {
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<String> subscriber = AssertSubscriber.create();
         Subscription subscription = mock(Subscription.class);
 
         subscriber.onSubscribe(subscription);
@@ -51,7 +51,7 @@ public class MultiAssertSubscriberTest {
 
     @Test
     public void testNoItems() {
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<String> subscriber = AssertSubscriber.create();
         Subscription subscription = mock(Subscription.class);
 
         subscriber.onSubscribe(subscription);
@@ -66,7 +66,7 @@ public class MultiAssertSubscriberTest {
 
     @Test
     public void testAwait() {
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<String> subscriber = AssertSubscriber.create();
         Subscription subscription = mock(Subscription.class);
 
         subscriber.onSubscribe(subscription);
@@ -84,7 +84,7 @@ public class MultiAssertSubscriberTest {
 
     @Test
     public void testAwaitWithDuration() {
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<String> subscriber = AssertSubscriber.create();
         Subscription subscription = mock(Subscription.class);
 
         subscriber.onSubscribe(subscription);
@@ -102,7 +102,7 @@ public class MultiAssertSubscriberTest {
 
     @Test
     public void testAwaitOnFailure() {
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<String> subscriber = AssertSubscriber.create();
         Subscription subscription = mock(Subscription.class);
 
         subscriber.onSubscribe(subscription);
@@ -120,7 +120,7 @@ public class MultiAssertSubscriberTest {
 
     @Test
     public void testAwaitAlreadyCompleted() {
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<String> subscriber = AssertSubscriber.create();
         Subscription subscription = mock(Subscription.class);
 
         subscriber.onSubscribe(subscription);
@@ -133,7 +133,7 @@ public class MultiAssertSubscriberTest {
 
     @Test
     public void testAwaitAlreadyFailed() {
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<String> subscriber = AssertSubscriber.create();
         Subscription subscription = mock(Subscription.class);
 
         subscriber.onSubscribe(subscription);
@@ -146,7 +146,7 @@ public class MultiAssertSubscriberTest {
 
     @Test
     public void testUpfrontCancellation() {
-        MultiAssertSubscriber<String> subscriber = new MultiAssertSubscriber<>(0, true);
+        AssertSubscriber<String> subscriber = new AssertSubscriber<>(0, true);
         Subscription subscription = mock(Subscription.class);
         subscriber.onSubscribe(subscription);
         verify(subscription).cancel();
@@ -154,7 +154,7 @@ public class MultiAssertSubscriberTest {
 
     @Test
     public void testUpfrontRequest() {
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create(10);
+        AssertSubscriber<String> subscriber = AssertSubscriber.create(10);
         Subscription subscription = mock(Subscription.class);
         subscriber.onSubscribe(subscription);
         verify(subscription).request(10);
@@ -162,7 +162,7 @@ public class MultiAssertSubscriberTest {
 
     @Test
     public void testRun() {
-        MultiAssertSubscriber<String> subscriber = MultiAssertSubscriber.create();
+        AssertSubscriber<String> subscriber = AssertSubscriber.create();
         AtomicInteger count = new AtomicInteger();
         subscriber.run(count::incrementAndGet).run(count::incrementAndGet);
 

--- a/test-utils/src/test/java/io/smallrye/mutiny/test/MocksTest.java
+++ b/test-utils/src/test/java/io/smallrye/mutiny/test/MocksTest.java
@@ -1,7 +1,6 @@
 package io.smallrye.mutiny.test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
@@ -15,6 +14,22 @@ public class MocksTest {
         Subscriber<Object> subscriber = Mocks.subscriber();
         subscriber.onSubscribe(subscription);
         verify(subscription).request(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void subscriberWithRequests() {
+        Subscription subscription = mock(Subscription.class);
+        Subscriber<Object> subscriber = Mocks.subscriber(20);
+        subscriber.onSubscribe(subscription);
+        verify(subscription).request(20);
+    }
+
+    @Test
+    public void subscriberWithZeroRequest() {
+        Subscription subscription = mock(Subscription.class);
+        Subscriber<Object> subscriber = Mocks.subscriber(0);
+        subscriber.onSubscribe(subscription);
+        verify(subscription, never()).request(anyLong());
     }
 
 }


### PR DESCRIPTION
This PR contains a few improvements:

﻿- The CausedTest was using the wrong @Test annotation
- Add methods to create mocks subscribers.
- Rename the MultiAssertSubscriber to AssertSubscriber as it's not a MultiSubscriber
- Add a class allowing to wrap a Subscriber into a MultiSubscriber.
- Verify the behavior of the AbstractSubscriber
