### PR TITLE
Enforce Reactive Streams protocol in subscribers and processors

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/StrictMultiSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/StrictMultiSubscriber.java
@@ -1,5 +1,6 @@
 package io.smallrye.mutiny.helpers;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -78,6 +79,7 @@ public class StrictMultiSubscriber<T>
 
     @Override
     public void onItem(T t) {
+        Objects.requireNonNull(t);
         HalfSerializer.onNext(downstream, t, wip, failure);
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/Subscriptions.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/Subscriptions.java
@@ -347,7 +347,7 @@ public class Subscriptions {
         }
     }
 
-    @SuppressWarnings("SubscriberImplementation")
+    @SuppressWarnings({ "ReactiveStreamsSubscriberImplementation" })
     public static class CancelledSubscriber<X> implements Subscriber<X> {
         @Override
         public void onSubscribe(Subscription s) {
@@ -371,8 +371,8 @@ public class Subscriptions {
     }
 
     public static class DeferredSubscription implements Subscription {
-        private AtomicReference<Subscription> subscription = new AtomicReference<>();
-        private AtomicLong pendingRequests = new AtomicLong();
+        private final AtomicReference<Subscription> subscription = new AtomicReference<>();
+        private final AtomicLong pendingRequests = new AtomicLong();
 
         protected boolean isCancelled() {
             return subscription.get() == CANCELLED;

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/Subscriptions.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/Subscriptions.java
@@ -10,6 +10,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.CompositeException;
+import io.smallrye.mutiny.subscription.UniSubscription;
 
 public class Subscriptions {
 
@@ -262,7 +263,7 @@ public class Subscriptions {
         return failure.getAndSet(TERMINATED);
     }
 
-    public static class EmptySubscription implements Subscription {
+    public static class EmptySubscription implements Subscription, UniSubscription {
 
         @Override
         public void request(long requests) {

--- a/implementation/src/main/java/io/smallrye/mutiny/infrastructure/MutinyScheduler.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/infrastructure/MutinyScheduler.java
@@ -74,13 +74,13 @@ public class MutinyScheduler extends ScheduledThreadPoolExecutor {
         }
 
         @Override
-        public V get() {
-            throw new UnsupportedOperationException();
+        public V get() throws ExecutionException, InterruptedException {
+            return origin.get();
         }
 
         @Override
-        public V get(long timeout, TimeUnit unit) {
-            throw new UnsupportedOperationException();
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return origin.get(timeout, unit);
         }
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/infrastructure/UniInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/infrastructure/UniInterceptor.java
@@ -13,11 +13,16 @@ import io.smallrye.mutiny.subscription.UniSubscriber;
 public interface UniInterceptor {
 
     /**
+     * Default interceptor ordinal ({@code 100}).
+     */
+    int DEFAULT_ORDINAL = 100;
+
+    /**
      * @return the interceptor ordinal. The ordinal is used to sort the interceptor. Lower value are executed first.
      *         Default is 100.
      */
     default int ordinal() {
-        return 100;
+        return DEFAULT_ORDINAL;
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniFailOnTimeout.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniFailOnTimeout.java
@@ -14,6 +14,7 @@ import java.util.function.Supplier;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.ParameterValidation;
+import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
@@ -48,6 +49,7 @@ public class UniFailOnTimeout<I> extends UniOperator<I, I> {
                     }, timeout.toMillis(), TimeUnit.MILLISECONDS));
                 } catch (RejectedExecutionException e) {
                     // Executor out of service.
+                    subscriber.onSubscribe(Subscriptions.CANCELLED);
                     subscriber.onFailure(e);
                     return;
                 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnCancellationInvokeUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnCancellationInvokeUni.java
@@ -2,7 +2,6 @@ package io.smallrye.mutiny.operators;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 import io.smallrye.mutiny.Uni;
@@ -21,9 +20,6 @@ public class UniOnCancellationInvokeUni<I> extends UniOperator<I, I> {
     protected void subscribing(UniSerializedSubscriber<? super I> subscriber) {
         upstream().subscribe().withSubscriber(new UniDelegatingSubscriber<I, I>(subscriber) {
 
-            // Guard to invoke the supplier only once
-            private final AtomicBoolean invoked = new AtomicBoolean();
-
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 subscriber.onSubscribe(new UniSubscription() {
@@ -36,14 +32,10 @@ public class UniOnCancellationInvokeUni<I> extends UniOperator<I, I> {
                     }
 
                     private Uni<?> execute() {
-                        if (invoked.compareAndSet(false, true)) {
-                            try {
-                                return nonNull(supplier.get(), "uni");
-                            } catch (Throwable err) {
-                                return Uni.createFrom().failure(err);
-                            }
-                        } else {
-                            return Uni.createFrom().nullItem();
+                        try {
+                            return nonNull(supplier.get(), "uni");
+                        } catch (Throwable err) {
+                            return Uni.createFrom().failure(err);
                         }
                     }
                 });

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniSerializedSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniSerializedSubscriber.java
@@ -33,6 +33,7 @@ public class UniSerializedSubscriber<T> implements UniSubscriber<T>, UniSubscrip
     private final AtomicInteger state = new AtomicInteger(INIT);
     private final AbstractUni<T> upstream;
     private final UniSubscriber<? super T> downstream;
+
     private UniSubscription subscription;
     private final AtomicReference<Throwable> failure = new AtomicReference<>();
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/FlatMapManager.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/FlatMapManager.java
@@ -12,7 +12,7 @@ abstract class FlatMapManager<T> {
     private long producerIndex;
     private long consumerIndex;
 
-    private AtomicInteger size = new AtomicInteger();
+    private final AtomicInteger size = new AtomicInteger();
 
     private static final int[] FREE_EMPTY = new int[0];
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiIgnoreOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiIgnoreOp.java
@@ -1,5 +1,7 @@
 package io.smallrye.mutiny.operators.multi;
 
+import java.util.Objects;
+
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Multi;
@@ -13,11 +15,11 @@ public class MultiIgnoreOp<T> extends AbstractMultiOperator<T, Void> {
 
     @Override
     public void subscribe(MultiSubscriber<? super Void> downstream) {
-        upstream.subscribe().withSubscriber(new MultiIgnoreProcessor<>(downstream));
+        upstream.subscribe().withSubscriber(new MultiIgnoreProcessor<>(Objects.requireNonNull(downstream)));
     }
 
-    static class MultiIgnoreProcessor<T> extends MultiOperatorProcessor<T, Void> {
-        MultiIgnoreProcessor(MultiSubscriber<? super Void> downstream) {
+    public static class MultiIgnoreProcessor<T> extends MultiOperatorProcessor<T, Void> {
+        public MultiIgnoreProcessor(MultiSubscriber<? super Void> downstream) {
             super(downstream);
         }
 
@@ -29,6 +31,15 @@ public class MultiIgnoreOp<T> extends AbstractMultiOperator<T, Void> {
                 subscription.request(Long.MAX_VALUE);
             } else {
                 subscription.cancel();
+            }
+        }
+
+        @Override
+        public void request(long numberOfItems) {
+            // Request is handled by the onSubscribe method
+            // Just validate the parameter for compliance with Reactive Streams.
+            if (numberOfItems <= 0) {
+                onFailure(new IllegalArgumentException("Invalid number of request, must be greater than 0"));
             }
         }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/SerializedSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/SerializedSubscriber.java
@@ -1,5 +1,6 @@
 package io.smallrye.mutiny.subscription;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.Subscriber;
@@ -48,6 +49,7 @@ public final class SerializedSubscriber<T> implements Subscription, MultiSubscri
 
     @Override
     public void onItem(T t) {
+        Objects.requireNonNull(t); // Reactive Streams requirement
         if (cancelled || done) {
             return;
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/Subscribers.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/Subscribers.java
@@ -65,7 +65,7 @@ public class Subscribers {
         }
     }
 
-    private static class CallbackBasedSubscriber<T> implements CancellableSubscriber<T>, Subscription {
+    public static class CallbackBasedSubscriber<T> implements CancellableSubscriber<T>, Subscription {
 
         private final AtomicReference<Subscription> subscription = new AtomicReference<>();
         private final Consumer<? super T> onItem;

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/Subscribers.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/Subscribers.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.subscription;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -101,6 +102,7 @@ public class Subscribers {
 
         @Override
         public void onItem(T item) {
+            Objects.requireNonNull(item);
             if (subscription.get() != Subscriptions.CANCELLED) {
                 try {
                     // onItem cannot be null.
@@ -114,6 +116,7 @@ public class Subscribers {
 
         @Override
         public void onFailure(Throwable t) {
+            Objects.requireNonNull(t);
             if (subscription.getAndSet(Subscriptions.CANCELLED) != Subscriptions.CANCELLED) {
                 if (onFailure != null) {
                     onFailure.accept(t);

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/BlockingIterableTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/BlockingIterableTest.java
@@ -2,18 +2,25 @@ package io.smallrye.mutiny.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.reactivestreams.Subscriber;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.queues.SpscArrayQueue;
+import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.subscription.BackPressureFailure;
 
 public class BlockingIterableTest {
 
@@ -25,6 +32,10 @@ public class BlockingIterableTest {
             values.add(i);
         }
 
+        assertThat(values).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        values.clear();
+
+        Multi.createFrom().range(1, 11).subscribe().asIterable().spliterator().forEachRemaining(values::add);
         assertThat(values).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
 
@@ -121,6 +132,93 @@ public class BlockingIterableTest {
 
         assertThatThrownBy(() -> multi.subscribe().asIterable().forEach(i -> {
         })).isInstanceOf(ArithmeticException.class).hasMessageContaining("by zero");
+    }
+
+    @Test(timeOut = 1000)
+    public void testToIterableWithCheckedFailure() {
+        Multi<Integer> multi = Multi.createFrom().emitter(e -> e.emit(1).emit(0).fail(new IOException("boom")));
+
+        assertThatThrownBy(() -> multi.subscribe().asIterable().forEach(i -> {
+        })).isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(IOException.class)
+                .hasMessageContaining("boom");
+    }
+
+    @Test(timeOut = 1000)
+    public void testQueueSupplierFailing() {
+        assertThatThrownBy(() -> {
+            Multi.createFrom().items(1, 2, 3, 4, 5, 6)
+                    .subscribe().asIterable(10, () -> {
+                        throw new IllegalArgumentException("boom");
+                    }).forEach(i -> {
+                        // noop - the iterable is created lazily.
+                    });
+        }).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("boom");
+
+    }
+
+    @Test(timeOut = 1000)
+    public void testQueueSupplierReturningNull() {
+        assertThatThrownBy(() -> {
+            Multi.createFrom().items(1, 2, 3, 4, 5, 6)
+                    .subscribe().asIterable(10, () -> null).forEach(i -> {
+                        // noop - the iterable is created lazily.
+                    });
+        }).isInstanceOf(IllegalStateException.class);
+
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void testWaitingInterrupted() {
+        List<Integer> values = new ArrayList<>();
+        AtomicBoolean after = new AtomicBoolean();
+        AtomicBoolean cancelled = new AtomicBoolean();
+
+        Thread thread = new Thread(() -> {
+            try {
+                Multi.createFrom().<Integer> emitter(e -> e
+                        .onTermination(() -> cancelled.set(true))
+                        .emit(1))
+                        .subscribe().asIterable()
+                        .forEach(values::add);
+            } catch (Throwable e) {
+                assertThat(e).isInstanceOf(RuntimeException.class)
+                        .hasCauseInstanceOf(InterruptedException.class);
+                after.set(true);
+            }
+        });
+        thread.start();
+
+        await().until(() -> values.size() == 1);
+        thread.interrupt();
+        await().untilTrue(after);
+        assertThat(cancelled).isTrue();
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    public void testWithNullValues() {
+        Multi<Integer> rogue = new AbstractMulti<Integer>() {
+            @Override
+            public void subscribe(Subscriber<? super Integer> subscriber) {
+                subscriber.onNext(1);
+                subscriber.onNext(2);
+                subscriber.onNext(3);
+                subscriber.onNext(null);
+            }
+        };
+        BlockingIterable<Integer> integers = rogue.subscribe().asIterable();
+        integers.forEach(i -> assertThat(i).isPositive());
+    }
+
+    @Test(expectedExceptions = BackPressureFailure.class)
+    public void testOverflow() {
+
+        BlockingIterable<Integer> integers = Multi.createFrom()
+                .<Integer> emitter(e -> e.emit(1).emit(2).emit(3).emit(4).emit(5))
+                .subscribe().asIterable(10, () -> new SpscArrayQueue<>(4));
+        integers.forEach(i -> assertThat(i).isPositive());
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/SubscriptionsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/SubscriptionsTest.java
@@ -1,8 +1,8 @@
 package io.smallrye.mutiny.helpers;
 
-import io.smallrye.mutiny.CompositeException;
-import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -13,9 +13,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import org.reactivestreams.Subscription;
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.CompositeException;
 
 public class SubscriptionsTest {
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIgnoreTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIgnoreTest.java
@@ -1,14 +1,21 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.MultiSubscribers;
+import io.smallrye.mutiny.operators.multi.MultiIgnoreOp;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
 import io.smallrye.mutiny.test.AssertSubscriber;
+import io.smallrye.mutiny.test.Mocks;
 
 public class MultiIgnoreTest {
 
@@ -21,6 +28,7 @@ public class MultiIgnoreTest {
                 .assertHasNotReceivedAnyItem();
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void testAsUni() {
         CompletableFuture<Void> future = Multi.createFrom().items(1, 2, 3, 4)
@@ -60,5 +68,39 @@ public class MultiIgnoreTest {
 
         assertThat(future).isNotCompleted();
         future.cancel(true);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testSubscriberCannotBeNull() {
+        MultiIgnoreOp<Integer> ignore = new MultiIgnoreOp<>(Multi.createFrom().items(1, 2, 3, 4));
+        ignore.subscribe(null);
+    }
+
+    @Test
+    public void testSingleSubscriberAcceptedAndSingleRequest() {
+        Subscription subscription1 = mock(Subscription.class);
+        Subscription subscription2 = mock(Subscription.class);
+        Subscriber<Void> mock = Mocks.subscriber();
+        MultiSubscriber<Void> subscriber = MultiSubscribers.toMultiSubscriber(mock);
+        MultiIgnoreOp.MultiIgnoreProcessor<Integer> ignore = new MultiIgnoreOp.MultiIgnoreProcessor<>(subscriber);
+        ignore.onSubscribe(subscription1);
+        ignore.onSubscribe(subscription2);
+
+        verify(subscription1).request(Long.MAX_VALUE);
+        verify(subscription1, never()).cancel();
+        verify(mock).onSubscribe(ignore);
+        verify(subscription2, never()).request(anyLong());
+        verify(subscription2).cancel();
+    }
+
+    @Test
+    public void testIllegalRequests() {
+        AssertSubscriber<Void> subscriber = Multi.createFrom().nothing()
+                .onItem().ignore()
+                .subscribe().withSubscriber(AssertSubscriber.create(0));
+
+        subscriber
+                .request(-1)
+                .assertHasFailedWith(IllegalArgumentException.class, null);
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnSubscribeTest.java
@@ -49,7 +49,6 @@ public class MultiOnSubscribeTest {
         assertThat(reference).doesNotHaveValue(null);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testDeprecatedOnSubscribed() {
         AtomicInteger count = new AtomicInteger();
@@ -105,7 +104,6 @@ public class MultiOnSubscribeTest {
 
         assertThat(count).hasValue(2);
         assertThat(reference).doesNotHaveValue(null);
-
     }
 
     @Test
@@ -239,5 +237,18 @@ public class MultiOnSubscribeTest {
                 .assertSubscribed()
                 .assertCompletedSuccessfully().assertReceived(1, 2, 3);
 
+    }
+
+    @Test
+    public void testThatRunOnSubscriptionEmitRequestOnSubscribe() {
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .subscribe().withSubscriber(AssertSubscriber.create(2));
+
+        subscriber
+                .request(1)
+                .await()
+                .assertReceived(1, 2, 3)
+                .assertCompletedSuccessfully();
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
@@ -1,7 +1,6 @@
 package io.smallrye.mutiny.operators;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
@@ -36,8 +35,6 @@ public class UniAwaitTest {
             assertThat(e).hasCauseInstanceOf(IOException.class).hasMessageEndingWith("boom");
         }
     }
-
-    // Uni.createFrom().failure before onTimeout
 
     @Test(timeOut = 1000)
     public void testAwaitingOnAnAsyncUni() {
@@ -121,6 +118,20 @@ public class UniAwaitTest {
     @Test(timeOut = 100, expectedExceptions = TimeoutException.class)
     public void testTimeoutAndOptional() {
         Uni.createFrom().nothing().await().asOptional().atMost(Duration.ofMillis(10));
+    }
+
+    @Test
+    public void testInvalidDurations() {
+        Uni<Integer> one = Uni.createFrom().item(1);
+
+        // Null duration means infinite
+        assertThat(one.await().atMost(null)).isEqualTo(1);
+
+        assertThatThrownBy(() -> one.await().atMost(Duration.ofMillis(-2000)))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("duration");
+
+        assertThatThrownBy(() -> one.await().atMost(Duration.ofSeconds(0)))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("duration");
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayUntilTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayUntilTest.java
@@ -71,6 +71,7 @@ public class UniOnItemDelayUntilTest {
         assertThat(i).isEqualTo(1);
     }
 
+
     @Test
     public void testWithDelay() {
         int i = Uni.createFrom().item(1).onItem().delayIt().until(x -> delayed)
@@ -114,6 +115,21 @@ public class UniOnItemDelayUntilTest {
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber.assertNoResult();
         subscriber.cancel();
+    }
+
+    @Test
+    public void testImmediateCancellation() {
+        AtomicBoolean called = new AtomicBoolean();
+        UniAssertSubscriber<Integer> subscriber = Uni.createFrom().item(1)
+                // It will never emit the item
+                .onItem().delayIt().until(i -> {
+                    called.set(true);
+                    return Uni.createFrom().nothing();
+                })
+                .subscribe().withSubscriber(new UniAssertSubscriber<>(true));
+
+        subscriber.assertNotCompleted();
+        assertThat(called).isFalse();
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayUntilTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayUntilTest.java
@@ -71,7 +71,6 @@ public class UniOnItemDelayUntilTest {
         assertThat(i).isEqualTo(1);
     }
 
-
     @Test
     public void testWithDelay() {
         int i = Uni.createFrom().item(1).onItem().delayIt().until(x -> delayed)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessorTest.java
@@ -1,12 +1,18 @@
 package io.smallrye.mutiny.operators.multi.processors;
 
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
+import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.reactivestreams.Subscription;
 import org.testng.annotations.Test;
 
+import io.smallrye.mutiny.helpers.queues.Queues;
+import io.smallrye.mutiny.subscription.BackPressureFailure;
 import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class UnicastProcessorTest {
@@ -43,6 +49,68 @@ public class UnicastProcessorTest {
 
         await().until(() -> subscriber.items().size() == 5 * 10000);
         executor.shutdownNow();
+    }
+
+    @Test
+    public void testWithImmediateCancellationFromDownstream() {
+        UnicastProcessor<String> processor = UnicastProcessor.create();
+        AssertSubscriber<String> subscriber = processor
+                .subscribe().withSubscriber(new AssertSubscriber<>(50, true));
+
+        processor.onNext("a");
+        processor.onNext("b");
+        processor.onComplete();
+
+        subscriber.assertNotTerminated()
+                .assertSubscribed()
+                .assertHasNotReceivedAnyItem();
+
+        processor = UnicastProcessor.create();
+        subscriber = processor
+                .subscribe().withSubscriber(new AssertSubscriber<>(50, true));
+
+        processor.onNext("a");
+        processor.onNext("b");
+        processor.onError(new IOException("boom"));
+
+        subscriber.assertNotTerminated()
+                .assertSubscribed()
+                .assertHasNotReceivedAnyItem();
+    }
+
+    @Test
+    public void testWithImmediateCancellationFromDownstreamWhileWaitingForUpstreamSubscription() {
+        UnicastProcessor<String> processor = UnicastProcessor.create();
+        AssertSubscriber<String> subscriber = processor
+                .subscribe().withSubscriber(new AssertSubscriber<>(50, true));
+
+        processor.onSubscribe(mock(Subscription.class));
+        processor.onNext("a");
+        processor.onNext("b");
+        processor.onComplete();
+
+        subscriber.assertNotTerminated()
+                .assertSubscribed()
+                .assertHasNotReceivedAnyItem();
+    }
+
+    @Test
+    public void testOverflow() {
+        Queue<Integer> queue = Queues.<Integer> get(1).get();
+        UnicastProcessor<Integer> processor = UnicastProcessor.create(queue, null);
+        AssertSubscriber<Integer> subscriber = processor.subscribe()
+                .withSubscriber(AssertSubscriber.create(2));
+
+        processor.onNext(1);
+        processor.onNext(2);
+        processor.onNext(3);
+        processor.onNext(4);
+
+        subscriber.assertSubscribed()
+                .assertReceived(1, 2)
+                // The overflow is only propagated on the next request.
+                .request(2)
+                .assertHasFailedWith(BackPressureFailure.class, "");
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/SwitchableSubscriptionSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/SwitchableSubscriptionSubscriberTest.java
@@ -1,0 +1,668 @@
+package io.smallrye.mutiny.subscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.reactivestreams.Subscription;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.test.AssertSubscriber;
+
+public class SwitchableSubscriptionSubscriberTest {
+
+    private AssertSubscriber<Integer> subscriber;
+    private MultiSubscriber<Integer> downstream;
+    private SwitchableSubscriptionSubscriber<Integer> switchable;
+
+    @BeforeTest
+    public void init() {
+        subscriber = AssertSubscriber.create(10);
+        downstream = new MultiSubscriber<Integer>() {
+            @Override
+            public void onItem(Integer item) {
+                subscriber.onNext(item);
+            }
+
+            @Override
+            public void onFailure(Throwable failure) {
+                subscriber.onError(failure);
+            }
+
+            @Override
+            public void onCompletion() {
+                subscriber.onComplete();
+            }
+
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                subscriber.onSubscribe(subscription);
+            }
+        };
+    }
+
+    @Test
+    public void testInvalidRequests() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+        switchable.request(-1);
+        subscriber.assertHasFailedWith(IllegalArgumentException.class, "");
+    }
+
+    @Test
+    public void testCancellationIfTheDownstreamSubscriptionIsCancelled() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+        downstream.onSubscribe(switchable);
+        subscriber.assertSubscribed();
+
+        subscriber.cancel();
+        Subscription second = mock(Subscription.class);
+        switchable.onSubscribe(second);
+        verify(second, times(1)).cancel();
+        assertThat(switchable.isCancelled()).isTrue();
+    }
+
+    @Test
+    public void testCancellationOnSwitchEnabled() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+
+            @Override
+            protected boolean cancelUpstreamOnSwitch() {
+                return true;
+            }
+        };
+        Subscription first = mock(Subscription.class);
+        Subscription second = mock(Subscription.class);
+        switchable.request(5);
+
+        switchable.onSubscribe(first);
+        switchable.onSubscribe(second);
+        verify(first, times(1)).cancel();
+        verify(first, times(1)).request(5);
+        verify(second, times(0)).cancel();
+        verify(second, times(1)).request(5);
+    }
+
+    @Test
+    public void testCancellationOnSwitchDisabled() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+        Subscription first = mock(Subscription.class);
+        Subscription second = mock(Subscription.class);
+        switchable.request(5);
+
+        switchable.onSubscribe(first);
+        switchable.onSubscribe(second);
+        verify(first, times(0)).cancel();
+        verify(first, times(1)).request(5);
+        verify(second, times(0)).cancel();
+        verify(second, times(1)).request(5);
+    }
+
+    @Test
+    public void testRequests() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+        Subscription first = mock(Subscription.class);
+        Subscription second = mock(Subscription.class);
+        Subscription third = mock(Subscription.class);
+        switchable.request(5);
+        switchable.onSubscribe(first);
+
+        // Emit 5 - remaining 0
+        switchable.emitted(5);
+        switchable.onSubscribe(second);
+        verify(first, times(0)).cancel();
+        verify(first, times(1)).request(5);
+        verify(second, times(0)).cancel();
+        verify(second, times(0)).request(0);
+
+        switchable.request(10);
+        verify(second, times(1)).request(10);
+        // Emit 2 - remaining 8
+        switchable.emitted(2);
+        switchable.onSubscribe(third);
+        verify(third, times(1)).request(8);
+    }
+
+    @Test(invocationCount = 100)
+    public void testRaceOnSwitch() throws InterruptedException {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+        Subscription first = mock(Subscription.class);
+        Subscription second = mock(Subscription.class);
+        Subscription third = mock(Subscription.class);
+        switchable.request(5);
+
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(3);
+        Runnable r1 = () -> {
+            try {
+                start.await();
+                switchable.onSubscribe(first);
+                done.countDown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+        Runnable r2 = () -> {
+            try {
+                start.await();
+                switchable.onSubscribe(second);
+                done.countDown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+        Runnable r3 = () -> {
+            try {
+                start.await();
+                switchable.onSubscribe(third);
+                done.countDown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+        List<Runnable> list = Arrays.asList(r1, r2, r3);
+        Collections.shuffle(list);
+        for (Runnable r : list) {
+            new Thread(r).start();
+        }
+
+        start.countDown();
+        done.await();
+
+        verify(first, times(0)).cancel();
+        verify(second, times(0)).cancel();
+        verify(third, times(0)).cancel();
+        verify(first, atMost(1)).request(5);
+        verify(second, atMost(1)).request(5);
+        verify(third, atMost(1)).request(5);
+    }
+
+    @Test(invocationCount = 100)
+    public void testRaceOnSwitchWithCancellationOnSwitch() throws InterruptedException {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+
+            @Override
+            protected boolean cancelUpstreamOnSwitch() {
+                return true;
+            }
+        };
+        Subscription first = mock(Subscription.class);
+        Subscription second = mock(Subscription.class);
+        Subscription third = mock(Subscription.class);
+        switchable.request(5);
+
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(3);
+        Runnable r1 = () -> {
+            try {
+                start.await();
+                switchable.onSubscribe(first);
+                done.countDown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+        Runnable r2 = () -> {
+            try {
+                start.await();
+                switchable.onSubscribe(second);
+                done.countDown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+        Runnable r3 = () -> {
+            try {
+                start.await();
+                switchable.onSubscribe(third);
+                done.countDown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+        List<Runnable> list = Arrays.asList(r1, r2, r3);
+        Collections.shuffle(list);
+        for (Runnable r : list) {
+            new Thread(r).start();
+        }
+
+        start.countDown();
+        done.await();
+
+        verify(first, atMost(1)).cancel();
+        verify(second, atMost(1)).cancel();
+        verify(third, atMost(1)).cancel();
+        verify(first, atMost(1)).request(5);
+        verify(second, atMost(1)).request(5);
+        verify(third, atMost(1)).request(5);
+    }
+
+    @Test(invocationCount = 50)
+    public void testRaceOnSwitchAndEmitted() throws InterruptedException {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+        switchable.request(1000);
+
+        int threads = 1000;
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        List<Runnable> runnables = new ArrayList<>();
+        List<Subscription> subscriptions = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            int id = i;
+            Subscription sub = mock(Subscription.class);
+            Runnable runnable = () -> {
+                try {
+                    start.await();
+                    if (id % 2 == 0) {
+                        switchable.emitted(2);
+                    } else {
+                        switchable.onSubscribe(sub);
+                    }
+                    done.countDown();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            };
+            subscriptions.add(sub);
+            runnables.add(runnable);
+        }
+
+        Collections.shuffle(runnables);
+        for (Runnable r : runnables) {
+            new Thread(r).start();
+        }
+
+        start.countDown();
+        done.await();
+
+        for (Subscription s : subscriptions) {
+            verify(s, times(0)).cancel();
+            verify(s, atMost(1)).request(anyLong());
+        }
+    }
+
+    @Test
+    public void testWhenSubscriptionIsMissed() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+
+            @Override
+            protected boolean cancelUpstreamOnSwitch() {
+                return true;
+            }
+        };
+
+        AtomicInteger wip = switchable.wip;
+
+        wip.getAndIncrement();
+
+        Subscription sub1 = mock(Subscription.class);
+        Subscription sub2 = mock(Subscription.class);
+
+        switchable.onSubscribe(sub1);
+        switchable.onSubscribe(sub2);
+
+        verify(sub1, times(1)).cancel();
+        verify(sub2, times(0)).cancel();
+    }
+
+    @Test
+    public void testUnboundedRequest() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+
+            @Override
+            protected boolean cancelUpstreamOnSwitch() {
+                return true;
+            }
+        };
+
+        switchable.request(Long.MAX_VALUE);
+
+        assertThat(switchable.requested).isEqualTo(Long.MAX_VALUE);
+        assertThat(switchable.unbounded).isTrue();
+
+        switchable.unbounded = false;
+        switchable.request(Long.MAX_VALUE);
+        assertThat(switchable.requested).isEqualTo(Long.MAX_VALUE);
+
+        switchable.emitted(1);
+        assertThat(switchable.requested).isEqualTo(Long.MAX_VALUE);
+
+        switchable.unbounded = false;
+
+        switchable.emitted(Long.MAX_VALUE);
+        assertThat(switchable.requested).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testCancellationInDrainLoop() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+
+            @Override
+            protected boolean cancelUpstreamOnSwitch() {
+                return true;
+            }
+        };
+        switchable.cancel();
+
+        Subscription sub = mock(Subscription.class);
+        switchable.pendingSubscription.set(sub);
+        switchable.wip.getAndIncrement();
+        switchable.drainLoop();
+        verify(sub, times(1)).cancel();
+    }
+
+    @Test
+    public void testDrainLoopWithUnboundedRequests() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+
+        switchable.wip.getAndIncrement();
+        switchable.request(Long.MAX_VALUE);
+        switchable.drainLoop();
+
+        assertThat(switchable.wip).hasValue(0);
+    }
+
+    @Test
+    public void testMissedRequests() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+
+        switchable.wip.getAndIncrement();
+        switchable.requested = 0;
+        switchable.missedRequested.set(1);
+        switchable.drainLoop();
+        assertThat(switchable.requested).isEqualTo(1);
+    }
+
+    @Test
+    public void testDrainLoopWithMissedRequestsAndItems() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+
+        switchable.wip.getAndIncrement();
+        switchable.requested = 0;
+        switchable.missedRequested.set(Long.MAX_VALUE);
+        switchable.missedItems.set(25);
+        switchable.drainLoop();
+
+        assertThat(switchable.requested).isEqualTo(Long.MAX_VALUE);
+
+    }
+
+    @Test
+    public void testWhenWeEmitMoreThanRequested() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+        switchable.wip.getAndIncrement();
+        switchable.requested = 0;
+
+        switchable.missedRequested.set(1);
+        switchable.missedItems.set(2);
+        switchable.drainLoop();
+
+        assertThat(switchable.requested).isEqualTo(0);
+        assertThat(switchable.missedRequested).hasValue(0);
+        assertThat(switchable.missedItems).hasValue(0);
+    }
+
+    @Test
+    public void testMissedFirstSubscription() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+
+        switchable.wip.getAndIncrement();
+        Subscription subscription = mock(Subscription.class);
+        switchable.pendingSubscription.set(subscription);
+        switchable.drainLoop();
+        assertThat(subscription).isEqualTo(switchable.currentUpstream.get());
+    }
+
+    @Test
+    public void testPendingSubscriptionWithoutCancellationOnSwitch() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+
+        Subscription subscription1 = mock(Subscription.class);
+        Subscription subscription2 = mock(Subscription.class);
+        Subscription subscription3 = mock(Subscription.class);
+
+        switchable.onSubscribe(subscription1);
+        switchable.wip.getAndIncrement();
+
+        switchable.onSubscribe(subscription2);
+        switchable.onSubscribe(subscription3);
+
+        switchable.drainLoop();
+        verify(subscription1, times(0)).cancel();
+        verify(subscription2, times(0)).cancel();
+        verify(subscription3, times(0)).cancel();
+
+        assertThat(subscription3).isEqualTo(switchable.currentUpstream.get());
+    }
+
+    @Test
+    public void testPendingSubscriptionWithCancellationOnSwitch() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+
+            @Override
+            protected boolean cancelUpstreamOnSwitch() {
+                return true;
+            }
+        };
+
+        Subscription subscription1 = mock(Subscription.class);
+        Subscription subscription2 = mock(Subscription.class);
+        Subscription subscription3 = mock(Subscription.class);
+
+        switchable.onSubscribe(subscription1);
+        switchable.wip.getAndIncrement();
+
+        switchable.onSubscribe(subscription2);
+        switchable.onSubscribe(subscription3);
+
+        switchable.drainLoop();
+        verify(subscription1, times(1)).cancel();
+        verify(subscription2, times(1)).cancel();
+        verify(subscription3, times(0)).cancel();
+
+        assertThat(subscription3).isEqualTo(switchable.currentUpstream.get());
+    }
+
+    @Test
+    public void testEmittedAndUnbounded() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+
+        switchable.request(Long.MAX_VALUE);
+        switchable.emitted(100);
+        switchable.request(10);
+
+        assertThat(switchable.unbounded).isTrue();
+        assertThat(switchable.requested).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testDrainLoopAfterCancellation() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+        Subscription subscription = mock(Subscription.class);
+        switchable.onSubscribe(subscription);
+
+        switchable.wip.getAndIncrement();
+        switchable.cancel();
+
+        verify(subscription, times(0)).cancel();
+        switchable.drainLoop();
+        verify(subscription, times(1)).cancel();
+    }
+
+    @Test
+    public void testRequestHappeningDuringWIP() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+        Subscription subscription = mock(Subscription.class);
+        switchable.onSubscribe(subscription);
+        switchable.request(10);
+
+        switchable.wip.getAndIncrement();
+        switchable.emitted(5);
+        switchable.request(3);
+        switchable.drainLoop();
+
+        verify(subscription, times(0)).cancel();
+        verify(subscription, times(1)).request(3);
+    }
+
+    @Test
+    public void testRequestAndSwitchHappeningDuringWIP() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+        };
+        Subscription subscription1 = mock(Subscription.class);
+        Subscription subscription2 = mock(Subscription.class);
+        switchable.onSubscribe(subscription1);
+        switchable.request(10);
+
+        switchable.wip.getAndIncrement();
+        switchable.requested = 10;
+        switchable.missedRequested.set(3);
+        switchable.emitted(5);
+        switchable.pendingSubscription.set(subscription2);
+        switchable.drainLoop();
+
+        verify(subscription1, times(0)).cancel();
+        verify(subscription2, times(0)).cancel();
+        verify(subscription2, times(1)).request(8);
+    }
+
+    @Test
+    public void testRequestAndSwitchHappeningDuringWIPWithCancellation() {
+        switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+            @Override
+            public void onItem(Integer item) {
+                downstream.onItem(item);
+            }
+
+            @Override
+            protected boolean cancelUpstreamOnSwitch() {
+                return true;
+            }
+        };
+        Subscription subscription1 = mock(Subscription.class);
+        Subscription subscription2 = mock(Subscription.class);
+        switchable.onSubscribe(subscription1);
+        switchable.request(10);
+
+        switchable.wip.getAndIncrement();
+        switchable.requested = 10;
+        switchable.missedRequested.set(3);
+        switchable.emitted(5);
+        switchable.pendingSubscription.set(subscription2);
+        switchable.drainLoop();
+
+        verify(subscription1, times(1)).cancel();
+        verify(subscription2, times(0)).cancel();
+        verify(subscription2, times(1)).request(8);
+    }
+
+}

--- a/implementation/src/test/java/tck/AbstractBlackBoxSubscriberTck.java
+++ b/implementation/src/test/java/tck/AbstractBlackBoxSubscriberTck.java
@@ -1,0 +1,21 @@
+package tck;
+
+import org.reactivestreams.tck.SubscriberBlackboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+
+public abstract class AbstractBlackBoxSubscriberTck extends SubscriberBlackboxVerification<Integer> {
+
+    public AbstractBlackBoxSubscriberTck() {
+        this(100);
+    }
+
+    public AbstractBlackBoxSubscriberTck(long timeout) {
+        super(new TestEnvironment(timeout));
+    }
+
+    @Override
+    public Integer createElement(int i) {
+        return i;
+    }
+
+}

--- a/implementation/src/test/java/tck/AbstractWhiteBoxSubscriberTck.java
+++ b/implementation/src/test/java/tck/AbstractWhiteBoxSubscriberTck.java
@@ -1,0 +1,60 @@
+package tck;
+
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+public abstract class AbstractWhiteBoxSubscriberTck extends SubscriberWhiteboxVerification<Integer> {
+
+    public AbstractWhiteBoxSubscriberTck() {
+        this(100);
+    }
+
+    public AbstractWhiteBoxSubscriberTck(long timeout) {
+        super(new TestEnvironment(timeout));
+    }
+
+    public MultiSubscriber<Integer> createReportingDownstreamSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
+        return new MultiSubscriber<Integer>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                probe.registerOnSubscribe(new SubscriberPuppet() {
+                    @Override
+                    public void triggerRequest(long elements) {
+                        subscription.request(elements);
+                    }
+
+                    @Override
+                    public void signalCancel() {
+                        subscription.cancel();
+                    }
+                });
+            }
+
+            @Override
+            public void onItem(Integer item) {
+                probe.registerOnNext(item);
+            }
+
+            @Override
+            public void onFailure(Throwable failure) {
+                probe.registerOnError(failure);
+
+            }
+
+            @Override
+            public void onCompletion() {
+                probe.registerOnComplete();
+            }
+
+        };
+    }
+
+    @Override
+    public Integer createElement(int i) {
+        return i;
+    }
+
+}

--- a/implementation/src/test/java/tck/BroadcastProcessorSubscriberTckTest.java
+++ b/implementation/src/test/java/tck/BroadcastProcessorSubscriberTckTest.java
@@ -1,0 +1,22 @@
+package tck;
+
+import org.reactivestreams.Subscriber;
+import org.testng.annotations.Ignore;
+
+import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
+
+public class BroadcastProcessorSubscriberTckTest extends AbstractBlackBoxSubscriberTck {
+
+    @Override
+    public Subscriber<Integer> createSubscriber() {
+        return BroadcastProcessor.create();
+    }
+
+    @Override
+    @Ignore
+    public void required_spec205_blackbox_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal()
+            throws Exception {
+        // Ignoring test
+        // The broadcast processor is able to handle multiple subscription.
+    }
+}

--- a/implementation/src/test/java/tck/BroadcastSerializedProcessorSubscriberTckTest.java
+++ b/implementation/src/test/java/tck/BroadcastSerializedProcessorSubscriberTckTest.java
@@ -1,0 +1,22 @@
+package tck;
+
+import org.reactivestreams.Subscriber;
+import org.testng.annotations.Ignore;
+
+import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
+
+public class BroadcastSerializedProcessorSubscriberTckTest extends AbstractBlackBoxSubscriberTck {
+
+    @Override
+    public Subscriber<Integer> createSubscriber() {
+        return BroadcastProcessor.<Integer> create().serialized();
+    }
+
+    @Override
+    @Ignore
+    public void required_spec205_blackbox_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal()
+            throws Exception {
+        // Ignoring test
+        // The broadcast processor is able to handle multiple subscription.
+    }
+}

--- a/implementation/src/test/java/tck/CallbackBasedSubscriberTckTest.java
+++ b/implementation/src/test/java/tck/CallbackBasedSubscriberTckTest.java
@@ -1,0 +1,28 @@
+package tck;
+
+import org.reactivestreams.Subscriber;
+
+import io.smallrye.mutiny.subscription.Subscribers;
+
+public class CallbackBasedSubscriberTckTest extends AbstractWhiteBoxSubscriberTck {
+    @Override
+    public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
+        return new Subscribers.CallbackBasedSubscriber<>(
+                probe::registerOnNext,
+                probe::registerOnError,
+                probe::registerOnComplete,
+                subscription -> probe.registerOnSubscribe(new SubscriberPuppet() {
+                    @Override
+                    public void triggerRequest(long elements) {
+                        subscription.request(elements);
+                    }
+
+                    @Override
+                    public void signalCancel() {
+                        subscription.cancel();
+                    }
+                })
+
+        );
+    }
+}

--- a/implementation/src/test/java/tck/MultiFromCollectionTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromCollectionTckTest.java
@@ -14,6 +14,6 @@ public class MultiFromCollectionTckTest extends AbstractPublisherTck<Long> {
         for (int i = 0; i < elements; i++) {
             list.add((long) i);
         }
-        return Multi.createFrom().iterable(list);
+        return Multi.createFrom().items(list.toArray(new Long[0]));
     }
 }

--- a/implementation/src/test/java/tck/MultiRunSubscriptionOnTckTest.java
+++ b/implementation/src/test/java/tck/MultiRunSubscriptionOnTckTest.java
@@ -1,0 +1,37 @@
+package tck;
+
+import io.smallrye.mutiny.Multi;
+import org.reactivestreams.Publisher;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.LongStream;
+
+public class MultiRunSubscriptionOnTckTest extends AbstractPublisherTck<Long> {
+
+    private ExecutorService executor;
+
+    @BeforeMethod
+    public void init() {
+        executor = Executors.newFixedThreadPool(3);
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        executor.shutdown();
+    }
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+                .runSubscriptionOn(executor);
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+                .runSubscriptionOn(executor);
+    }
+}

--- a/implementation/src/test/java/tck/MultiRunSubscriptionOnTckTest.java
+++ b/implementation/src/test/java/tck/MultiRunSubscriptionOnTckTest.java
@@ -1,13 +1,14 @@
 package tck;
 
-import io.smallrye.mutiny.Multi;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.LongStream;
+
 import org.reactivestreams.Publisher;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.stream.LongStream;
+import io.smallrye.mutiny.Multi;
 
 public class MultiRunSubscriptionOnTckTest extends AbstractPublisherTck<Long> {
 

--- a/implementation/src/test/java/tck/SerializedProcessorSubscriberTckTest.java
+++ b/implementation/src/test/java/tck/SerializedProcessorSubscriberTckTest.java
@@ -1,0 +1,13 @@
+package tck;
+
+import org.reactivestreams.Subscriber;
+
+import io.smallrye.mutiny.subscription.SerializedSubscriber;
+
+public class SerializedProcessorSubscriberTckTest extends AbstractWhiteBoxSubscriberTck {
+
+    @Override
+    public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
+        return new SerializedSubscriber<>(createReportingDownstreamSubscriber(probe));
+    }
+}

--- a/implementation/src/test/java/tck/SerializedUnicastProcessorPublisherTckTest.java
+++ b/implementation/src/test/java/tck/SerializedUnicastProcessorPublisherTckTest.java
@@ -1,0 +1,23 @@
+package tck;
+
+import java.util.stream.IntStream;
+
+import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.operators.multi.processors.SerializedProcessor;
+import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
+
+public class SerializedUnicastProcessorPublisherTckTest extends AbstractPublisherTck<Integer> {
+
+    @Override
+    public Publisher<Integer> createPublisher(long elements) {
+        Multi<Integer> multi = Multi.createFrom().items(IntStream.rangeClosed(1, (int) elements).boxed());
+        SerializedProcessor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
+
+        multi.subscribe(processor);
+
+        return processor;
+
+    }
+}

--- a/implementation/src/test/java/tck/StrictMultiSubscriberTckTest.java
+++ b/implementation/src/test/java/tck/StrictMultiSubscriberTckTest.java
@@ -1,0 +1,16 @@
+package tck;
+
+import org.reactivestreams.Subscriber;
+
+import io.smallrye.mutiny.helpers.StrictMultiSubscriber;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+public class StrictMultiSubscriberTckTest extends AbstractWhiteBoxSubscriberTck {
+
+    @Override
+    public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
+        MultiSubscriber<? super Integer> downstream = createReportingDownstreamSubscriber(probe);
+        return new StrictMultiSubscriber<>(downstream);
+    }
+
+}

--- a/implementation/src/test/java/tck/SwitchableSubscriptionSubscriberTckTest.java
+++ b/implementation/src/test/java/tck/SwitchableSubscriptionSubscriberTckTest.java
@@ -1,0 +1,48 @@
+package tck;
+
+import java.util.Objects;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+import io.smallrye.mutiny.subscription.SwitchableSubscriptionSubscriber;
+
+public class SwitchableSubscriptionSubscriberTckTest extends AbstractWhiteBoxSubscriberTck {
+
+    @Override
+    public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
+        MultiSubscriber<? super Integer> downstream = createReportingDownstreamSubscriber(probe);
+        return new SwitchableSubscriptionSubscriber<Integer>(downstream) {
+
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                // To pass the TCK we need to disable the switch and cancel the second subscription
+                if (super.currentUpstream.get() != null) {
+                    subscription.cancel();
+                }
+
+                probe.registerOnSubscribe(new SubscriberPuppet() {
+                    @Override
+                    public void triggerRequest(long elements) {
+                        subscription.request(elements);
+                    }
+
+                    @Override
+                    public void signalCancel() {
+                        subscription.cancel();
+                    }
+                });
+                super.setOrSwitchUpstream(subscription);
+            }
+
+            @Override
+            public void onItem(Integer item) {
+                Objects.requireNonNull(item); // Just here to pass the TCK.
+                probe.registerOnNext(item);
+            }
+
+        };
+    }
+
+}

--- a/implementation/src/test/java/tck/UnicastProcessorSubscriberTckTest.java
+++ b/implementation/src/test/java/tck/UnicastProcessorSubscriberTckTest.java
@@ -1,0 +1,14 @@
+package tck;
+
+import org.reactivestreams.Subscriber;
+
+import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
+
+public class UnicastProcessorSubscriberTckTest extends AbstractBlackBoxSubscriberTck {
+
+    @Override
+    public Subscriber<Integer> createSubscriber() {
+        return UnicastProcessor.create();
+    }
+
+}

--- a/implementation/src/test/java/tck/UnicastSerializedProcessorSubscriberTckTest.java
+++ b/implementation/src/test/java/tck/UnicastSerializedProcessorSubscriberTckTest.java
@@ -1,0 +1,14 @@
+package tck;
+
+import org.reactivestreams.Subscriber;
+
+import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
+
+public class UnicastSerializedProcessorSubscriberTckTest extends AbstractBlackBoxSubscriberTck {
+
+    @Override
+    public Subscriber<Integer> createSubscriber() {
+        return UnicastProcessor.<Integer> create().serialized();
+    }
+
+}


### PR DESCRIPTION
This PR implements the Reactive Streams TCK for the subscribers and processors.
It also fixes a few issues regarding the protocol.


- BlockingIterable: Throw BackPressureException when the buffer is full
- Cancellation cannot happen concurrently thanks to the UniSerializedSubscriber
- Verify the behavior of Uni.onItem().delay() when the subscriber cancels immediately.
- Verify invalid durations in Uni.await().atMost
- Add Reactive TCK tests for the Multi subscribers and processors
- Extract default interceptor ordinal into a constant
- Verify the behavior of the  SwitchableSubscriptionSubscriber
- The Multi Ignore operator must reject invalid request and emit request only once and check for null subscribers
- Verify cancellation and overflow management in the Unicast processor
- Reactive Streams TCK for the runSubscriptionOn operator
- Make EmptySubscription usable for both regular subscription and UniSubscription
- MutinyScheduler should implement the get methods.
- UniFailOnTimeout must send a subscription downstream before propagating a failure
- The TCK was not testing the right operator
- Verify the behavior of the cancelled subscriber
- Implement the Reactive Stream TCK for the RunOnSubscription operator
- Implement Subscriber TCK For the callback based TCK
- Refactor exponential backoff
- Verify runSubscriptionOn emits request on subscription
- Verify onNoItem with cancellation and rejected task
- The callback based subscribers must throw an NPE on null item and failure (Reactive Streams rule)
