### PR TITLE
Parametric type signatures fixes

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -374,7 +374,7 @@ public interface Multi<T> extends Publisher<T> {
      *        {@code null}
      * @return the new {@link Multi}
      */
-    default Multi<T> invokeUni(Function<? super T, ? extends Uni<?>> action) {
+    default Multi<T> invokeUni(Function<? super T, Uni<?>> action) {
         return onItem().invokeUni(nonNull(action, "action"));
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -431,7 +431,7 @@ public interface Uni<T> {
      *        {@code null}
      * @return the new {@link Uni}
      */
-    default Uni<T> invokeUni(Function<? super T, ? extends Uni<?>> action) {
+    default Uni<T> invokeUni(Function<? super T, Uni<?>> action) {
         return onItem().invokeUni(nonNull(action, "action"));
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
@@ -399,7 +399,7 @@ public class MultiCreate {
      * @param <T> the type of item
      * @return the produced {@link Multi}
      */
-    public <T> Multi<T> deferred(Supplier<? extends Multi<? extends T>> supplier) {
+    public <T> Multi<T> deferred(Supplier<Multi<? extends T>> supplier) {
         return Infrastructure.onMultiCreation(new DeferredMulti<>(nonNull(supplier, "supplier")));
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnFailure.java
@@ -92,7 +92,7 @@ public class MultiOnFailure<T> {
      * @param action the function taking the failure and returning a {@link Uni}, must not be {@code null}
      * @return the new {@link Multi}
      */
-    public Multi<T> invokeUni(Function<Throwable, ? extends Uni<?>> action) {
+    public Multi<T> invokeUni(Function<Throwable, Uni<?>> action) {
         ParameterValidation.nonNull(action, "action");
         return recoverWithMulti(failure -> {
             Uni<?> uni = action.apply(failure);

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnFailure.java
@@ -210,7 +210,7 @@ public class MultiOnFailure<T> {
      * @return the new {@link Multi} that would emit events from the multi produced by the given function in case the
      *         upstream sends a failure.
      */
-    public Multi<T> recoverWithMulti(Function<? super Throwable, ? extends Multi<? extends T>> function) {
+    public Multi<T> recoverWithMulti(Function<? super Throwable, Multi<? extends T>> function) {
         return Infrastructure.onMultiCreation(new MultiFlatMapOnFailure<>(upstream, predicate,
                 nonNull(function, "function")));
     }
@@ -228,7 +228,7 @@ public class MultiOnFailure<T> {
      * @return the new {@link Multi} that would emit events from the multi produced by the given supplier in case the
      *         upstream sends a failure.
      */
-    public Multi<T> recoverWithMulti(Supplier<? extends Multi<? extends T>> supplier) {
+    public Multi<T> recoverWithMulti(Supplier<Multi<? extends T>> supplier) {
         return recoverWithMulti(ignored -> supplier.get());
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItem.java
@@ -91,7 +91,7 @@ public class MultiOnItem<T> {
      * @param action the function taking the item and returning a {@link Uni}, must not be {@code null}
      * @return the new {@link Multi}
      */
-    public Multi<T> invokeUni(Function<? super T, ? extends Uni<?>> action) {
+    public Multi<T> invokeUni(Function<? super T, Uni<?>> action) {
         ParameterValidation.nonNull(action, "action");
         return transformToUni(i -> {
             Uni<?> uni = action.apply(i);
@@ -285,7 +285,7 @@ public class MultiOnItem<T> {
      * @param <O> the type of item emitted by the {@link Multi} produced by the mapper.
      * @return the object to configure the flatten behavior.
      */
-    public <O> MultiFlatten<T, O> transformToUni(Function<? super T, ? extends Uni<? extends O>> mapper) {
+    public <O> MultiFlatten<T, O> transformToUni(Function<? super T, Uni<? extends O>> mapper) {
         nonNull(mapper, "mapper");
         Function<? super T, ? extends Publisher<? extends O>> wrapper = res -> mapper.apply(res).toMulti();
         return new MultiFlatten<>(upstream, wrapper, 1, false);
@@ -313,7 +313,7 @@ public class MultiOnItem<T> {
      * @param <O> the type of item emitted by the {@link Multi} produced by the mapper.
      * @return the resulting multi
      */
-    public <O> Multi<O> transformToUniAndConcatenate(Function<? super T, ? extends Uni<? extends O>> mapper) {
+    public <O> Multi<O> transformToUniAndConcatenate(Function<? super T, Uni<? extends O>> mapper) {
         return transformToUni(mapper).concatenate();
     }
 
@@ -339,7 +339,7 @@ public class MultiOnItem<T> {
      * @param <O> the type of item emitted by the {@link Multi} produced by the mapper.
      * @return the resulting multi
      */
-    public <O> Multi<O> transformToUniAndMerge(Function<? super T, ? extends Uni<? extends O>> mapper) {
+    public <O> Multi<O> transformToUniAndMerge(Function<? super T, Uni<? extends O>> mapper) {
         return transformToUni(mapper).merge();
     }
 
@@ -354,7 +354,7 @@ public class MultiOnItem<T> {
      * @deprecated Use {@link #transformToUni(Function)} instead
      */
     @Deprecated
-    public <O> MultiFlatten<T, O> produceUni(Function<? super T, ? extends Uni<? extends O>> mapper) {
+    public <O> MultiFlatten<T, O> produceUni(Function<? super T, Uni<? extends O>> mapper) {
         nonNull(mapper, "mapper");
         Function<? super T, ? extends Publisher<? extends O>> wrapper = res -> mapper.apply(res).toMulti();
         return new MultiFlatten<>(upstream, wrapper, 1, false);

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiRepetition.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiRepetition.java
@@ -22,7 +22,7 @@ public class MultiRepetition {
      * @param <T> the type of emitted item
      * @return the object to configure the repetition
      */
-    public <S, T> UniRepeat<T> uni(Supplier<S> stateSupplier, Function<S, ? extends Uni<? extends T>> producer) {
+    public <S, T> UniRepeat<T> uni(Supplier<S> stateSupplier, Function<S, Uni<? extends T>> producer) {
         Uni<T> upstream = Uni.createFrom().deferred(stateSupplier, producer);
         return new UniRepeat<>(upstream);
     }
@@ -34,7 +34,7 @@ public class MultiRepetition {
      * @param <T> the type of emitted item
      * @return the object to configure the repetition
      */
-    public <T> UniRepeat<T> uni(Supplier<? extends Uni<? extends T>> uniSupplier) {
+    public <T> UniRepeat<T> uni(Supplier<Uni<? extends T>> uniSupplier) {
         Uni<T> upstream = Uni.createFrom().deferred(uniSupplier);
         return new UniRepeat<>(upstream);
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiTransform.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiTransform.java
@@ -105,7 +105,7 @@ public class MultiTransform<T> {
      * @param tester the predicate, must not be {@code null}, must not produce {@code null}
      * @return the produced {@link Multi}
      */
-    public Multi<T> byTestingItemsWith(Function<? super T, ? extends Uni<Boolean>> tester) {
+    public Multi<T> byTestingItemsWith(Function<? super T, Uni<Boolean>> tester) {
         nonNull(tester, "tester");
         return upstream.onItem().transformToMultiAndConcatenate(res -> {
             Uni<Boolean> uni = tester.apply(res);

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniCreate.java
@@ -419,8 +419,8 @@ public class UniCreate {
      * @param <T> the type of item
      * @return the produced {@link Uni}
      */
-    public <T> Uni<T> deferred(Supplier<? extends Uni<? extends T>> supplier) {
-        Supplier<? extends Uni<? extends T>> actual = ParameterValidation.nonNull(supplier, "supplier");
+    public <T> Uni<T> deferred(Supplier<Uni<? extends T>> supplier) {
+        Supplier<Uni<? extends T>> actual = ParameterValidation.nonNull(supplier, "supplier");
         return Infrastructure.onUniCreation(new UniCreateFromDeferredSupplier<>(actual));
     }
 
@@ -451,7 +451,7 @@ public class UniCreate {
      * @param <S> the type of the state
      * @return the produced {@link Uni}
      */
-    public <T, S> Uni<T> deferred(Supplier<S> stateSupplier, Function<S, ? extends Uni<? extends T>> mapper) {
+    public <T, S> Uni<T> deferred(Supplier<S> stateSupplier, Function<S, Uni<? extends T>> mapper) {
         ParameterValidation.nonNull(stateSupplier, "stateSupplier");
         ParameterValidation.nonNull(mapper, "mapper");
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
@@ -76,7 +76,7 @@ public class UniOnFailure<T> {
      * @param action the callback, must not be {@code null}
      * @return the new {@link Uni}
      */
-    public Uni<T> invokeUni(Function<Throwable, ? extends Uni<?>> action) {
+    public Uni<T> invokeUni(Function<Throwable, Uni<?>> action) {
         ParameterValidation.nonNull(action, "action");
         return recoverWithUni(failure -> {
             Uni<?> uni = Objects.requireNonNull(action.apply(failure), "The `action` produced a `null` uni");
@@ -166,7 +166,7 @@ public class UniOnFailure<T> {
      * @return the new {@link Uni} that would emit events from the uni produced by the given function in case the
      *         upstream sends a failure.
      */
-    public Uni<T> recoverWithUni(Function<? super Throwable, ? extends Uni<? extends T>> function) {
+    public Uni<T> recoverWithUni(Function<? super Throwable, Uni<? extends T>> function) {
         return Infrastructure.onUniCreation(
                 new UniOnFailureFlatMap<>(upstream, predicate, nonNull(function, "function")));
     }
@@ -183,7 +183,7 @@ public class UniOnFailure<T> {
      * @return the new {@link Uni} that would emits events from the uni produced by the given supplier in case the
      *         upstream sends a failure.
      */
-    public Uni<T> recoverWithUni(Supplier<? extends Uni<? extends T>> supplier) {
+    public Uni<T> recoverWithUni(Supplier<Uni<? extends T>> supplier) {
         return recoverWithUni(ignored -> supplier.get());
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItem.java
@@ -55,7 +55,7 @@ public class UniOnItem<T> {
      *        {@code null}
      * @return the new {@link Uni}
      */
-    public Uni<T> invokeUni(Function<? super T, ? extends Uni<?>> action) {
+    public Uni<T> invokeUni(Function<? super T, Uni<?>> action) {
         ParameterValidation.nonNull(action, "action");
         return transformToUni(item -> {
             Uni<?> uni = Objects.requireNonNull(action.apply(item), "The callback produced a `null` uni");
@@ -112,7 +112,7 @@ public class UniOnItem<T> {
      * @return a new {@link Uni} that would fire events from the uni produced by the mapper function, possibly
      *         in an asynchronous manner.
      */
-    public <R> Uni<R> transformToUni(Function<? super T, ? extends Uni<? extends R>> mapper) {
+    public <R> Uni<R> transformToUni(Function<? super T, Uni<? extends R>> mapper) {
         return Infrastructure.onUniCreation(new UniOnItemTransformToUni<>(upstream, mapper));
     }
 
@@ -134,7 +134,7 @@ public class UniOnItem<T> {
      * @deprecated Use {@link #transformToUni(Function)} instead
      */
     @Deprecated
-    public <R> Uni<R> produceUni(Function<? super T, ? extends Uni<? extends R>> mapper) {
+    public <R> Uni<R> produceUni(Function<? super T, Uni<? extends R>> mapper) {
         return transformToUni(mapper);
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItemDelay.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItemDelay.java
@@ -65,7 +65,7 @@ public class UniOnItemDelay<T> {
      * @param function the function, must not be {@code null}
      * @return the produced {@link Uni}.
      */
-    public Uni<T> until(Function<? super T, ? extends Uni<?>> function) {
+    public Uni<T> until(Function<? super T, Uni<?>> function) {
         return Infrastructure.onUniCreation(new UniDelayUntil<>(upstream, function, executor));
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItemOrFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnItemOrFailure.java
@@ -44,7 +44,7 @@ public class UniOnItemOrFailure<T> {
      * @param callback the callback, must not be {@code null}
      * @return the new {@link Uni}
      */
-    public Uni<T> invokeUni(BiFunction<? super T, Throwable, ? extends Uni<?>> callback) {
+    public Uni<T> invokeUni(BiFunction<? super T, Throwable, Uni<?>> callback) {
         ParameterValidation.nonNull(callback, "callback");
         return transformToUni((res, fail) -> {
             Uni<?> uni = callback.apply(res, fail);
@@ -123,7 +123,7 @@ public class UniOnItemOrFailure<T> {
      * @return a new {@link Uni} that would fire events from the uni produced by the mapper function, possibly
      *         in an asynchronous manner.
      */
-    public <R> Uni<R> transformToUni(BiFunction<? super T, Throwable, ? extends Uni<? extends R>> mapper) {
+    public <R> Uni<R> transformToUni(BiFunction<? super T, Throwable, Uni<? extends R>> mapper) {
         return Infrastructure.onUniCreation(new UniOnItemOrFailureFlatMap<>(upstream, mapper));
     }
 
@@ -148,7 +148,7 @@ public class UniOnItemOrFailure<T> {
      * @deprecated Use {@link #transformToUni(BiFunction)} instead
      */
     @Deprecated
-    public <R> Uni<R> produceUni(BiFunction<? super T, Throwable, ? extends Uni<? extends R>> mapper) {
+    public <R> Uni<R> produceUni(BiFunction<? super T, Throwable, Uni<? extends R>> mapper) {
         return transformToUni(mapper);
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNotNull.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNotNull.java
@@ -47,7 +47,7 @@ public class UniOnNotNull<T> {
      * @param action the callback, must not be {@code null}
      * @return the new {@link Uni}
      */
-    public Uni<T> invokeUni(Function<? super T, ? extends Uni<?>> action) {
+    public Uni<T> invokeUni(Function<? super T, Uni<?>> action) {
         return upstream.onItem().invokeUni(item -> {
             if (item != null) {
                 return action.apply(item);
@@ -119,7 +119,7 @@ public class UniOnNotNull<T> {
      * @deprecated Use {@link #transformToUni(Function)} instead
      */
     @Deprecated
-    public <R> Uni<R> produceUni(Function<? super T, ? extends Uni<? extends R>> mapper) {
+    public <R> Uni<R> produceUni(Function<? super T, Uni<? extends R>> mapper) {
         return transformToUni(mapper);
     }
 
@@ -141,7 +141,7 @@ public class UniOnNotNull<T> {
      * @return a new {@link Uni} that would fire events from the uni produced by the mapper function, possibly
      *         in an asynchronous manner.
      */
-    public <R> Uni<R> transformToUni(Function<? super T, ? extends Uni<? extends R>> mapper) {
+    public <R> Uni<R> transformToUni(Function<? super T, Uni<? extends R>> mapper) {
         return upstream.onItem().transformToUni(item -> {
             if (item != null) {
                 return mapper.apply(item);

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnTimeout.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnTimeout.java
@@ -92,7 +92,7 @@ public class UniOnTimeout<T> {
      * @param supplier the fallback supplier, must not be {@code null}, must not produce {@code null}
      * @return the new {@link Uni}
      */
-    public Uni<T> recoverWithUni(Supplier<? extends Uni<? extends T>> supplier) {
+    public Uni<T> recoverWithUni(Supplier<Uni<? extends T>> supplier) {
         return fail().onFailure(TimeoutException.class).recoverWithUni(supplier);
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/MultiFlatMapOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/MultiFlatMapOnFailure.java
@@ -15,10 +15,10 @@ import io.smallrye.mutiny.operators.multi.MultiOnFailureResumeOp;
 
 public class MultiFlatMapOnFailure<T> extends MultiOperator<T, T> {
     private final Predicate<? super Throwable> predicate;
-    private final Function<? super Throwable, ? extends Multi<? extends T>> mapper;
+    private final Function<? super Throwable, Multi<? extends T>> mapper;
 
     public MultiFlatMapOnFailure(Multi<T> upstream, Predicate<? super Throwable> predicate,
-            Function<? super Throwable, ? extends Multi<? extends T>> mapper) {
+            Function<? super Throwable, Multi<? extends T>> mapper) {
         super(nonNull(upstream, "upstream"));
         this.predicate = predicate == null ? x -> true : predicate;
         this.mapper = nonNull(mapper, "mapper");

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplier.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplier.java
@@ -9,9 +9,9 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 
 public class UniCreateFromDeferredSupplier<T> extends UniOperator<Void, T> {
-    private final Supplier<? extends Uni<? extends T>> supplier;
+    private final Supplier<Uni<? extends T>> supplier;
 
-    public UniCreateFromDeferredSupplier(Supplier<? extends Uni<? extends T>> supplier) {
+    public UniCreateFromDeferredSupplier(Supplier<Uni<? extends T>> supplier) {
         super(null);
         this.supplier = supplier; // Already checked
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniDelayUntil.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniDelayUntil.java
@@ -11,10 +11,10 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniSubscription;
 
 public class UniDelayUntil<T> extends UniOperator<T, T> {
-    private final Function<? super T, ? extends Uni<?>> function;
+    private final Function<? super T, Uni<?>> function;
     private final ScheduledExecutorService executor;
 
-    public UniDelayUntil(Uni<T> upstream, Function<? super T, ? extends Uni<?>> function,
+    public UniDelayUntil(Uni<T> upstream, Function<? super T, Uni<?>> function,
             ScheduledExecutorService executor) {
         super(nonNull(upstream, "upstream"));
         this.function = nonNull(function, "function");

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnFailureFlatMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnFailureFlatMap.java
@@ -11,12 +11,12 @@ import io.smallrye.mutiny.subscription.UniSubscription;
 
 public class UniOnFailureFlatMap<I> extends UniOperator<I, I> {
 
-    private final Function<? super Throwable, ? extends Uni<? extends I>> mapper;
+    private final Function<? super Throwable, Uni<? extends I>> mapper;
     private final Predicate<? super Throwable> predicate;
 
     public UniOnFailureFlatMap(Uni<I> upstream,
             Predicate<? super Throwable> predicate,
-            Function<? super Throwable, ? extends Uni<? extends I>> mapper) {
+            Function<? super Throwable, Uni<? extends I>> mapper) {
         super(nonNull(upstream, "upstream"));
         this.mapper = nonNull(mapper, "mapper");
         this.predicate = nonNull(predicate, "predicate");

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureFlatMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemOrFailureFlatMap.java
@@ -11,15 +11,15 @@ import io.smallrye.mutiny.subscription.UniSubscription;
 
 public class UniOnItemOrFailureFlatMap<I, O> extends UniOperator<I, O> {
 
-    private final BiFunction<? super I, Throwable, ? extends Uni<? extends O>> mapper;
+    private final BiFunction<? super I, Throwable, Uni<? extends O>> mapper;
 
     public UniOnItemOrFailureFlatMap(Uni<I> upstream,
-            BiFunction<? super I, Throwable, ? extends Uni<? extends O>> mapper) {
+            BiFunction<? super I, Throwable, Uni<? extends O>> mapper) {
         super(nonNull(upstream, "upstream"));
         this.mapper = nonNull(mapper, "mapper");
     }
 
-    public static <I, O> void invokeAndSubstitute(BiFunction<? super I, Throwable, ? extends Uni<? extends O>> mapper,
+    public static <I, O> void invokeAndSubstitute(BiFunction<? super I, Throwable, Uni<? extends O>> mapper,
             I item,
             Throwable failure,
             UniSerializedSubscriber<? super O> subscriber,

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemTransformToUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemTransformToUni.java
@@ -16,14 +16,14 @@ import io.smallrye.mutiny.subscription.UniSubscription;
 
 public class UniOnItemTransformToUni<I, O> extends UniOperator<I, O> {
 
-    private final Function<? super I, ? extends Uni<? extends O>> mapper;
+    private final Function<? super I, Uni<? extends O>> mapper;
 
-    public UniOnItemTransformToUni(Uni<I> upstream, Function<? super I, ? extends Uni<? extends O>> mapper) {
+    public UniOnItemTransformToUni(Uni<I> upstream, Function<? super I, Uni<? extends O>> mapper) {
         super(nonNull(upstream, "upstream"));
         this.mapper = nonNull(mapper, "mapper");
     }
 
-    public static <I, O> void invokeAndSubstitute(Function<? super I, ? extends Uni<? extends O>> mapper, I input,
+    public static <I, O> void invokeAndSubstitute(Function<? super I, Uni<? extends O>> mapper, I input,
             UniSerializedSubscriber<? super O> subscriber,
             FlatMapSubscription flatMapSubscription) {
         Uni<? extends O> outcome;


### PR DESCRIPTION
Removes `<? extends Uni>` and `<? extends Multi>` in the API

This does not cover collections and iterables for which this remains useful.

Fixes #265