### PR TITLE
Remove non executed code and continue drop exception integration

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroupIterable.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroupIterable.java
@@ -26,7 +26,7 @@ public class UniAndGroupIterable<T1> {
         this(source, iterable, false);
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public UniAndGroupIterable(Uni<? extends T1> source, Iterable<? extends Uni<?>> iterable, boolean collectFailures) {
         this.source = source;
         List<? extends Uni<?>> others;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAny.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAny.java
@@ -28,7 +28,7 @@ public class UniAny {
     @SafeVarargs
     public final <T> Uni<T> of(Uni<? super T>... unis) {
         List<Uni<? super T>> list = Arrays.asList(nonNull(unis, "unis"));
-        return Infrastructure.onUniCreation(new UniOrCombination<>(list));
+        return of(list);
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
@@ -13,7 +13,7 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.UniOnFailureFlatMap;
-import io.smallrye.mutiny.operators.UniOnFailureMap;
+import io.smallrye.mutiny.operators.UniOnFailureTransform;
 import io.smallrye.mutiny.operators.UniOnItemConsume;
 
 /**
@@ -108,7 +108,7 @@ public class UniOnFailure<T> {
      * @return the new {@link Uni}
      */
     public Uni<T> transform(Function<? super Throwable, ? extends Throwable> mapper) {
-        return Infrastructure.onUniCreation(new UniOnFailureMap<>(upstream, predicate, mapper));
+        return Infrastructure.onUniCreation(new UniOnFailureTransform<>(upstream, predicate, mapper));
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniZip.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniZip.java
@@ -16,7 +16,10 @@ import io.smallrye.mutiny.tuples.*;
  */
 public class UniZip {
 
-    public static final UniZip INSTANCE = new UniZip();
+    /**
+     * Singleton instance.
+     */
+    static final UniZip INSTANCE = new UniZip();
 
     private UniZip() {
         // avoid direct instantiation

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/EmptyUniSubscription.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/EmptyUniSubscription.java
@@ -19,13 +19,17 @@ public class EmptyUniSubscription implements UniSubscription {
         // Avoid direct instantiation.
     }
 
+    /**
+     * Propagates a failure to the given downstream subscriber.
+     * The subscriber receive the {@code CANCELLED} subscription followed with the failure.
+     *
+     * @param subscriber the subscriber, must not be {@code null}
+     * @param failure the failure, must not be {@code null}
+     * @param <T> the expected item type
+     */
     public static <T> void propagateFailureEvent(UniSubscriber<T> subscriber, Throwable failure) {
         subscriber.onSubscribe(CANCELLED);
-        if (failure == null) {
-            subscriber.onFailure(new NullPointerException());
-        } else {
-            subscriber.onFailure(failure);
-        }
+        subscriber.onFailure(failure);
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnFailureTransform.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnFailureTransform.java
@@ -8,14 +8,13 @@ import java.util.function.Predicate;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 
-public class UniOnFailureMap<I, O> extends UniOperator<I, O> {
+public class UniOnFailureTransform<I, O> extends UniOperator<I, O> {
 
     private final Function<? super Throwable, ? extends Throwable> mapper;
     private final Predicate<? super Throwable> predicate;
 
-    public UniOnFailureMap(Uni<I> upstream,
+    public UniOnFailureTransform(Uni<I> upstream,
             Predicate<? super Throwable> predicate,
             Function<? super Throwable, ? extends Throwable> mapper) {
         super(nonNull(upstream, "upstream"));
@@ -29,12 +28,6 @@ public class UniOnFailureMap<I, O> extends UniOperator<I, O> {
 
             @Override
             public void onFailure(Throwable failure) {
-                if (subscriber.isCancelledOrDone()) {
-                    // Avoid calling the mapper if we are done to save some cycles.
-                    // If the cancellation happen during the call, the events won't be dispatched.
-                    Infrastructure.handleDroppedException(failure);
-                    return;
-                }
                 boolean test;
                 try {
                     test = predicate.test(failure);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemTransform.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniOnItemTransform.java
@@ -20,12 +20,6 @@ public class UniOnItemTransform<I, O> extends UniOperator<I, O> {
 
             @Override
             public void onItem(I item) {
-                if (subscriber.isCancelledOrDone()) {
-                    // Avoid calling the mapper if we are done to save some cycles.
-                    // If the cancellation happen during the call, the events won't be dispatched.
-                    return;
-                }
-
                 O outcome;
                 try {
                     outcome = mapper.apply(item);

--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Functions.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Functions.java
@@ -1,26 +1,11 @@
 package io.smallrye.mutiny.tuples;
 
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 public final class Functions {
 
     private Functions() {
-    }
-
-    private static final Consumer NOOP_CONSUMER = x -> {
-    };
-    private static final Runnable NOOP = () -> {
-    };
-
-    @SuppressWarnings("unchecked")
-    public static <T> Consumer<T> noopConsumer() {
-        return NOOP_CONSUMER;
-    }
-
-    public static Runnable noopAction() {
-        return NOOP;
     }
 
     @FunctionalInterface

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/UniInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/UniInterceptorTest.java
@@ -142,7 +142,7 @@ public class UniInterceptorTest {
     @Test
     public void testDefaultOrdinal() {
         UniInterceptor itcp = new UniInterceptor() {
-          // do nothing
+            // do nothing
         };
 
         assertThat(itcp.ordinal()).isEqualTo(UniInterceptor.DEFAULT_ORDINAL);

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/UniInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/UniInterceptorTest.java
@@ -56,7 +56,7 @@ public class UniInterceptorTest {
     public void testCreationInterception() {
         Infrastructure.registerUniInterceptor(new UniInterceptor() {
 
-            long creationTime = System.nanoTime();
+            final long creationTime = System.nanoTime();
 
             @Override
             public <T> Uni<T> onUniCreation(Uni<T> uni) {
@@ -83,7 +83,7 @@ public class UniInterceptorTest {
     public void testCreationInterceptionWithMap() {
         Infrastructure.registerUniInterceptor(new UniInterceptor() {
 
-            long creationTime = System.nanoTime();
+            final long creationTime = System.nanoTime();
 
             @Override
             public <T> Uni<T> onUniCreation(Uni<T> uni) {
@@ -137,5 +137,23 @@ public class UniInterceptorTest {
 
         int result = Uni.createFrom().item(23).map(i -> i * 2).await().indefinitely();
         assertThat(result).isEqualTo(23 * 2 + 1 + 1 + 1); // 3 subscribers: item, map and the subscriber
+    }
+
+    @Test
+    public void testDefaultOrdinal() {
+        UniInterceptor itcp = new UniInterceptor() {
+          // do nothing
+        };
+
+        assertThat(itcp.ordinal()).isEqualTo(UniInterceptor.DEFAULT_ORDINAL);
+
+        itcp = new UniInterceptor() {
+            @Override
+            public int ordinal() {
+                return 25;
+            }
+        };
+
+        assertThat(itcp.ordinal()).isEqualTo(25);
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAndTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAndTest.java
@@ -4,6 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.testng.annotations.Test;
 
@@ -20,7 +24,8 @@ public class UniAndTest {
         Uni<Integer> uni = Uni.createFrom().item(1);
         Uni<Integer> uni2 = Uni.createFrom().item(2);
 
-        UniAssertSubscriber<Tuple2<Integer, Integer>> subscriber = Uni.combine().all().unis(uni, uni2).asTuple().subscribe()
+        UniAssertSubscriber<Tuple2<Integer, Integer>> subscriber = Uni.combine().all().unis(uni, uni2).asTuple()
+                .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
         assertThat(subscriber.getItem().asList()).containsExactly(1, 2);
@@ -113,7 +118,8 @@ public class UniAndTest {
         Uni<Integer> uni5 = Uni.createFrom().item(5);
         Uni<Integer> uni6 = Uni.createFrom().item(6);
 
-        UniAssertSubscriber<Tuple6<Integer, Integer, Integer, Integer, Integer, Integer>> subscriber = Uni.combine().all()
+        UniAssertSubscriber<Tuple6<Integer, Integer, Integer, Integer, Integer, Integer>> subscriber = Uni.combine()
+                .all()
                 .unis(uni1, uni2, uni3, uni4, uni5, uni6).asTuple().subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -156,7 +162,8 @@ public class UniAndTest {
         Uni<Integer> uni6 = Uni.createFrom().item(6);
         Uni<Integer> uni7 = Uni.createFrom().item(7);
 
-        UniAssertSubscriber<Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer>> subscriber = Uni.combine()
+        UniAssertSubscriber<Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer>> subscriber = Uni
+                .combine()
                 .all()
                 .unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7).asTuple().subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
@@ -201,6 +208,57 @@ public class UniAndTest {
                 .withSubscriber(UniAssertSubscriber.create());
 
         assertThat(subscriber.getItem().asList()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9);
+    }
+
+    @Test
+    public void testWithListOfUnis() {
+        Uni<Integer> uni1 = Uni.createFrom().item(1);
+        Uni<Integer> uni2 = Uni.createFrom().item(2);
+        Uni<Integer> uni3 = Uni.createFrom().item(3);
+        Uni<Integer> uni4 = Uni.createFrom().item(4);
+        Uni<Integer> uni5 = Uni.createFrom().item(5);
+        Uni<Integer> uni6 = Uni.createFrom().item(6);
+        Uni<Integer> uni7 = Uni.createFrom().item(7);
+        Uni<Integer> uni8 = Uni.createFrom().item(8);
+        Uni<Integer> uni9 = Uni.createFrom().item(9);
+
+        List<Uni<Integer>> list = Arrays.asList(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9);
+
+        UniAssertSubscriber<Integer> subscriber = Uni
+                .combine().all().unis(list)
+                .combinedWith(items -> items.stream().mapToInt(i -> (Integer) i).sum())
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+
+        subscriber
+                .assertCompletedSuccessfully()
+                .assertItem(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9);
+    }
+
+    @Test
+    public void testWithSetOfUnis() {
+        Uni<Integer> uni1 = Uni.createFrom().item(1);
+        Uni<Integer> uni2 = Uni.createFrom().item(2);
+        Uni<Integer> uni3 = Uni.createFrom().item(3);
+        Uni<Integer> uni4 = Uni.createFrom().item(4);
+        Uni<Integer> uni5 = Uni.createFrom().item(5);
+        Uni<Integer> uni6 = Uni.createFrom().item(6);
+        Uni<Integer> uni7 = Uni.createFrom().item(7);
+        Uni<Integer> uni8 = Uni.createFrom().item(8);
+        Uni<Integer> uni9 = Uni.createFrom().item(9);
+
+        List<Uni<Integer>> list = Arrays.asList(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9);
+        Set<Uni<Integer>> set = new HashSet<>(list);
+
+        UniAssertSubscriber<Integer> subscriber = Uni
+                .combine().all().unis(set)
+                .combinedWith(items -> items.stream().mapToInt(i -> (Integer) i).sum())
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+
+        subscriber
+                .assertCompletedSuccessfully()
+                .assertItem(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9);
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
@@ -4,10 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.testng.annotations.Test;
 
@@ -138,7 +140,8 @@ public class UniZipTest {
         Uni<Integer> uni6 = Uni.createFrom().item(6);
         Uni<Integer> uni7 = Uni.createFrom().item(7);
 
-        UniAssertSubscriber<Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer>> subscriber = Uni.combine()
+        UniAssertSubscriber<Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer>> subscriber = Uni
+                .combine()
                 .all()
                 .unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7).asTuple()
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
@@ -221,10 +224,11 @@ public class UniZipTest {
 
         Uni<Integer> failed = Uni.createFrom().failure(new IOException("boom"));
 
-        assertThatThrownBy(() -> Uni.combine().all().unis(uni1, uni2, uni3, failed, uni4).discardItems().await().indefinitely())
-                .isInstanceOf(CompletionException.class)
-                .hasCauseInstanceOf(IOException.class)
-                .hasMessageContaining("boom");
+        assertThatThrownBy(
+                () -> Uni.combine().all().unis(uni1, uni2, uni3, failed, uni4).discardItems().await().indefinitely())
+                        .isInstanceOf(CompletionException.class)
+                        .hasCauseInstanceOf(IOException.class)
+                        .hasMessageContaining("boom");
 
         Uni<Integer> failed2 = Uni.createFrom().failure(new IllegalStateException("d'oh"));
 
@@ -233,6 +237,181 @@ public class UniZipTest {
                         .await().indefinitely())
                                 .isInstanceOf(CompositeException.class)
                                 .hasMessageContaining("boom").hasMessageContaining("d'oh");
+    }
+
+    @Test
+    public void testWithArraysAndImmediateItems() {
+        // We need 10 unis to avoid being handled as tuples
+        Uni<Integer> uni1 = Uni.createFrom().item(1);
+        Uni<Integer> uni2 = Uni.createFrom().item(2);
+        Uni<Integer> uni3 = Uni.createFrom().item(3);
+        Uni<Integer> uni4 = Uni.createFrom().item(4);
+        Uni<Integer> uni5 = Uni.createFrom().item(5);
+        Uni<Integer> uni6 = Uni.createFrom().item(6);
+        Uni<Integer> uni7 = Uni.createFrom().item(7);
+        Uni<Integer> uni8 = Uni.createFrom().item(8);
+        Uni<Integer> uni9 = Uni.createFrom().item(9);
+        Uni<Integer> uni10 = Uni.createFrom().item(10);
+
+        int sum = Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9, uni10)
+                .combinedWith(l -> l.stream().mapToInt(o -> (Integer) o).sum())
+                .await().indefinitely();
+
+        assertThat(sum).isEqualTo(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10);
+
+    }
+
+    @Test
+    public void testWithArraysAndOneFailure() {
+        // We need 10 unis to avoid being handled as tuples
+        Uni<Integer> uni1 = Uni.createFrom().item(1);
+        Uni<Integer> uni2 = Uni.createFrom().item(2);
+        Uni<Integer> uni3 = Uni.createFrom().item(3);
+        Uni<Integer> uni4 = Uni.createFrom().item(4);
+        Uni<Integer> uni5 = Uni.createFrom().item(5);
+        Uni<Integer> uni6 = Uni.createFrom().failure(new ArithmeticException("boom"));
+        Uni<Integer> uni7 = Uni.createFrom().item(7);
+        Uni<Integer> uni8 = Uni.createFrom().item(8);
+        Uni<Integer> uni9 = Uni.createFrom().item(9);
+        Uni<Integer> uni10 = Uni.createFrom().item(10);
+
+        assertThatThrownBy(() -> Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9, uni10)
+                .combinedWith(l -> l.stream().mapToInt(o -> (Integer) o).sum())
+                .await().indefinitely()).isInstanceOf(ArithmeticException.class).hasMessageContaining("boom");
+
+    }
+
+    @Test
+    public void testWithArraysAndMultipleFailures() {
+        // We need 10 unis to avoid being handled as tuples
+        Uni<Integer> uni1 = Uni.createFrom().item(1);
+        Uni<Integer> uni2 = Uni.createFrom().item(2);
+        Uni<Integer> uni3 = Uni.createFrom().item(3);
+        Uni<Integer> uni4 = Uni.createFrom().failure(new UncheckedIOException(new IOException("io")));
+        Uni<Integer> uni5 = Uni.createFrom().item(5);
+        Uni<Integer> uni6 = Uni.createFrom().failure(new ArithmeticException("boom"));
+        Uni<Integer> uni7 = Uni.createFrom().item(7);
+        Uni<Integer> uni8 = Uni.createFrom().item(8);
+        Uni<Integer> uni9 = Uni.createFrom().item(9);
+        Uni<Integer> uni10 = Uni.createFrom().failure(new IllegalStateException("state"));
+
+        assertThatThrownBy(() -> Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9, uni10)
+                .combinedWith(l -> l.stream().mapToInt(o -> (Integer) o).sum())
+                .await().indefinitely()).isInstanceOf(UncheckedIOException.class).hasMessageContaining("io");
+
+    }
+
+    @Test
+    public void testWithArraysAndMultipleFailuresAndFailureCollection() {
+        // We need 10 unis to avoid being handled as tuples
+        Uni<Integer> uni1 = Uni.createFrom().item(1);
+        Uni<Integer> uni2 = Uni.createFrom().item(2);
+        Uni<Integer> uni3 = Uni.createFrom().item(3);
+        Uni<Integer> uni4 = Uni.createFrom().failure(new UncheckedIOException(new IOException("io")));
+        Uni<Integer> uni5 = Uni.createFrom().item(5);
+        Uni<Integer> uni6 = Uni.createFrom().failure(new ArithmeticException("boom"));
+        Uni<Integer> uni7 = Uni.createFrom().item(7);
+        Uni<Integer> uni8 = Uni.createFrom().item(8);
+        Uni<Integer> uni9 = Uni.createFrom().item(9);
+        Uni<Integer> uni10 = Uni.createFrom().failure(new IllegalStateException("state"));
+
+        assertThatThrownBy(() -> Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9, uni10)
+                .collectFailures()
+                .combinedWith(l -> l.stream().mapToInt(o -> (Integer) o).sum())
+                .await().indefinitely()).isInstanceOfSatisfying(CompositeException.class, t -> {
+                    assertThat(t.getCauses()).hasSize(3);
+                    assertThat(t.getSuppressed()).hasSize(2);
+                    assertThat(t.getCause()).isInstanceOf(UncheckedIOException.class);
+                    assertThat(t.getSuppressed()[0]).isInstanceOf(ArithmeticException.class);
+                    assertThat(t.getSuppressed()[1]).isInstanceOf(IllegalStateException.class);
+                });
+
+    }
+
+    @Test
+    public void testWithArraysWithOnlyFailuresAndFailureCollection() {
+        // We need 10 unis to avoid being handled as tuples
+        Uni<Integer> uni1 = Uni.createFrom().failure(new IOException("1"));
+        Uni<Integer> uni2 = Uni.createFrom().failure(new IOException("2"));
+        Uni<Integer> uni3 = Uni.createFrom().failure(new IOException("3"));
+        Uni<Integer> uni4 = Uni.createFrom().failure(new IOException("4"));
+        Uni<Integer> uni5 = Uni.createFrom().failure(new IOException("5"));
+        Uni<Integer> uni6 = Uni.createFrom().failure(new IOException("6"));
+        Uni<Integer> uni7 = Uni.createFrom().failure(new IOException("7"));
+        Uni<Integer> uni8 = Uni.createFrom().failure(new IOException("8"));
+        Uni<Integer> uni9 = Uni.createFrom().failure(new IOException("9"));
+        Uni<Integer> uni10 = Uni.createFrom().failure(new IOException("10"));
+
+        assertThatThrownBy(() -> Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9, uni10)
+                .collectFailures()
+                .combinedWith(l -> l.stream().mapToInt(o -> (Integer) o).sum())
+                .await().indefinitely()).isInstanceOfSatisfying(CompositeException.class, t -> {
+                    assertThat(t.getCauses()).hasSize(10);
+                    assertThat(t.getSuppressed()).hasSize(9);
+                });
+
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void testWithArraysWithNoResultAndCancellation() {
+        int count = 10;
+        AtomicBoolean[] subscriptions = new AtomicBoolean[count];
+        AtomicBoolean[] cancellations = new AtomicBoolean[count];
+        for (int i = 0; i < count; i++) {
+            subscriptions[i] = new AtomicBoolean();
+            cancellations[i] = new AtomicBoolean();
+        }
+
+        // We need 10 unis to avoid being handled as tuples
+        Uni<Integer> uni1 = Uni.createFrom().item(1)
+                .onSubscribe().invoke(s -> subscriptions[0].set(true))
+                .onCancellation().invoke(() -> cancellations[0].set(true));
+        Uni<Integer> uni2 = Uni.createFrom().item(2)
+                .onSubscribe().invoke(s -> subscriptions[1].set(true))
+                .onCancellation().invoke(() -> cancellations[1].set(true));
+        Uni<Integer> uni3 = Uni.createFrom().item(3)
+                .onSubscribe().invoke(s -> subscriptions[2].set(true))
+                .onCancellation().invoke(() -> cancellations[2].set(true));
+        Uni<Integer> uni4 = Uni.createFrom().item(4)
+                .onSubscribe().invoke(s -> subscriptions[3].set(true))
+                .onCancellation().invoke(() -> cancellations[3].set(true));
+        Uni<Integer> uni5 = Uni.createFrom().item(5)
+                .onSubscribe().invoke(s -> subscriptions[4].set(true))
+                .onCancellation().invoke(() -> cancellations[4].set(true));
+        Uni<Integer> uni6 = Uni.createFrom().item(6)
+                .onSubscribe().invoke(s -> subscriptions[5].set(true))
+                .onCancellation().invoke(() -> cancellations[5].set(true));
+        Uni<Integer> uni7 = Uni.createFrom().<Integer> emitter(e -> {
+            // Do not emit
+        })
+                .onSubscribe().invoke(s -> subscriptions[6].set(true))
+                .onCancellation().invoke(() -> cancellations[6].set(true));
+        Uni<Integer> uni8 = Uni.createFrom().item(() -> 8)
+                .onSubscribe().invoke(s -> subscriptions[7].set(true))
+                .onCancellation().invoke(() -> cancellations[7].set(true));
+        Uni<Integer> uni9 = Uni.createFrom().item(() -> 9)
+                .onSubscribe().invoke(s -> subscriptions[8].set(true))
+                .onCancellation().invoke(() -> cancellations[8].set(true));
+        Uni<Integer> uni10 = Uni.createFrom().item(() -> 10)
+                .onSubscribe().invoke(s -> subscriptions[9].set(true))
+                .onCancellation().invoke(() -> cancellations[9].set(true));
+
+        Uni<Integer> all = Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9, uni10)
+                .combinedWith(l -> l.stream().mapToInt(o -> (Integer) o).sum());
+
+        assertThat(subscriptions).allSatisfy(bool -> assertThat(bool).isFalse());
+        assertThat(cancellations).allSatisfy(bool -> assertThat(bool).isFalse());
+        UniAssertSubscriber<Integer> subscriber = all.subscribe().withSubscriber(new UniAssertSubscriber<>());
+
+        subscriber.assertSubscribed()
+                .assertNotCompleted()
+                .assertNoFailure();
+
+        assertThat(subscriptions).allSatisfy(bool -> assertThat(bool).isTrue());
+        assertThat(cancellations).allSatisfy(bool -> assertThat(bool).isFalse());
+        subscriber.cancel();
+        assertThat(subscriptions).allSatisfy(bool -> assertThat(bool).isTrue());
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/CallbackBasedSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/CallbackBasedSubscriberTest.java
@@ -1,0 +1,135 @@
+package io.smallrye.mutiny.subscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Subscription;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.CompositeException;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+@SuppressWarnings("ConstantConditions")
+public class CallbackBasedSubscriberTest {
+
+    @AfterMethod
+    public void cleanup() {
+        Infrastructure.resetDroppedExceptionHandler();
+    }
+
+    @Test
+    public void testOnSubscriberThrowingException() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        AtomicBoolean completed = new AtomicBoolean();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<Throwable> captured = new AtomicReference<>();
+        Infrastructure.setDroppedExceptionHandler(captured::set);
+        Multi.createFrom().item(1)
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .subscribe().with(
+                        sub -> {
+                            throw new IllegalArgumentException("boom");
+                        },
+                        i -> {
+                        },
+                        failure::set,
+                        () -> completed.set(true));
+
+        assertThat(completed).isFalse();
+        assertThat(failure.get()).isNull();
+        assertThat(cancelled).isTrue();
+        assertThat(captured.get()).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("boom");
+    }
+
+    @Test
+    public void testOnItemThrowingException() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        AtomicBoolean completed = new AtomicBoolean();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<Throwable> captured = new AtomicReference<>();
+        Infrastructure.setDroppedExceptionHandler(captured::set);
+        Multi.createFrom().item(1)
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .subscribe().with(
+                        i -> {
+                            throw new IllegalArgumentException("boom");
+                        },
+                        failure::set,
+                        () -> completed.set(true));
+
+        assertThat(completed).isFalse();
+        assertThat(failure.get()).isNull();
+        assertThat(cancelled).isTrue();
+        assertThat(captured.get()).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("boom");
+    }
+
+    @Test
+    public void testOnFailureThrowingException() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        AtomicBoolean completed = new AtomicBoolean();
+        AtomicReference<Throwable> captured = new AtomicReference<>();
+        Infrastructure.setDroppedExceptionHandler(captured::set);
+        Multi.createFrom().failure(new IOException("I/O"))
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .subscribe().with(
+                        i -> {
+                        },
+                        f -> {
+                            throw new IllegalArgumentException("boom");
+                        },
+                        () -> completed.set(true));
+
+        assertThat(completed).isFalse();
+        assertThat(cancelled).isFalse();
+        assertThat(captured.get()).isInstanceOf(CompositeException.class)
+                .hasMessageContaining("boom").hasMessageContaining("I/O");
+    }
+
+    @Test
+    public void testOnFailureAfterCancellation() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        AtomicBoolean completed = new AtomicBoolean();
+        AtomicReference<Throwable> captured = new AtomicReference<>();
+        Infrastructure.setDroppedExceptionHandler(captured::set);
+        Multi.createFrom().failure(new IOException("I/O"))
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .subscribe().with(
+                        Subscription::cancel,
+                        i -> {
+                        },
+                        f -> {
+                            throw new IllegalArgumentException("boom");
+                        },
+                        () -> completed.set(true));
+
+        assertThat(completed).isFalse();
+        assertThat(cancelled).isTrue();
+        assertThat(captured.get()).isInstanceOf(IOException.class)
+                .hasMessageContaining("I/O");
+    }
+
+    @Test
+    public void testDroppedFailureWithoutFailureCallback() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        AtomicBoolean completed = new AtomicBoolean();
+        AtomicReference<Throwable> captured = new AtomicReference<>();
+        Infrastructure.setDroppedExceptionHandler(captured::set);
+        Multi.createFrom().failure(new IOException("I/O"))
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .subscribe().withSubscriber(new Subscribers.CallbackBasedSubscriber<>(i -> {
+                },
+                        null, null, s -> {
+                        }));
+
+        assertThat(completed).isFalse();
+        assertThat(cancelled).isFalse();
+        assertThat(captured.get()).isInstanceOf(IOException.class)
+                .hasMessageContaining("I/O");
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/SerializedSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/SerializedSubscriberTest.java
@@ -1,0 +1,796 @@
+package io.smallrye.mutiny.subscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.testng.TestException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.test.AssertSubscriber;
+import io.smallrye.mutiny.test.Mocks;
+
+public class SerializedSubscriberTest {
+
+    Subscriber<Integer> subscriber;
+
+    @BeforeMethod
+    public void before() {
+        subscriber = Mocks.subscriber(Long.MAX_VALUE);
+    }
+
+    @AfterMethod
+    public void clean() {
+        Infrastructure.resetDroppedExceptionHandler();
+    }
+
+    private <T> Subscriber<T> serialized(Subscriber<T> subscriber) {
+        return new SerializedSubscriber<>(subscriber);
+    }
+
+    @Test
+    public void testNormalSingleThreadedEmission() {
+        SingleThreadedPublisher publisher = new SingleThreadedPublisher(1, 2, 3);
+        Subscriber<Integer> serialized = serialized(subscriber);
+
+        publisher.subscribe(serialized);
+        publisher.await();
+
+        verify(subscriber, times(1)).onNext(1);
+        verify(subscriber, times(1)).onNext(2);
+        verify(subscriber, times(1)).onNext(3);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber, times(1)).onComplete();
+    }
+
+    @Test
+    public void testNormalMultiThreadedEmission() {
+        MultiThreadedPublisher publisher = new MultiThreadedPublisher(1, 2, 3);
+        BusySubscriber busy = new BusySubscriber();
+        Subscriber<Integer> serialized = serialized(busy);
+
+        publisher.subscribe(serialized);
+        publisher.await();
+
+        assertThat(busy.onNextCount).hasValue(3);
+        assertThat(busy.onError).isFalse();
+        assertThat(busy.onComplete).isTrue();
+
+        // we can have concurrency, but the onNext execution should be single threaded
+        assertThat(publisher.maxConcurrentThreads.get()).isGreaterThan(1);
+        assertThat(busy.maxConcurrentThreads.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void testMultiThreadedEmissionWithFailureAtTheEnd() throws InterruptedException {
+        MultiThreadedPublisher publisher = new MultiThreadedPublisher(1, 2, 3, -1);
+
+        BusySubscriber busy = new BusySubscriber();
+        Subscriber<Integer> serialized = serialized(busy);
+
+        publisher.subscribe(serialized);
+        publisher.await();
+        busy.terminalEvent.await();
+
+        // we can't know how many onNext calls will occur since they each run on a separate thread
+        // that depends on thread scheduling so 0, 1, 2 and 3 are all valid options
+        assertThat(busy.onNextCount.get()).isLessThan(4);
+        assertThat(busy.onError).isTrue();
+        assertThat(busy.onComplete).isFalse();
+
+        // we can have concurrency, but the onNext execution should be single threaded
+        assertThat(publisher.maxConcurrentThreads.get()).isGreaterThan(1);
+        assertThat(busy.maxConcurrentThreads.get()).isEqualTo(1);
+    }
+
+    @Test(invocationCount = 10)
+    public void testMultiThreadedEmissionWithFailureInTheMiddleOfTheStream() throws InterruptedException {
+        MultiThreadedPublisher publisher = new MultiThreadedPublisher(1, 2, 3, -1, 4, 5, 6, 7, 8, 9);
+        BusySubscriber busy = new BusySubscriber();
+        Subscriber<Integer> serialized = serialized(busy);
+
+        publisher.subscribe(serialized);
+        publisher.await();
+        busy.terminalEvent.await();
+
+        assertThat(busy.onNextCount.get()).isLessThan(9);
+        assertThat(busy.onError).isTrue();
+        assertThat(busy.onComplete).isFalse();
+
+        // we can have concurrency, but the onNext execution should be single threaded
+        assertThat(publisher.maxConcurrentThreads.get()).isGreaterThan(1);
+        assertThat(busy.maxConcurrentThreads.get()).isEqualTo(1);
+    }
+
+    /**
+     * A non-realistic use case that tries to expose thread-safety issues by throwing lots of out-of-order
+     * events on many threads.
+     */
+    @Test
+    public void runOutOfOrderConcurrencyTest() {
+        ExecutorService executor = Executors.newFixedThreadPool(20);
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+        Infrastructure.setDroppedExceptionHandler(failures::add);
+
+        try {
+            ConcurrentSubscriber sub = new ConcurrentSubscriber();
+            Subscriber<String> serialized = serialized(new SafeSubscriber<>(sub));
+
+            Future<?> f1 = executor.submit(new OnNextThread(serialized, 12000));
+            Future<?> f2 = executor.submit(new OnNextThread(serialized, 5000));
+            Future<?> f3 = executor.submit(new OnNextThread(serialized, 75000));
+            Future<?> f4 = executor.submit(new OnNextThread(serialized, 13500));
+            Future<?> f5 = executor.submit(new OnNextThread(serialized, 22000));
+            Future<?> f6 = executor.submit(new OnNextThread(serialized, 15000));
+            Future<?> f7 = executor.submit(new OnNextThread(serialized, 7500));
+            Future<?> f8 = executor.submit(new OnNextThread(serialized, 23500));
+            Future<?> f10 = executor
+                    .submit(new CompletionThread(serialized, TestConcurrencySubscriberEvent.onComplete, f1, f2, f3,
+                            f4));
+
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+            Future<?> f11 = executor
+                    .submit(new CompletionThread(serialized, TestConcurrencySubscriberEvent.onComplete, f4, f6, f7));
+            Future<?> f12 = executor
+                    .submit(new CompletionThread(serialized, TestConcurrencySubscriberEvent.onComplete, f4, f6, f7));
+            Future<?> f13 = executor
+                    .submit(new CompletionThread(serialized, TestConcurrencySubscriberEvent.onComplete, f4, f6, f7));
+            Future<?> f14 = executor
+                    .submit(new CompletionThread(serialized, TestConcurrencySubscriberEvent.onComplete, f4, f6, f7));
+            // // the next 4 onError events should wait on same as f10
+            Future<?> f15 = executor
+                    .submit(new CompletionThread(serialized, TestConcurrencySubscriberEvent.onError, f1, f2, f3, f4));
+            Future<?> f16 = executor
+                    .submit(new CompletionThread(serialized, TestConcurrencySubscriberEvent.onError, f1, f2, f3, f4));
+            Future<?> f17 = executor
+                    .submit(new CompletionThread(serialized, TestConcurrencySubscriberEvent.onError, f1, f2, f3, f4));
+            Future<?> f18 = executor
+                    .submit(new CompletionThread(serialized, TestConcurrencySubscriberEvent.onError, f1, f2, f3, f4));
+
+            waitOnThreads(f1, f2, f3, f4, f5, f6, f7, f8, f10, f11, f12, f13, f14, f15, f16, f17, f18);
+            @SuppressWarnings("unused")
+            int numNextEvents = sub.assertEvents(null);
+
+            assertThat(failures).allSatisfy(t -> assertThat(t).isInstanceOf(RuntimeException.class));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testConcurrency() {
+        ExecutorService executor = Executors.newFixedThreadPool(20);
+        try {
+            ConcurrentSubscriber sub = new ConcurrentSubscriber();
+            Subscriber<String> serialized = serialized(new SafeSubscriber<>(sub));
+            serialized.onSubscribe(mock(Subscription.class));
+
+            Future<?> f1 = executor.submit(new OnNextThread(serialized, 12000));
+            Future<?> f2 = executor.submit(new OnNextThread(serialized, 5000));
+            Future<?> f3 = executor.submit(new OnNextThread(serialized, 75000));
+            Future<?> f4 = executor.submit(new OnNextThread(serialized, 13500));
+            Future<?> f5 = executor.submit(new OnNextThread(serialized, 22000));
+            Future<?> f6 = executor.submit(new OnNextThread(serialized, 15000));
+            Future<?> f7 = executor.submit(new OnNextThread(serialized, 7500));
+            Future<?> f8 = executor.submit(new OnNextThread(serialized, 23500));
+
+            Future<?> f10 = executor
+                    .submit(new CompletionThread(serialized, TestConcurrencySubscriberEvent.onComplete, f1, f2, f3, f4,
+                            f5, f6, f7, f8));
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+
+            waitOnThreads(f1, f2, f3, f4, f5, f6, f7, f8, f10);
+            int numNextEvents = sub.assertEvents(null);
+            assertThat(numNextEvents).isEqualTo(12000 + 5000 + 75000 + 13500 + 22000 + 15000 + 7500 + 23500);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testOnFailureReentry() {
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+        Infrastructure.setDroppedExceptionHandler(failures::add);
+
+        final AtomicReference<Subscriber<Integer>> reference = new AtomicReference<>();
+
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<Integer>(Long.MAX_VALUE) {
+            @Override
+            public void onNext(Integer v) {
+                reference.get().onError(new TestException("boom-1"));
+                reference.get().onError(new TestException("boom-2"));
+                super.onNext(v);
+            }
+        };
+        SerializedSubscriber<Integer> serialized = new SerializedSubscriber<>(subscriber);
+        serialized.onSubscribe(mock(Subscription.class));
+        reference.set(serialized);
+
+        serialized.onNext(1);
+
+        subscriber
+                .assertReceived(1)
+                .assertHasFailedWith(TestException.class, "boom-1");
+
+        assertThat(failures).hasSize(1).allSatisfy(f -> assertThat(f).isInstanceOf(TestException.class)
+                .hasMessageContaining("boom-2"));
+    }
+
+    @Test
+    public void testOnCompleteReentry() {
+        final AtomicReference<Subscriber<Integer>> reference = new AtomicReference<>();
+
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<Integer>(Long.MAX_VALUE) {
+            @Override
+            public void onNext(Integer v) {
+                reference.get().onComplete();
+                reference.get().onComplete();
+                super.onNext(v);
+            }
+        };
+        SerializedSubscriber<Integer> serialized = new SerializedSubscriber<>(subscriber);
+        serialized.onSubscribe(mock(Subscription.class));
+        reference.set(serialized);
+
+        subscriber.onNext(1);
+
+        subscriber
+                .assertReceived(1)
+                .assertCompletedSuccessfully();
+    }
+
+    @Test
+    public void testCancellation() {
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(Long.MAX_VALUE);
+        SerializedSubscriber<Integer> serialized = new SerializedSubscriber<>(subscriber);
+
+        Subscription subscription = mock(Subscription.class);
+        serialized.onSubscribe(subscription);
+
+        subscriber.cancel();
+        verify(subscription).cancel();
+    }
+
+    private void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test(invocationCount = 10)
+    public void testOnCompleteRace() {
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(Long.MAX_VALUE);
+        SerializedSubscriber<Integer> serialized = new SerializedSubscriber<>(subscriber);
+        Subscription subscription = mock(Subscription.class);
+        serialized.onSubscribe(subscription);
+
+        CountDownLatch start = new CountDownLatch(2);
+        Runnable runnable = () -> {
+            start.countDown();
+            await(start);
+            serialized.onCompletion();
+        };
+        Arrays.asList(runnable, runnable).forEach(r -> new Thread(r).start());
+
+        subscriber.await().assertCompletedSuccessfully();
+    }
+
+    @Test(invocationCount = 10)
+    public void testOnNextOnCompleteRace() {
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(Long.MAX_VALUE);
+        SerializedSubscriber<Integer> serialized = new SerializedSubscriber<>(subscriber);
+        Subscription subscription = mock(Subscription.class);
+        serialized.onSubscribe(subscription);
+
+        CountDownLatch start = new CountDownLatch(2);
+
+        Runnable r1 = () -> {
+            start.countDown();
+            await(start);
+            serialized.onComplete();
+        };
+
+        Runnable r2 = () -> {
+            start.countDown();
+            await(start);
+            serialized.onNext(1);
+        };
+
+        List<Runnable> runnables = Arrays.asList(r1, r2);
+        Collections.shuffle(runnables);
+        runnables.forEach(r -> new Thread(r).start());
+
+        subscriber.await().assertCompletedSuccessfully();
+        assertThat(subscriber.items()).hasSizeBetween(0, 1);
+    }
+
+    @Test(invocationCount = 10)
+    public void testOnNextOnErrorRace() {
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(Long.MAX_VALUE);
+        SerializedSubscriber<Integer> serialized = new SerializedSubscriber<>(subscriber);
+        Subscription subscription = mock(Subscription.class);
+        serialized.onSubscribe(subscription);
+
+        CountDownLatch start = new CountDownLatch(2);
+
+        Runnable r1 = () -> {
+            start.countDown();
+            await(start);
+            serialized.onError(new TestException("boom"));
+        };
+
+        Runnable r2 = () -> {
+            start.countDown();
+            await(start);
+            serialized.onNext(1);
+        };
+
+        List<Runnable> runnables = Arrays.asList(r1, r2);
+        Collections.shuffle(runnables);
+        runnables.forEach(r -> new Thread(r).start());
+
+        subscriber.await().assertHasFailedWith(TestException.class, "boom");
+        assertThat(subscriber.items()).hasSizeBetween(0, 1);
+    }
+
+    @Test(invocationCount = 10)
+    public void testOnCompleteOnErrorRace() {
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(Long.MAX_VALUE);
+        SerializedSubscriber<Integer> serialized = new SerializedSubscriber<>(subscriber);
+        Subscription subscription = mock(Subscription.class);
+        serialized.onSubscribe(subscription);
+
+        CountDownLatch start = new CountDownLatch(2);
+
+        Runnable r1 = () -> {
+            start.countDown();
+            await(start);
+            serialized.onError(new TestException("boom"));
+        };
+
+        Runnable r2 = () -> {
+            start.countDown();
+            await(start);
+            serialized.onComplete();
+        };
+
+        List<Runnable> runnables = Arrays.asList(r1, r2);
+        Collections.shuffle(runnables);
+        runnables.forEach(r -> new Thread(r).start());
+
+        subscriber.await();
+        if (subscriber.hasCompleted()) {
+            subscriber.assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
+        } else {
+            subscriber.assertHasFailedWith(TestException.class, "boom");
+        }
+    }
+
+    @Test
+    public void testThatTheSerializedSubscriberAcceptOnlyOnSubscription() {
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+        Infrastructure.setDroppedExceptionHandler(failures::add);
+
+        AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(Long.MAX_VALUE);
+        SerializedSubscriber<Integer> serialized = new SerializedSubscriber<>(subscriber);
+
+        serialized.onSubscribe(mock(Subscription.class));
+
+        Subscription another = mock(Subscription.class);
+        serialized.onSubscribe(another);
+
+        verify(another).cancel();
+        assertThat(failures).hasSize(1)
+                .allSatisfy(i -> assertThat(i).isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("Subscription already set"));
+    }
+
+    /**
+     * Publish elements on a single thread.
+     */
+    @SuppressWarnings("ReactiveStreamsPublisherImplementation")
+    static class SingleThreadedPublisher implements Publisher<Integer> {
+
+        List<Integer> values;
+        Thread thread;
+
+        SingleThreadedPublisher(final Integer... values) {
+            this.values = Arrays.asList(values);
+        }
+
+        @Override
+        public void subscribe(final Subscriber<? super Integer> subscriber) {
+            subscriber.onSubscribe(mock(Subscription.class));
+            thread = new Thread(() -> {
+                try {
+                    for (int i : values) {
+                        subscriber.onNext(i);
+                    }
+                    subscriber.onComplete();
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            thread.start();
+        }
+
+        public void await() {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * Publish elements on a multiple threads.
+     */
+    @SuppressWarnings("ReactiveStreamsPublisherImplementation")
+    static class MultiThreadedPublisher implements Publisher<Integer> {
+
+        List<Integer> values;
+        Thread t;
+        AtomicInteger threadsRunning = new AtomicInteger();
+        AtomicInteger maxConcurrentThreads = new AtomicInteger();
+        ExecutorService threadPool;
+
+        MultiThreadedPublisher(Integer... values) {
+            this.values = Arrays.asList(values);
+            this.threadPool = Executors.newCachedThreadPool();
+        }
+
+        @Override
+        public void subscribe(final Subscriber<? super Integer> subscriber) {
+            subscriber.onSubscribe(mock(Subscription.class));
+            final NullPointerException npe = new NullPointerException();
+            t = new Thread(() -> {
+                try {
+                    int j = 0;
+                    for (final int i : values) {
+                        final int fj = ++j;
+                        threadPool.execute(() -> {
+                            threadsRunning.incrementAndGet();
+                            try {
+                                if (i == -1) {
+                                    // force an error on -1
+                                    throw npe;
+                                } else {
+                                    // allow the exception to queue up
+                                    int sleep = (fj % 3) * 10;
+                                    if (sleep != 0) {
+                                        Thread.sleep(sleep);
+                                    }
+                                }
+                                subscriber.onNext(i);
+                                // capture 'maxThreads'
+                                int concurrentThreads = threadsRunning.get();
+                                int maxThreads = maxConcurrentThreads.get();
+                                if (concurrentThreads > maxThreads) {
+                                    maxConcurrentThreads.compareAndSet(maxThreads, concurrentThreads);
+                                }
+                            } catch (Throwable e) {
+                                subscriber.onError(e);
+                            } finally {
+                                threadsRunning.decrementAndGet();
+                            }
+                        });
+                    }
+                    // we are done spawning threads
+                    threadPool.shutdown();
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+
+                // wait until all threads are done, then mark it as COMPLETED
+                try {
+                    // wait for all the threads to finish
+                    threadPool.awaitTermination(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+                subscriber.onComplete();
+            });
+            t.start();
+        }
+
+        public void await() {
+            try {
+                t.join();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @SuppressWarnings("ReactiveStreamsSubscriberImplementation")
+    private static class BusySubscriber implements Subscriber<Integer> {
+        volatile boolean onComplete;
+        volatile boolean onError;
+        AtomicInteger onNextCount = new AtomicInteger();
+        AtomicInteger threadsRunning = new AtomicInteger();
+        AtomicInteger maxConcurrentThreads = new AtomicInteger();
+        final CountDownLatch terminalEvent = new CountDownLatch(1);
+
+        @Override
+        public void onComplete() {
+            threadsRunning.incrementAndGet();
+            try {
+                onComplete = true;
+            } finally {
+                captureMaxThreads();
+                threadsRunning.decrementAndGet();
+                terminalEvent.countDown();
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            threadsRunning.incrementAndGet();
+            try {
+                onError = true;
+            } finally {
+                captureMaxThreads();
+                threadsRunning.decrementAndGet();
+                terminalEvent.countDown();
+            }
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            s.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(Integer item) {
+            threadsRunning.incrementAndGet();
+            try {
+                onNextCount.incrementAndGet();
+                try {
+                    // simulate doing something computational
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            } finally {
+                // capture 'maxThreads'
+                captureMaxThreads();
+                threadsRunning.decrementAndGet();
+            }
+        }
+
+        protected void captureMaxThreads() {
+            int concurrentThreads = threadsRunning.get();
+            int maxThreads = maxConcurrentThreads.get();
+            if (concurrentThreads > maxThreads) {
+                maxConcurrentThreads.compareAndSet(maxThreads, concurrentThreads);
+                if (concurrentThreads > 1) {
+                    new RuntimeException("should not be greater than 1").printStackTrace();
+                }
+            }
+        }
+
+    }
+
+    /**
+     * A thread that just pass data to onNext.
+     */
+    public static class OnNextThread implements Runnable {
+
+        private final CountDownLatch latch;
+        private final Subscriber<String> subscriber;
+        private final int itemToSend;
+        final AtomicInteger produced;
+        private final CountDownLatch running;
+
+        OnNextThread(Subscriber<String> subscriber, int itemToSend, AtomicInteger produced) {
+            this(subscriber, itemToSend, produced, null, null);
+        }
+
+        OnNextThread(Subscriber<String> subscriber, int itemToSend, AtomicInteger produced, CountDownLatch latch,
+                CountDownLatch running) {
+            this.subscriber = subscriber;
+            this.itemToSend = itemToSend;
+            this.produced = produced;
+            this.latch = latch;
+            this.running = running;
+        }
+
+        OnNextThread(Subscriber<String> subscriber, int itemToSend) {
+            this(subscriber, itemToSend, new AtomicInteger());
+        }
+
+        @Override
+        public void run() {
+            if (running != null) {
+                running.countDown();
+            }
+            for (int i = 0; i < itemToSend; i++) {
+                subscriber.onNext(Thread.currentThread().getId() + "-" + i);
+                if (latch != null) {
+                    latch.countDown();
+                }
+                produced.incrementAndGet();
+            }
+        }
+    }
+
+    /**
+     * A thread that will call onError or onNext.
+     */
+    public static class CompletionThread implements Runnable {
+
+        private final Subscriber<String> subscriber;
+        private final TestConcurrencySubscriberEvent event;
+        private final Future<?>[] waitOnThese;
+
+        CompletionThread(Subscriber<String> Subscriber, TestConcurrencySubscriberEvent event,
+                Future<?>... waitOnThese) {
+            this.subscriber = Subscriber;
+            this.event = event;
+            this.waitOnThese = waitOnThese;
+        }
+
+        @Override
+        public void run() {
+            /* if we have 'waitOnThese' futures, we'll wait on them before proceeding */
+            if (waitOnThese != null) {
+                for (Future<?> f : waitOnThese) {
+                    try {
+                        f.get();
+                    } catch (Throwable e) {
+                        System.err.println("Error while waiting on future in CompletionThread");
+                    }
+                }
+            }
+
+            /* send the event */
+            if (event == TestConcurrencySubscriberEvent.onError) {
+                subscriber.onError(new RuntimeException("mocked exception"));
+            } else if (event == TestConcurrencySubscriberEvent.onComplete) {
+                subscriber.onComplete();
+
+            } else {
+                throw new IllegalArgumentException("Expecting either onError or onComplete");
+            }
+        }
+    }
+
+    enum TestConcurrencySubscriberEvent {
+        onComplete,
+        onError,
+        onNext
+    }
+
+    @SuppressWarnings("ReactiveStreamsSubscriberImplementation")
+    private static class ConcurrentSubscriber implements Subscriber<String> {
+
+        /**
+         * Used to store the order and number of events received.
+         */
+        private final LinkedBlockingQueue<TestConcurrencySubscriberEvent> events = new LinkedBlockingQueue<>();
+        private final int waitTime;
+
+        @SuppressWarnings("unused")
+        ConcurrentSubscriber(int waitTimeInNext) {
+            this.waitTime = waitTimeInNext;
+        }
+
+        ConcurrentSubscriber() {
+            this.waitTime = 0;
+        }
+
+        @Override
+        public void onComplete() {
+            events.add(TestConcurrencySubscriberEvent.onComplete);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            events.add(TestConcurrencySubscriberEvent.onError);
+        }
+
+        @Override
+        public void onNext(String item) {
+            events.add(TestConcurrencySubscriberEvent.onNext);
+            // do some artificial work to make the thread scheduling/timing vary
+            int s = 0;
+            for (int i = 0; i < 20; i++) {
+                s += s * i;
+            }
+
+            if (waitTime > 0) {
+                try {
+                    Thread.sleep(waitTime);
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+            }
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            s.request(Long.MAX_VALUE);
+        }
+
+        /**
+         * Assert the order of events is correct and return the number of onNext executions.
+         *
+         * @param expectedEndingEvent the last event
+         * @return int count of onNext calls
+         * @throws IllegalStateException If order of events was invalid.
+         */
+        public int assertEvents(TestConcurrencySubscriberEvent expectedEndingEvent) throws IllegalStateException {
+            int nextCount = 0;
+            boolean finished = false;
+            for (TestConcurrencySubscriberEvent e : events) {
+                if (e == TestConcurrencySubscriberEvent.onNext) {
+                    if (finished) {
+                        // already finished, we shouldn't get this again
+                        throw new IllegalStateException("Received onNext but we're already finished.");
+                    }
+                    nextCount++;
+                } else if (e == TestConcurrencySubscriberEvent.onError) {
+                    if (finished) {
+                        // already finished, we shouldn't get this again
+                        throw new IllegalStateException("Received onError but we're already finished.");
+                    }
+                    if (expectedEndingEvent != null && TestConcurrencySubscriberEvent.onError != expectedEndingEvent) {
+                        throw new IllegalStateException(
+                                "Received onError ending event but expected " + expectedEndingEvent);
+                    }
+                    finished = true;
+                } else if (e == TestConcurrencySubscriberEvent.onComplete) {
+                    if (finished) {
+                        // already finished, we shouldn't get this again
+                        throw new IllegalStateException("Received onComplete but we're already finished.");
+                    }
+                    if (expectedEndingEvent != null
+                            && TestConcurrencySubscriberEvent.onComplete != expectedEndingEvent) {
+                        throw new IllegalStateException(
+                                "Received onComplete ending event but expected " + expectedEndingEvent);
+                    }
+                    finished = true;
+                }
+            }
+
+            return nextCount;
+        }
+
+    }
+
+    private static void waitOnThreads(Future<?>... futures) {
+        for (Future<?> f : futures) {
+            try {
+                f.get(20, TimeUnit.SECONDS);
+            } catch (Throwable e) {
+                throw new RuntimeException("Failed while wiating", e);
+            }
+        }
+    }
+
+}

--- a/test-utils/src/main/java/io/smallrye/mutiny/test/AssertSubscriber.java
+++ b/test-utils/src/main/java/io/smallrye/mutiny/test/AssertSubscriber.java
@@ -58,7 +58,7 @@ public class AssertSubscriber<T> implements Subscriber<T> {
      * Number of completion events.
      * Reactive Streams compliant upstream should only send one subscription.
      */
-    private int numberOfCompletionEvents = 0;
+    private volatile int numberOfCompletionEvents = 0;
 
     /**
      * Whether or not the subscriber should cancel the subscription as soon as it receives it.
@@ -287,5 +287,9 @@ public class AssertSubscriber<T> implements Subscriber<T> {
 
     public boolean isCancelled() {
         return cancelled;
+    }
+
+    public boolean hasCompleted() {
+        return numberOfCompletionEvents >= 1;
     }
 }


### PR DESCRIPTION

- Remove guard for concurrent events as the serialized subscriber already takes care of these. Handle dropped exception in the UniSerializedSubscriber
- Add more tests around Uni.combine().all and Uni.combine().any
- Remove unused code and null checks
- Verify ordinal behavior in the UniInterceptor
- Test dropped exception in the SafeSubscriber and CallbackSubscriber
- Fix dropped exception in the SerializedSubscriber and add more tests
