### PR TITLE
Make Tuple's toString homegeneous

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple2.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Tuple2.java
@@ -118,6 +118,6 @@ public class Tuple2<L, R> implements Tuple {
 
     @Override
     public String toString() {
-        return "Tuple2{left=" + item1 + ", right=" + item2 + '}';
+        return "Tuple{item1=" + item1 + ", item2=" + item2 + '}';
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple2Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple2Test.java
@@ -8,11 +8,10 @@ import java.util.Collections;
 
 import org.testng.annotations.Test;
 
+@SuppressWarnings("EqualsWithItself")
 public class Tuple2Test {
 
-    // TODO Test tuples
-
-    private Tuple2<Integer, Integer> somePair = Tuple2.of(1, 3);
+    private final Tuple2<Integer, Integer> somePair = Tuple2.of(1, 3);
 
     @Test
     public void testThatNullIsAcceptedAsItem1() {
@@ -124,6 +123,7 @@ public class Tuple2Test {
     @Test
     public void testEquality() {
         assertThat(somePair).isEqualTo(somePair);
+        assertThat(somePair.equals(somePair)).isTrue();
         assertThat(somePair).isNotEqualTo(Tuple2.of(1, 1));
         assertThat(somePair).isNotEqualTo("not a pair");
         assertThat(somePair).isEqualTo(Tuple2.of(1, 3));
@@ -141,6 +141,11 @@ public class Tuple2Test {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> Tuples.tuple2(Arrays.asList(1, 2, 3)));
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> Tuples.tuple2(null));
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(somePair.toString()).contains("item1=1", "item2=3");
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple3Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple3Test.java
@@ -8,9 +8,10 @@ import java.util.Collections;
 
 import org.testng.annotations.Test;
 
+@SuppressWarnings("EqualsWithItself")
 public class Tuple3Test {
 
-    private Tuple3<Integer, Integer, Integer> someTuple = new Tuple3<>(1, 2, 3);
+    private final Tuple3<Integer, Integer, Integer> someTuple = new Tuple3<>(1, 2, 3);
 
     @Test
     public void assertNullValues() {
@@ -51,6 +52,7 @@ public class Tuple3Test {
     @Test
     public void testEquality() {
         assertThat(someTuple).isEqualTo(someTuple);
+        assertThat(someTuple.equals(someTuple)).isTrue();
         assertThat(someTuple).isNotEqualTo(Tuple3.of(1, 2, 4));
         assertThat(someTuple).isNotEqualTo("not a tuple");
         assertThat(someTuple).isEqualTo(Tuple3.of(1, 2, 3));
@@ -78,5 +80,12 @@ public class Tuple3Test {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> Tuples.tuple3(Arrays.asList(1, 2, 3, 4)));
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> Tuples.tuple3(null));
+    }
+
+    @Test
+    public void testToString() {
+        for (int i = 1; i <= someTuple.size(); i++) {
+            assertThat(someTuple.toString()).contains("item" + i + "=" + someTuple.nth(i - 1));
+        }
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple4Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple4Test.java
@@ -83,4 +83,11 @@ public class Tuple4Test {
                 .isThrownBy(() -> Tuples.tuple4(Arrays.asList(1, 2, 3, 4, 5)));
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> Tuples.tuple4(null));
     }
+
+    @Test
+    public void testToString() {
+        for (int i = 1; i <= someTuple.size(); i++) {
+            assertThat(someTuple.toString()).contains("item" + i + "=" + someTuple.nth(i - 1));
+        }
+    }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple5Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple5Test.java
@@ -88,4 +88,11 @@ public class Tuple5Test {
                 .isThrownBy(() -> Tuples.tuple5(Arrays.asList(1, 2, 3, 4, 5, 6)));
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> Tuples.tuple5(null));
     }
+
+    @Test
+    public void testToString() {
+        for (int i = 1; i <= someTuple.size(); i++) {
+            assertThat(someTuple.toString()).contains("item" + i + "=" + someTuple.nth(i - 1));
+        }
+    }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple6Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple6Test.java
@@ -91,4 +91,11 @@ public class Tuple6Test {
                 .isThrownBy(() -> Tuples.tuple6(Arrays.asList(1, 2, 3, 4, 5, 6, 7)));
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> Tuples.tuple6(null));
     }
+
+    @Test
+    public void testToString() {
+        for (int i = 1; i <= someTuple.size(); i++) {
+            assertThat(someTuple.toString()).contains("item" + i + "=" + someTuple.nth(i - 1));
+        }
+    }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple7Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple7Test.java
@@ -98,4 +98,11 @@ public class Tuple7Test {
                 .isThrownBy(() -> Tuples.tuple7(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8)));
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> Tuples.tuple7(null));
     }
+
+    @Test
+    public void testToString() {
+        for (int i = 1; i <= someTuple.size(); i++) {
+            assertThat(someTuple.toString()).contains("item" + i + "=" + someTuple.nth(i - 1));
+        }
+    }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple8Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple8Test.java
@@ -105,4 +105,11 @@ public class Tuple8Test {
                 .isThrownBy(() -> Tuples.tuple8(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9)));
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> Tuples.tuple8(null));
     }
+
+    @Test
+    public void testToString() {
+        for (int i = 1; i <= someTuple.size(); i++) {
+            assertThat(someTuple.toString()).contains("item" + i + "=" + someTuple.nth(i - 1));
+        }
+    }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple9Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple9Test.java
@@ -110,4 +110,11 @@ public class Tuple9Test {
                 .isThrownBy(() -> Tuples.tuple9(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> Tuples.tuple9(null));
     }
+
+    @Test
+    public void testToString() {
+        for (int i = 1; i <= someTuple.size(); i++) {
+            assertThat(someTuple.toString()).contains("item" + i + "=" + someTuple.nth(i - 1));
+        }
+    }
 }


### PR DESCRIPTION
Make sure that Tuple's implementation follow the same toString pattern, and test it.﻿
