### PR TITLE
Add more tests for some Multi operators

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnEvent.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnEvent.java
@@ -59,6 +59,7 @@ public class MultiOnEvent<T> {
      * Action when items are being requested.
      *
      * @param callback the action
+     * @return a new {@link Multi}
      * @deprecated Use {@link Multi#onRequest()} instead
      */
     @Deprecated

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOverflow.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOverflow.java
@@ -19,12 +19,6 @@ public class MultiOverflow<T> {
         this.upstream = nonNull(upstream, "upstream");
     }
 
-    public static <T> Multi<T> buffer(Multi<T> upstream, int size) {
-        return new MultiOnOverflowBufferOp<>(upstream, size,
-                false, false, x -> {
-                });
-    }
-
     /**
      * When the downstream cannot keep up with the upstream emissions, instruct to use an <strong>unbounded</strong>
      * buffer to store the items until they are consumed.

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiSubscribe.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiSubscribe.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.groups;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+import static io.smallrye.mutiny.subscription.Subscribers.NO_ON_FAILURE;
 
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -210,7 +211,7 @@ public class MultiSubscribe<T> {
         nonNull(onItem, "onItem");
         CancellableSubscriber<? super T> subscriber = Subscribers.from(
                 nonNull(onItem, "onItem"),
-                null,
+                NO_ON_FAILURE,
                 null,
                 s -> s.request(Long.MAX_VALUE));
         return withSubscriber(subscriber);

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOr.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOr.java
@@ -18,10 +18,6 @@ public class UniOr<T> {
         this.upstream = nonNull(upstream, "upstream");
     }
 
-    public Uni<T> uni(Uni<T> other) {
-        return unis(upstream, other);
-    }
-
     @SafeVarargs
     public final Uni<T> unis(Uni<T>... other) {
         List<Uni<T>> list = new ArrayList<>();

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/DrainUtils.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/DrainUtils.java
@@ -19,8 +19,8 @@ public class DrainUtils {
      * The AtomicLong (this) holds the requested amount in bits 0..62 so there is room
      * for one signal bit. This also means the standard request accounting helper method doesn't work.
      */
-    private static final long COMPLETED_MASK = 0x8000_0000_0000_0000L;
-    private static final long REQUESTED_MASK = 0x7FFF_FFFF_FFFF_FFFFL;
+    protected static final long COMPLETED_MASK = 0x8000_0000_0000_0000L;
+    protected static final long REQUESTED_MASK = 0x7FFF_FFFF_FFFF_FFFFL;
 
     private DrainUtils() {
         // avoid direct instantiation.

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/MpscLinkedQueue.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/MpscLinkedQueue.java
@@ -126,12 +126,12 @@ public final class MpscLinkedQueue<T> implements Queue<T> {
 
     @Override
     public T element() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public T peek() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/SpscLinkedArrayQueue.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/SpscLinkedArrayQueue.java
@@ -177,7 +177,7 @@ public final class SpscLinkedArrayQueue<E> extends AbstractQueue<E> implements Q
 
     @Override
     public Iterator<E> iterator() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     public int size() {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
@@ -103,7 +103,7 @@ public abstract class AbstractUni<T> implements Uni<T> {
     @Override
     public Uni<T> runSubscriptionOn(Executor executor) {
         return Infrastructure.onUniCreation(
-                new UniCallSubscribeOn<>(this, executor));
+                new UniRunSubscribeOn<>(this, executor));
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniRunSubscribeOn.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniRunSubscribeOn.java
@@ -10,11 +10,11 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
 
-public class UniCallSubscribeOn<I> extends UniOperator<I, I> {
+public class UniRunSubscribeOn<I> extends UniOperator<I, I> {
 
     private final Executor executor;
 
-    public UniCallSubscribeOn(Uni<? extends I> upstream, Executor executor) {
+    public UniRunSubscribeOn(Uni<? extends I> upstream, Executor executor) {
         super(nonNull(upstream, "upstream"));
         this.executor = nonNull(executor, "executor");
     }
@@ -42,7 +42,12 @@ public class UniCallSubscribeOn<I> extends UniOperator<I, I> {
 
         @Override
         public void run() {
-            AbstractUni.subscribe(upstream(), this);
+            try {
+                AbstractUni.subscribe(upstream(), this);
+            } catch (Exception e) {
+                super.onSubscribe(CANCELLED);
+                super.onFailure(e);
+            }
         }
 
         @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOp.java
@@ -13,7 +13,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
-import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Multi;
@@ -75,9 +74,9 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
         private final Supplier<List<T>> supplier;
         private final Runnable flush;
 
-        private AtomicInteger terminated = new AtomicInteger(RUNNING);
-        private AtomicLong requested = new AtomicLong();
-        private AtomicInteger index = new AtomicInteger();
+        private final AtomicInteger terminated = new AtomicInteger(RUNNING);
+        private final AtomicLong requested = new AtomicLong();
+        private final AtomicInteger index = new AtomicInteger();
         private List<T> current;
         private ScheduledFuture<?> task;
 
@@ -199,20 +198,6 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
             } finally {
                 super.onCompletion();
             }
-        }
-
-        /**
-         * @return has this {@link Subscriber} terminated with success ?
-         */
-        final boolean isCompleted() {
-            return terminated.get() == SUCCEED;
-        }
-
-        /**
-         * @return has this {@link Subscriber} terminated with an error ?
-         */
-        final boolean isFailed() {
-            return terminated.get() == FAILED;
         }
 
         @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDistinctOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDistinctOp.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators.multi;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
@@ -19,10 +20,7 @@ public final class MultiDistinctOp<T> extends AbstractMultiOperator<T, T> {
 
     @Override
     public void subscribe(MultiSubscriber<? super T> actual) {
-        if (actual == null) {
-            throw new NullPointerException("Subscriber cannot be `null`");
-        }
-        upstream.subscribe().withSubscriber(new DistinctProcessor<>(actual));
+        upstream.subscribe(new DistinctProcessor<>(Objects.requireNonNull(actual, "Subscriber must not be `null`")));
     }
 
     static final class DistinctProcessor<T> extends MultiOperatorProcessor<T, T> {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiMapOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiMapOp.java
@@ -24,10 +24,10 @@ public final class MultiMapOp<T, U> extends AbstractMultiOperator<T, U> {
         upstream.subscribe().withSubscriber(new MapProcessor<T, U>(downstream, mapper));
     }
 
-    static class MapProcessor<I, O> extends MultiOperatorProcessor<I, O> {
+    public static class MapProcessor<I, O> extends MultiOperatorProcessor<I, O> {
         private final Function<? super I, ? extends O> mapper;
 
-        MapProcessor(MultiSubscriber<? super O> actual, Function<? super I, ? extends O> mapper) {
+        public MapProcessor(MultiSubscriber<? super O> actual, Function<? super I, ? extends O> mapper) {
             super(actual);
             this.mapper = mapper;
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipUntilPublisherOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipUntilPublisherOp.java
@@ -72,8 +72,8 @@ public final class MultiSkipUntilPublisherOp<T, U> extends AbstractMultiOperator
 
     static final class SkipUntilMainProcessor<T> extends MultiOperatorProcessor<T, T> {
 
-        private AtomicReference<Subscription> other = new AtomicReference<>();
-        private AtomicBoolean gate = new AtomicBoolean(false);
+        private final AtomicReference<Subscription> other = new AtomicReference<>();
+        private final AtomicBoolean gate = new AtomicBoolean(false);
 
         SkipUntilMainProcessor(Subscriber<? super T> downstream) {
             super(new SerializedSubscriber<>(downstream));

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/Subscribers.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/Subscribers.java
@@ -12,58 +12,14 @@ import io.smallrye.mutiny.helpers.Subscriptions;
 
 public class Subscribers {
 
-    public static <T> CancellableSubscriber<T> cancelled() {
-        return new CancellationSubscriber<>();
-    }
-
     @SuppressWarnings("ThrowableNotThrown")
-    private static final Consumer<? super Throwable> NO_ON_FAILURE = failure -> new Exception(
-            "Missing onError method in the subscriber", failure).printStackTrace(); // NOSONAR
-
-    public static <T> CancellableSubscriber<T> from(Consumer<? super T> onItem) {
-        return new CallbackBasedSubscriber<>(onItem, NO_ON_FAILURE, null, null);
-    }
-
-    public static <T> CancellableSubscriber<T> from(Consumer<? super T> onItem, Consumer<? super Throwable> onFailure) {
-        return new CallbackBasedSubscriber<>(onItem, onFailure, null, null);
-    }
-
-    public static <T> CancellableSubscriber<T> from(Consumer<? super T> onItem, Consumer<? super Throwable> onFailure,
-            Runnable onCompletion) {
-        return new CallbackBasedSubscriber<>(onItem, onFailure, onCompletion, null);
-    }
+    public static final Consumer<? super Throwable> NO_ON_FAILURE = failure -> new Exception(
+            "Missing onFailure/onError handler in the subscriber", failure).printStackTrace(); // NOSONAR
 
     public static <T> CancellableSubscriber<T> from(Consumer<? super T> onItem, Consumer<? super Throwable> onFailure,
             Runnable onCompletion,
             Consumer<? super Subscription> onSubscription) {
         return new CallbackBasedSubscriber<>(onItem, onFailure, onCompletion, onSubscription);
-    }
-
-    private static class CancellationSubscriber<T> implements CancellableSubscriber<T> {
-        @Override
-        public void onSubscribe(Subscription s) {
-            s.cancel();
-        }
-
-        @Override
-        public void onItem(T t) {
-            // Ignored
-        }
-
-        @Override
-        public void onFailure(Throwable t) {
-            // Ignored
-        }
-
-        @Override
-        public void onCompletion() {
-            // Ignored
-        }
-
-        @Override
-        public void cancel() {
-            // already cancelled, so ignoring.
-        }
     }
 
     public static class CallbackBasedSubscriber<T> implements CancellableSubscriber<T>, Subscription {

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/queues/DrainUtilsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/queues/DrainUtilsTest.java
@@ -1,0 +1,143 @@
+package io.smallrye.mutiny.helpers.queues;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
+
+import org.reactivestreams.Subscription;
+import org.testng.annotations.Test;
+
+import io.reactivex.internal.util.QueueDrainHelper;
+import io.smallrye.mutiny.test.AssertSubscriber;
+
+public class DrainUtilsTest {
+
+    @Test
+    public void testPostCompleteWithNoItems() {
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
+        ArrayDeque<Integer> queue = new ArrayDeque<>();
+        AtomicLong state = new AtomicLong();
+        Subscription subscription = mock(Subscription.class);
+        subscriber.onSubscribe(subscription);
+
+        DrainUtils.postComplete(subscriber, queue, state, () -> false);
+
+        subscriber.assertHasNotReceivedAnyItem()
+                .assertCompletedSuccessfully();
+
+    }
+
+    @Test
+    public void testPostCompleteWithRequest() {
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
+        ArrayDeque<Integer> queue = new ArrayDeque<>();
+        AtomicLong state = new AtomicLong();
+        Subscription subscription = mock(Subscription.class);
+        subscriber.onSubscribe(subscription);
+        queue.offer(1);
+        state.getAndIncrement();
+        DrainUtils.postComplete(subscriber, queue, state, () -> false);
+        subscriber
+                .assertCompletedSuccessfully()
+                .assertReceived(1);
+    }
+
+    @Test(invocationCount = 100)
+    public void testCompleteVsRequestRace() throws InterruptedException {
+        BooleanSupplier isCancelled = () -> false;
+        Subscription subscription = mock(Subscription.class);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
+        ArrayDeque<Integer> queue = new ArrayDeque<>();
+        AtomicLong requested = new AtomicLong();
+        subscriber.onSubscribe(subscription);
+
+        queue.offer(1);
+
+        CountDownLatch start = new CountDownLatch(2);
+        CountDownLatch done = new CountDownLatch(2);
+        Runnable r1 = () -> {
+            start.countDown();
+            try {
+                start.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            DrainUtils.postCompleteRequest(1L, subscriber, queue, requested, isCancelled);
+            done.countDown();
+        };
+
+        Runnable r2 = () -> {
+            start.countDown();
+            try {
+                start.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            DrainUtils.postComplete(subscriber, queue, requested, isCancelled);
+            done.countDown();
+        };
+
+        List<Runnable> runnables = Arrays.asList(r1, r2);
+        Collections.shuffle(runnables);
+
+        runnables.forEach(r -> new Thread(r).start());
+
+        done.await();
+        subscriber.assertReceived(1);
+    }
+
+    @Test
+    public void testPostCompleteAfterCancellation() {
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(1);
+        ArrayDeque<Integer> queue = new ArrayDeque<>();
+        AtomicLong state = new AtomicLong();
+        Subscription subscription = mock(Subscription.class);
+        subscriber.onSubscribe(subscription);
+        queue.offer(1);
+        state.getAndIncrement();
+        subscriber.cancel();
+
+        QueueDrainHelper.postComplete(subscriber, queue, state, subscriber::isCancelled);
+        subscriber
+                .assertSubscribed()
+                .assertHasNotReceivedAnyItem()
+                .assertNotTerminated();
+    }
+
+    @Test
+    public void testPostCompleteCancelledAfterReceptionOfTheFirstItem() {
+        final AssertSubscriber<Integer> subscriber = new AssertSubscriber<Integer>(10) {
+            @Override
+            public void onNext(Integer item) {
+                // Cancel just after the item reception.
+                super.onNext(item);
+                cancel();
+            }
+        };
+        ArrayDeque<Integer> queue = new ArrayDeque<>();
+        AtomicLong state = new AtomicLong();
+        Subscription subscription = mock(Subscription.class);
+        subscriber.onSubscribe(subscription);
+        queue.offer(1);
+        state.getAndIncrement();
+
+        DrainUtils.postComplete(subscriber, queue, state, subscriber::isCancelled);
+        subscriber
+                .assertNotTerminated()
+                .assertReceived(1)
+                .assertHasNotFailed();
+    }
+
+    @Test
+    public void testPostCompleteAlreadyComplete() {
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(1);
+        Queue<Integer> q = new ArrayDeque<>();
+        q.offer(1);
+        AtomicLong state = new AtomicLong(DrainUtils.COMPLETED_MASK);
+        DrainUtils.postComplete(subscriber, q, state, () -> false);
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiFilterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiFilterTest.java
@@ -1,14 +1,23 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
+import org.reactivestreams.Subscriber;
 import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.multi.MultiFilterOp;
+import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
+import io.smallrye.mutiny.test.AssertSubscriber;
+import io.smallrye.mutiny.test.Mocks;
 
 public class MultiFilterTest {
 
@@ -22,6 +31,13 @@ public class MultiFilterTest {
     public void testThatFunctionCannotBeNull() {
         Multi.createFrom().range(1, 4)
                 .transform().byTestingItemsWith(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testThatSubscriberCannotBeNull() {
+        Multi<Integer> multi = Multi.createFrom().range(1, 4);
+        MultiFilterOp<Integer> filter = new MultiFilterOp<>(multi, x -> x % 2 == 0);
+        filter.subscribe(null);
     }
 
     @Test
@@ -50,5 +66,91 @@ public class MultiFilterTest {
                 .filter(test)
                 .collectItems().asList()
                 .await().indefinitely()).containsExactly(1, 3);
+    }
+
+    @Test
+    public void testNoEmissionAfterCompletion() {
+        BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
+        MultiFilterOp<Integer> filter = new MultiFilterOp<>(processor, x -> x % 2 == 0);
+        Subscriber<Integer> subscriber = Mocks.subscriber();
+        filter.subscribe(subscriber);
+
+        processor.onNext(1);
+        processor.onNext(2);
+        processor.onNext(3);
+        processor.onNext(4);
+        processor.onComplete();
+        processor.onNext(5);
+        processor.onNext(6);
+
+        verify(subscriber).onNext(2);
+        verify(subscriber).onNext(4);
+        verify(subscriber, never()).onNext(6);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testNoEmissionAfterFailure() {
+        BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
+        MultiFilterOp<Integer> filter = new MultiFilterOp<>(processor, x -> x % 2 == 0);
+        Subscriber<Integer> subscriber = Mocks.subscriber();
+        filter.subscribe(subscriber);
+
+        processor.onNext(1);
+        processor.onNext(2);
+        processor.onNext(3);
+        processor.onNext(4);
+        processor.onError(new IOException("boom"));
+        processor.onNext(5);
+        processor.onNext(6);
+
+        verify(subscriber).onNext(2);
+        verify(subscriber).onNext(4);
+        verify(subscriber, never()).onNext(6);
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(any(IOException.class));
+
+    }
+
+    @Test
+    public void testNoEmissionAfterCancellation() {
+        BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
+        AssertSubscriber<Integer> subscriber = processor.transform().byFilteringItemsWith(x -> x % 2 == 0)
+                .subscribe().withSubscriber(AssertSubscriber.create(20));
+
+        processor.onNext(1);
+        processor.onNext(2);
+        processor.onNext(3);
+        processor.onNext(4);
+        subscriber.cancel();
+        processor.onNext(5);
+        processor.onNext(6);
+        processor.onComplete();
+        subscriber.assertReceived(2, 4)
+                .assertNotTerminated();
+    }
+
+    @Test
+    public void testWithPredicateThrowingException() {
+        BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
+        AssertSubscriber<Integer> subscriber = processor.transform().byFilteringItemsWith(x -> {
+            if (x == 3) {
+                throw new IllegalArgumentException("boom");
+            }
+            return x % 2 == 0;
+        })
+                .subscribe().withSubscriber(AssertSubscriber.create(20));
+
+        processor.onNext(1);
+        processor.onNext(2);
+        processor.onNext(3);
+        processor.onNext(4);
+        processor.onNext(5);
+        processor.onNext(6);
+        processor.onComplete();
+        subscriber.assertReceived(2)
+                .assertHasFailedWith(IllegalArgumentException.class, "boom");
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnItemTransformTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnItemTransformTest.java
@@ -1,0 +1,125 @@
+package io.smallrye.mutiny.operators;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.operators.multi.MultiMapOp;
+import io.smallrye.mutiny.subscription.MultiEmitter;
+import io.smallrye.mutiny.test.AssertSubscriber;
+
+public class MultiOnItemTransformTest {
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMapperCannotBeNull() {
+        new MultiMapOp<>(Multi.createFrom().item(1), null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testUpstreamCannotBeNull() {
+        new MultiMapOp<>(null, x -> x);
+    }
+
+    @Test
+    public void testMapperMustNotReturnNull() {
+        Multi.createFrom().items(1, 2, 3)
+                .onItem().transform(i -> {
+                    if (i == 2) {
+                        return null;
+                    }
+                    return i + 1;
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(3))
+                .assertHasFailedWith(NullPointerException.class, "")
+                .assertReceived(2);
+    }
+
+    @Test
+    public void testOnUpstreamFailure() {
+        Multi<Integer> upstream1 = Multi.createFrom().items(1, 2);
+        Multi<Integer> upstream2 = Multi.createFrom().failure(new IOException("boom"));
+
+        Multi.createBy().concatenating().streams(upstream1, upstream2)
+                .onItem().transform(i -> i + 1)
+                .subscribe().withSubscriber(AssertSubscriber.create(3))
+                .assertHasFailedWith(IOException.class, "boom")
+                .assertReceived(2, 3);
+    }
+
+    @Test
+    public void testNormal() {
+        Multi.createFrom().items(1, 2, 3)
+                .onItem().transform(i -> i + 1)
+                .subscribe().withSubscriber(AssertSubscriber.create(3))
+                .assertCompletedSuccessfully()
+                .assertReceived(2, 3, 4);
+    }
+
+    @Test
+    public void testNormalBackPressure() {
+        Multi.createFrom().items(1, 2, 3)
+                .onItem().transform(i -> i + 1)
+                .subscribe().withSubscriber(AssertSubscriber.create())
+                .assertNotTerminated()
+                .assertSubscribed()
+                .request(2)
+                .assertReceived(2, 3)
+                .assertNotTerminated()
+                .request(2)
+                .assertReceived(2, 3, 4)
+                .assertCompletedSuccessfully();
+    }
+
+    @Test
+    public void testMapperThrowingException() {
+        Multi.createFrom().items(1, 2, 3)
+                .onItem().transform(i -> {
+                    if (i == 2) {
+                        throw new ArithmeticException("boom");
+                    }
+                    return i + 1;
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(3))
+                .assertHasFailedWith(ArithmeticException.class, "boom")
+                .assertReceived(2);
+    }
+
+    @Test
+    public void testMapperNotCalledAfterCancellation() {
+        AtomicReference<MultiEmitter<? super Integer>> emitter = new AtomicReference<>();
+        Multi.createFrom().<Integer> emitter(emitter::set)
+                .onItem().transform(i -> i + 1)
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .assertNotTerminated()
+                .assertSubscribed()
+                .assertHasNotReceivedAnyItem()
+                .run(() -> emitter.get().emit(1).emit(2))
+                .assertNotTerminated()
+                .assertReceived(2)
+                .cancel()
+                .assertNotTerminated()
+                .assertReceived(2)
+                .run(() -> emitter.get().emit(3).complete())
+                .assertNotTerminated()
+                .assertReceived(2);
+
+        Multi.createFrom().<Integer> emitter(emitter::set)
+                .onItem().transform(i -> i + 1)
+                .subscribe().withSubscriber(AssertSubscriber.create(2))
+                .assertNotTerminated()
+                .assertSubscribed()
+                .assertHasNotReceivedAnyItem()
+                .run(() -> emitter.get().emit(1).emit(2))
+                .assertNotTerminated()
+                .assertReceived(2, 3)
+                .cancel()
+                .assertNotTerminated()
+                .assertReceived(2, 3)
+                .run(() -> emitter.get().emit(3).fail(new IOException("boom")))
+                .assertNotTerminated()
+                .assertReceived(2, 3);
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToMultiTest.java
@@ -2,7 +2,6 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -114,7 +113,8 @@ public class MultiTransformToMultiTest {
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
         Multi.createFrom().range(1, 100_001)
-                .onItem().transformToMulti(i -> Multi.createFrom().completionStage(CompletableFuture.supplyAsync(() -> i)))
+                .onItem()
+                .transformToMulti(i -> Multi.createFrom().completionStage(CompletableFuture.supplyAsync(() -> i)))
                 .collectFailures().concatenate()
                 .subscribe(subscriber);
 
@@ -431,7 +431,8 @@ public class MultiTransformToMultiTest {
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
         Multi.createFrom().range(1, 10001)
-                .onItem().transformToMulti(i -> Multi.createFrom().completionStage(CompletableFuture.supplyAsync(() -> i)))
+                .onItem()
+                .transformToMulti(i -> Multi.createFrom().completionStage(CompletableFuture.supplyAsync(() -> i)))
                 .withRequests(20)
                 .merge(25)
                 .subscribe(subscriber);
@@ -473,7 +474,8 @@ public class MultiTransformToMultiTest {
     @Test
     public void testProduceCompletionStageAlternative() {
         List<Integer> list = Multi.createFrom().range(1, 4)
-                .onItem().transformToUni(i -> Uni.createFrom().completionStage(CompletableFuture.supplyAsync(() -> i + 1)))
+                .onItem()
+                .transformToUni(i -> Uni.createFrom().completionStage(CompletableFuture.supplyAsync(() -> i + 1)))
                 .merge()
                 .collectItems().asList().await().indefinitely();
 
@@ -864,7 +866,6 @@ public class MultiTransformToMultiTest {
         AssertSubscriber<Integer> subscriber = Multi.createFrom().range(1, 1001)
                 .flatMap(i -> Multi.createFrom().item(i).runSubscriptionOn(Infrastructure.getDefaultExecutor()))
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
-
         subscriber.await()
                 .assertCompletedSuccessfully();
         assertThat(subscriber.items()).hasSize(1000);
@@ -1095,7 +1096,6 @@ public class MultiTransformToMultiTest {
             BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
             AssertSubscriber<Integer> subscriber = processor.flatMap(k -> Multi.createFrom().item(k))
                     .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
-
             CountDownLatch start = new CountDownLatch(1);
             CountDownLatch done = new CountDownLatch(2);
             Runnable r1 = () -> {
@@ -1154,6 +1154,7 @@ public class MultiTransformToMultiTest {
     public void testNoDeliveryAfterFailure() {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
         Subscriber<Integer> subscriber = Mocks.subscriber();
+
         processor.onItem().transformToMulti(i -> Multi.createFrom().item(i + 1)).merge()
                 .subscribe().withSubscriber(subscriber);
 
@@ -1167,4 +1168,5 @@ public class MultiTransformToMultiTest {
         verify(subscriber, never()).onComplete();
         verify(subscriber, never()).onNext(3);
     }
+
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureTransformTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureTransformTest.java
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
 
-public class UniOnFailureMapToTest {
+public class UniOnFailureTransformTest {
 
     private Uni<Integer> failure;
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/FlatMapMainSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/FlatMapMainSubscriberTest.java
@@ -1,0 +1,198 @@
+package io.smallrye.mutiny.operators.multi;
+
+import static io.smallrye.mutiny.helpers.MultiSubscribers.toMultiSubscriber;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.testng.annotations.Test;
+
+import io.reactivex.processors.PublishProcessor;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.queues.Queues;
+import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.subscription.BackPressureFailure;
+import io.smallrye.mutiny.test.AssertSubscriber;
+import io.smallrye.mutiny.test.Mocks;
+
+public class FlatMapMainSubscriberTest {
+
+    @Test
+    public void testThatInvalidRequestAreRejectedByMainSubscriber() {
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
+
+        MultiFlatMapOp.FlatMapMainSubscriber<Integer, Integer> sub = new MultiFlatMapOp.FlatMapMainSubscriber<>(
+                toMultiSubscriber(subscriber),
+                i -> Multi.createFrom().item(2),
+                false,
+                4,
+                Queues.get(4),
+                10);
+
+        Multi.createFrom().item(1)
+                .subscribe().withSubscriber(sub);
+
+        sub.request(-1);
+        subscriber.assertHasFailedWith(IllegalArgumentException.class, "");
+    }
+
+    @Test
+    public void testCancellationFromMainSubscriber() {
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
+
+        MultiFlatMapOp.FlatMapMainSubscriber<Integer, Integer> sub = new MultiFlatMapOp.FlatMapMainSubscriber<>(
+                toMultiSubscriber(subscriber),
+                i -> Multi.createFrom().item(2),
+                false,
+                4,
+                Queues.get(4),
+                10);
+
+        Multi.createFrom().item(1)
+                .subscribe().withSubscriber(sub);
+
+        sub.cancel();
+        subscriber.assertNotTerminated();
+        sub.cancel();
+        sub.onItem(1);
+        subscriber.assertHasNotReceivedAnyItem();
+    }
+
+    @Test
+    public void testThatNoItemsAreDispatchedAfterCompletion() {
+        Subscriber<Integer> subscriber = Mocks.subscriber();
+
+        MultiFlatMapOp.FlatMapMainSubscriber<Integer, Integer> sub = new MultiFlatMapOp.FlatMapMainSubscriber<>(
+                toMultiSubscriber(subscriber),
+                i -> Multi.createFrom().item(2),
+                false,
+                4,
+                Queues.get(4),
+                10);
+
+        sub.onSubscribe(mock(Subscription.class));
+        sub.onNext(1);
+        sub.onComplete();
+
+        sub.onNext(2);
+        sub.onComplete();
+
+        verify(subscriber).onNext(2);
+        verify(subscriber).onComplete();
+        verify(subscriber, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testThatNoItemsAreDispatchedAfterFailure() {
+        Subscriber<Integer> subscriber = Mocks.subscriber();
+
+        MultiFlatMapOp.FlatMapMainSubscriber<Integer, Integer> sub = new MultiFlatMapOp.FlatMapMainSubscriber<>(
+                toMultiSubscriber(subscriber),
+                i -> Multi.createFrom().item(2),
+                false,
+                4,
+                Queues.get(4),
+                10);
+
+        sub.onSubscribe(mock(Subscription.class));
+        sub.onNext(1);
+        sub.onError(new Exception("boom"));
+
+        sub.onNext(2);
+        sub.onComplete();
+        sub.onError(new Exception("boom"));
+
+        verify(subscriber).onNext(2);
+        verify(subscriber, never()).onComplete();
+        verify(subscriber).onError(any(Throwable.class));
+    }
+
+    AbstractMulti<Integer> rogue = new AbstractMulti<Integer>() {
+        @Override
+        public void subscribe(Subscriber<? super Integer> subscriber) {
+            subscriber.onSubscribe(mock(Subscription.class));
+            subscriber.onNext(1);
+            subscriber.onNext(2);
+        }
+    };
+
+    @Test
+    public void testInnerOverflow() {
+        Multi.createFrom().item(1)
+                .onItem().transformToMulti(v -> rogue)
+                .merge(1)
+                .subscribe().withSubscriber(AssertSubscriber.create(0))
+                .assertHasFailedWith(BackPressureFailure.class, "");
+    }
+
+    @Test
+    public void testInnerOverflow2() {
+        Subscriber<Integer> subscriber = Mocks.subscriber(0);
+
+        MultiFlatMapOp.FlatMapMainSubscriber<Integer, Integer> sub = new MultiFlatMapOp.FlatMapMainSubscriber<>(
+                toMultiSubscriber(subscriber),
+                i -> rogue,
+                false,
+                1,
+                Queues.get(1),
+                1);
+
+        sub.onSubscribe(mock(Subscription.class));
+        sub.onNext(1);
+        sub.done = true;
+        sub.drain();
+
+        verify(subscriber).onError(any(BackPressureFailure.class));
+
+    }
+
+    @Test
+    public void testInnerOverflowWithWip() {
+        Subscriber<Integer> subscriber = Mocks.subscriber(0);
+
+        MultiFlatMapOp.FlatMapMainSubscriber<Integer, Integer> sub = new MultiFlatMapOp.FlatMapMainSubscriber<>(
+                toMultiSubscriber(subscriber),
+                i -> rogue,
+                false,
+                1,
+                Queues.get(1),
+                1);
+
+        sub.onSubscribe(mock(Subscription.class));
+
+        sub.wip.getAndIncrement();
+
+        sub.onNext(1);
+        assertThat(sub.failures.get()).isInstanceOf(BackPressureFailure.class);
+
+        sub.wip.set(0);
+        sub.done = true;
+        sub.drain();
+
+        verify(subscriber).onError(any(BackPressureFailure.class));
+
+    }
+
+    @Test
+    public void testWhenInnerCompletesAfterOnNextInDrainThenCancels() {
+        PublishProcessor<Integer> pp = PublishProcessor.create();
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
+
+        Multi.createFrom().item(1)
+                .onItem().transformToMulti(v -> pp).merge()
+                .onItem().invoke(v -> {
+                    if (v == 1) {
+                        pp.onComplete();
+                        subscriber.cancel();
+                    }
+                })
+                .subscribe().withSubscriber(subscriber);
+
+        pp.onNext(1);
+
+        subscriber.request(1)
+                .assertReceived(1);
+    }
+}

--- a/implementation/src/test/java/tck/MultiOnItemTransformTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnItemTransformTckTest.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 
-public class MultiMapTckTest extends AbstractPublisherTck<Integer> {
+public class MultiOnItemTransformTckTest extends AbstractPublisherTck<Integer> {
 
     @Test
     public void mapStageShouldMapElements() {


### PR DESCRIPTION
Several Multi operators where missing tests.
This PR adds some and remove unused code.

- Rename UniOnFailureMApToTest to UniOnFailureTransformTest
- Remove unused constructor
- Verify the behavior of the Distinct Operator
- Improve Multi Skip Until operator and add more tests
- Verify the filter operator upon cancellation and failures/exceptions
- Add more test to Multi flatmap (transformToMulti)
- Add missing @return in MultiOnEvent javadoc
- Remove unused method in MultiBufferWithTimeoutOp
- Add test for the MutlOnItemTransform operator
- Add tests for Queues and make sure all Queue implementations throw UnsupportedOperationExceptions for unsupported operations
- Verify the behavior of the methods from DrainUtils
- Verify failure collection when merging multis
- Removed unused code in MultiOverflow, MultiSubscribe, and Subscribers
- Rename the UniRunSubscriptionOn operator

