### PR TITLE
Migrate tests to Junit 5

### DIFF
--- a/context-propagation/pom.xml
+++ b/context-propagation/pom.xml
@@ -24,8 +24,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/MultiContextPropagationTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/MultiContextPropagationTest.java
@@ -1,19 +1,12 @@
 package io.smallrye.mutiny.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.*;
 
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -22,9 +15,9 @@ import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiContextPropagationTest {
 
-    private final ExecutorService executor = Executors.newFixedThreadPool(4);
+    private static ExecutorService executor;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         Infrastructure.clearInterceptors();
         Infrastructure.reloadUniInterceptors();
@@ -32,14 +25,19 @@ public class MultiContextPropagationTest {
         MyContext.init();
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         Infrastructure.clearInterceptors();
         MyContext.clear();
     }
 
-    @AfterSuite
-    public void shutdown() {
+    @BeforeAll
+    public static void init() {
+        executor = Executors.newFixedThreadPool(4);
+    }
+
+    @AfterAll
+    public static void shutdown() {
         executor.shutdown();
     }
 
@@ -219,7 +217,7 @@ public class MultiContextPropagationTest {
         CompletableFuture<Integer> cf = new CompletableFuture<>();
         new Thread(() -> {
             try {
-                Assert.assertNull(MyContext.get());
+                assertNull(MyContext.get());
                 int result = cs2.get();
                 cf.complete(result);
             } catch (Throwable t) {

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/UniContextPropagationTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/UniContextPropagationTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -8,34 +9,35 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 
 public class UniContextPropagationTest {
 
-    private ExecutorService executor = Executors.newFixedThreadPool(4);
+    private static ExecutorService executor;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         Infrastructure.clearInterceptors();
         Infrastructure.reloadUniInterceptors();
         MyContext.init();
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         Infrastructure.clearInterceptors();
         MyContext.clear();
     }
 
-    @AfterSuite
-    public void shutdown() {
+    @BeforeAll
+    public static void init() {
+        executor = Executors.newFixedThreadPool(4);
+    }
+
+    @AfterAll
+    public static void shutdown() {
         executor.shutdown();
     }
 
@@ -119,7 +121,7 @@ public class UniContextPropagationTest {
         CompletableFuture<Integer> cf = new CompletableFuture<>();
         new Thread(() -> {
             try {
-                Assert.assertNull(MyContext.get());
+                assertNull(MyContext.get());
                 int result = cs2.get();
                 cf.complete(result);
             } catch (Throwable t) {

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationMultiTckTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationMultiTckTest.java
@@ -1,11 +1,12 @@
 package io.smallrye.mutiny.context.tck;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.stream.LongStream;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.testng.Assert;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.context.ContextPropagationMultiInterceptor;
@@ -26,7 +27,7 @@ public class ContextPropagationMultiTckTest extends PublisherVerification<Long> 
     public Publisher<Long> createPublisher(long elements) {
         Multi<Long> items = Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed());
         items = interceptor.onMultiCreation(items);
-        Assert.assertEquals(items.getClass().getName(),
+        assertEquals(items.getClass().getName(),
                 "io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$ContextPropagationMulti");
         return items;
     }
@@ -35,7 +36,7 @@ public class ContextPropagationMultiTckTest extends PublisherVerification<Long> 
     public Publisher<Long> createFailedPublisher() {
         Multi<Long> failed = Multi.createFrom().failure(new RuntimeException("failed"));
         failed = interceptor.onMultiCreation(failed);
-        Assert.assertEquals(failed.getClass().getName(),
+        assertEquals(failed.getClass().getName(),
                 "io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$ContextPropagationMulti");
         return failed;
     }

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>mutiny-reactor</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/documentation/src/test/java/snippets/BackPressureTest.java
+++ b/documentation/src/test/java/snippets/BackPressureTest.java
@@ -5,9 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.junit.Test;
 
 import io.smallrye.mutiny.Multi;
+import org.junit.jupiter.api.Test;
 
 public class BackPressureTest {
 

--- a/documentation/src/test/java/snippets/BroadcastProcessorTest.java
+++ b/documentation/src/test/java/snippets/BroadcastProcessorTest.java
@@ -3,7 +3,7 @@ package snippets;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 import io.smallrye.mutiny.test.AssertSubscriber;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BroadcastProcessorTest {
 

--- a/documentation/src/test/java/snippets/CollectTest.java
+++ b/documentation/src/test/java/snippets/CollectTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/documentation/src/test/java/snippets/CompletionStageTest.java
+++ b/documentation/src/test/java/snippets/CompletionStageTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/documentation/src/test/java/snippets/DelayTest.java
+++ b/documentation/src/test/java/snippets/DelayTest.java
@@ -2,7 +2,7 @@ package snippets;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.List;

--- a/documentation/src/test/java/snippets/DroppedExceptionTest.java
+++ b/documentation/src/test/java/snippets/DroppedExceptionTest.java
@@ -6,7 +6,7 @@ import java.util.logging.Logger;
 
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.Cancellable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniEmitter;

--- a/documentation/src/test/java/snippets/EmitOnTest.java
+++ b/documentation/src/test/java/snippets/EmitOnTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/documentation/src/test/java/snippets/EmitterTest.java
+++ b/documentation/src/test/java/snippets/EmitterTest.java
@@ -2,7 +2,7 @@ package snippets;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 

--- a/documentation/src/test/java/snippets/EventsTest.java
+++ b/documentation/src/test/java/snippets/EventsTest.java
@@ -1,7 +1,7 @@
 package snippets;
 
 import io.smallrye.mutiny.Uni;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 

--- a/documentation/src/test/java/snippets/FlatMapTest.java
+++ b/documentation/src/test/java/snippets/FlatMapTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/documentation/src/test/java/snippets/GettingStartedTest.java
+++ b/documentation/src/test/java/snippets/GettingStartedTest.java
@@ -1,6 +1,6 @@
 package snippets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GettingStartedTest {
 

--- a/documentation/src/test/java/snippets/HowToChainAsyncTest.java
+++ b/documentation/src/test/java/snippets/HowToChainAsyncTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 

--- a/documentation/src/test/java/snippets/HowToFilterTest.java
+++ b/documentation/src/test/java/snippets/HowToFilterTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/documentation/src/test/java/snippets/HowToJoinAsyncTest.java
+++ b/documentation/src/test/java/snippets/HowToJoinAsyncTest.java
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletableFuture;
 
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.tuples.Tuple3;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 

--- a/documentation/src/test/java/snippets/HowToTransformTest.java
+++ b/documentation/src/test/java/snippets/HowToTransformTest.java
@@ -2,7 +2,7 @@ package snippets;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;

--- a/documentation/src/test/java/snippets/Intro.java
+++ b/documentation/src/test/java/snippets/Intro.java
@@ -1,6 +1,6 @@
 package snippets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 

--- a/documentation/src/test/java/snippets/MergeTest.java
+++ b/documentation/src/test/java/snippets/MergeTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 

--- a/documentation/src/test/java/snippets/MergeVsConcatenateTest.java
+++ b/documentation/src/test/java/snippets/MergeVsConcatenateTest.java
@@ -2,7 +2,7 @@ package snippets;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.List;

--- a/documentation/src/test/java/snippets/MultiCreationTest.java
+++ b/documentation/src/test/java/snippets/MultiCreationTest.java
@@ -6,7 +6,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import io.smallrye.mutiny.subscription.MultiSubscriber;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 

--- a/documentation/src/test/java/snippets/MultiFailureTest.java
+++ b/documentation/src/test/java/snippets/MultiFailureTest.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 

--- a/documentation/src/test/java/snippets/PaginationTest.java
+++ b/documentation/src/test/java/snippets/PaginationTest.java
@@ -3,7 +3,7 @@ package snippets;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.test.AssertSubscriber;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/documentation/src/test/java/snippets/PollableSourceTest.java
+++ b/documentation/src/test/java/snippets/PollableSourceTest.java
@@ -3,7 +3,7 @@ package snippets;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.Cancellable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/documentation/src/test/java/snippets/ReactorTest.java
+++ b/documentation/src/test/java/snippets/ReactorTest.java
@@ -2,7 +2,7 @@ package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/documentation/src/test/java/snippets/RunSubscriptionOnTest.java
+++ b/documentation/src/test/java/snippets/RunSubscriptionOnTest.java
@@ -2,7 +2,7 @@ package snippets;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/documentation/src/test/java/snippets/RxJavaTest.java
+++ b/documentation/src/test/java/snippets/RxJavaTest.java
@@ -9,7 +9,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/documentation/src/test/java/snippets/ThenTest.java
+++ b/documentation/src/test/java/snippets/ThenTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 

--- a/documentation/src/test/java/snippets/UniBlockingTest.java
+++ b/documentation/src/test/java/snippets/UniBlockingTest.java
@@ -3,7 +3,7 @@ package snippets;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.smallrye.mutiny.Multi;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;

--- a/documentation/src/test/java/snippets/UniCreationTest.java
+++ b/documentation/src/test/java/snippets/UniCreationTest.java
@@ -3,7 +3,7 @@ package snippets;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/documentation/src/test/java/snippets/UniFailureTest.java
+++ b/documentation/src/test/java/snippets/UniFailureTest.java
@@ -1,7 +1,7 @@
 package snippets;
 
 import io.smallrye.mutiny.Uni;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;

--- a/documentation/src/test/java/snippets/UniMultiComparisonTest.java
+++ b/documentation/src/test/java/snippets/UniMultiComparisonTest.java
@@ -1,6 +1,6 @@
 package snippets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/documentation/src/test/java/snippets/UniNullTest.java
+++ b/documentation/src/test/java/snippets/UniNullTest.java
@@ -2,7 +2,7 @@ package snippets;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/documentation/src/test/java/snippets/UniTimeoutTest.java
+++ b/documentation/src/test/java/snippets/UniTimeoutTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 

--- a/documentation/src/test/java/snippets/UnicastProcessorTest.java
+++ b/documentation/src/test/java/snippets/UnicastProcessorTest.java
@@ -2,7 +2,7 @@ package snippets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -29,14 +29,22 @@
         </dependency>
 
         <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>reactive-streams-junit5-tck</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams-tck</artifactId>
             <version>${reactive-streams.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -53,13 +61,8 @@
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <junitArtifactName>none:none</junitArtifactName>
-                            <properties>
-                                <property>
-                                    <name>surefire.testng.verbose</name>
-                                    <value>5</value>
-                                </property>
-                            </properties>
+                            <!-- Disable TestNG -->
+                            <testNGArtifactName>none:none</testNGArtifactName>
                         </configuration>
                     </execution>
                 </executions>

--- a/implementation/src/test/java/io/smallrye/mutiny/CompositeExceptionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/CompositeExceptionTest.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompositeExceptionTest {
 

--- a/implementation/src/test/java/io/smallrye/mutiny/MultiStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/MultiStageTest.java
@@ -1,12 +1,13 @@
 package io.smallrye.mutiny;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class MultiStageTest {
 
@@ -41,18 +42,18 @@ public class MultiStageTest {
         assertThat(result).containsExactly("2", "3", "4");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFunctionMustNotBeNull() {
-        Multi.createFrom().item(1)
-                .stage(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1)
+                .stage(null));
     }
 
-    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*boom.*")
+    @Test
     public void testThatFunctionMustNotThrowException() {
-        Multi.createFrom().item(1)
+        assertThrows(IllegalStateException.class, () -> Multi.createFrom().item(1)
                 .stage(i -> {
                     throw new IllegalStateException("boom");
-                });
+                }));
     }
 
     @Test
@@ -62,7 +63,8 @@ public class MultiStageTest {
                 .stage(self -> self
                         .onItem().transform(i -> i + 1)
                         .onFailure().retry().indefinitely())
-                .stage(self -> self.onItem().transformToUni(i -> Uni.createFrom().item(Integer.toString(i))).concatenate())
+                .stage(self -> self.onItem().transformToUni(i -> Uni.createFrom().item(Integer.toString(i)))
+                        .concatenate())
                 .stage(self -> {
                     String r = self.collectItems().first().await().indefinitely();
                     result.set(r);

--- a/implementation/src/test/java/io/smallrye/mutiny/TestException.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/TestException.java
@@ -1,0 +1,12 @@
+package io.smallrye.mutiny;
+
+public class TestException extends RuntimeException {
+
+    public TestException() {
+        super("Test Exception");
+    }
+
+    public TestException(String message) {
+        super(message);
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/UniStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/UniStageTest.java
@@ -1,11 +1,13 @@
 package io.smallrye.mutiny;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class UniStageTest {
 
@@ -31,18 +33,18 @@ public class UniStageTest {
         assertThat(result).isEqualTo("24");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFunctionMustNotBeNull() {
-        Uni.createFrom().item(1)
-                .stage(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1)
+                .stage(null));
     }
 
-    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*boom.*")
+    @Test
     public void testThatFunctionMustNotThrowException() {
-        Uni.createFrom().item(1)
+        assertThatThrownBy(() -> Uni.createFrom().item(1)
                 .stage(i -> {
                     throw new IllegalStateException("boom");
-                });
+                })).isInstanceOf(IllegalStateException.class).hasMessageContaining("boom");
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
@@ -2,7 +2,7 @@ package io.smallrye.mutiny.converters;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.converters.multi.BuiltinConverters;

--- a/implementation/src/test/java/io/smallrye/mutiny/converters/UniConvertToTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/converters/UniConvertToTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.converters.uni.BuiltinConverters;

--- a/implementation/src/test/java/io/smallrye/mutiny/converters/UniCreateFromTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/converters/UniCreateFromTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.converters.uni.BuiltinConverters;

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiBroadcastTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiBroadcastTest.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.MultiEmitterProcessor;

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiConvertTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiConvertTest.java
@@ -1,11 +1,12 @@
 package io.smallrye.mutiny.groups;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -25,14 +26,14 @@ public class MultiConvertTest {
         assertThat(items).isSameAs(publisher);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatConverterCannotBeNull() {
-        Multi.createFrom().items(1, 2, 3).convert().with(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().items(1, 2, 3).convert().with(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatUpstreamCannotBeNull() {
-        new MultiConvert<>(null);
+        assertThrows(IllegalArgumentException.class, () -> new MultiConvert<>(null));
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiFlattenTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiFlattenTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiRepetitionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiRepetitionTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.groups;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -9,7 +10,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -85,22 +86,23 @@ public class MultiRepetitionTest {
         subscriber.assertHasFailedWith(NullPointerException.class, "supplier");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatStateSupplierCannotBeNullWithEmitterWithSharedState() {
-        Multi.createBy().repeating().uni(null,
+        assertThrows(IllegalArgumentException.class, () -> Multi.createBy().repeating().uni(null,
                 (x, emitter) -> {
-                });
+                }));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFunctionCannotBeNullWithEmitterWithSharedState() {
-        Multi.createBy().repeating().uni(() -> "hello",
-                (BiConsumer<String, UniEmitter<? super String>>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createBy().repeating().uni(() -> "hello",
+                (BiConsumer<String, UniEmitter<? super String>>) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFunctionCannotBeNullWithEmitter() {
-        Multi.createBy().repeating().uni((Consumer<UniEmitter<? super Object>>) null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Multi.createBy().repeating().uni((Consumer<UniEmitter<? super Object>>) null));
     }
 
     @Test
@@ -191,16 +193,17 @@ public class MultiRepetitionTest {
         subscriber.assertHasFailedWith(NullPointerException.class, "supplier");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatStateSupplierCannotBeNullWithUniWithSharedState() {
-        Multi.createBy().repeating().uni(null,
+        assertThrows(IllegalArgumentException.class, () -> Multi.createBy().repeating().uni(null,
                 (x, emitter) -> {
-                });
+                }));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFunctionCannotBeNullWithUniWithSharedState() {
-        Multi.createBy().repeating().uni(() -> "hello", (Function<String, Uni<? extends String>>) null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Multi.createBy().repeating().uni(() -> "hello", (Function<String, Uni<? extends String>>) null));
     }
 
     @Test
@@ -293,16 +296,17 @@ public class MultiRepetitionTest {
         subscriber.assertTerminated().assertCompletedSuccessfully().assertHasNotReceivedAnyItem();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatStateSupplierCannotBeNullWithCompletionStageWithSharedState() {
-        Multi.createBy().repeating().completionStage(null,
-                x -> CompletableFuture.completedFuture(1));
+        assertThrows(IllegalArgumentException.class, () -> Multi.createBy().repeating().completionStage(null,
+                x -> CompletableFuture.completedFuture(1)));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFunctionCannotBeNullWithCompletionStageWithSharedState() {
-        Multi.createBy().repeating().completionStage(() -> "hello",
-                (Function<String, CompletableFuture<? extends String>>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createBy().repeating().completionStage(() -> "hello",
+                (Function<String, CompletableFuture<? extends String>>) null));
+
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/UniSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/UniSubscriberTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.Cancellable;

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/CausedTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/CausedTest.java
@@ -1,11 +1,12 @@
 package io.smallrye.mutiny.helpers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.unchecked.Unchecked;
@@ -63,16 +64,16 @@ public class CausedTest {
                 .indefinitely());
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testWithNullParameter() {
-        Uni.createFrom()
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom()
                 .item(Unchecked.supplier(this::numberSupplierThrowingNumberFormatException))
                 .onFailure(Caused.by(null))
                 .recoverWithItem(SPECIFIC)
                 .onFailure()
                 .recoverWithItem(GENERIC)
                 .await()
-                .indefinitely();
+                .indefinitely());
     }
 
     private String stringSupplierThrowingIOException() throws IOException {

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/HalfSerializerTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/HalfSerializerTest.java
@@ -12,9 +12,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 import io.smallrye.mutiny.test.AssertSubscriber;
@@ -139,7 +140,7 @@ public class HalfSerializerTest {
         test.assertHasFailedWith(IOException.class, "test");
     }
 
-    @Test(invocationCount = 1000)
+    @RepeatedTest(100)
     public void testOnNextOnCompleteRace() throws InterruptedException {
         AtomicInteger wip = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
@@ -168,7 +169,7 @@ public class HalfSerializerTest {
         assertThat(test.items()).hasSizeBetween(0, 1);
     }
 
-    @Test(invocationCount = 1000)
+    @RepeatedTest(100)
     public void testOnErrorOnCompleteRace() throws InterruptedException {
         AtomicInteger wip = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/StrictMultiSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/StrictMultiSubscriberTest.java
@@ -8,9 +8,9 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/SubscriptionsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/SubscriptionsTest.java
@@ -13,8 +13,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.CompositeException;
 
@@ -86,7 +87,7 @@ public class SubscriptionsTest {
         verify(newSub).cancel();
     }
 
-    @Test(invocationCount = 1000)
+    @RepeatedTest(100)
     public void requestIfNotNullOrAccumulateRace() throws InterruptedException {
         AtomicReference<Subscription> container = new AtomicReference<>();
         Subscription subscription = mock(Subscription.class);
@@ -107,7 +108,7 @@ public class SubscriptionsTest {
         latch.await();
     }
 
-    @Test(invocationCount = 1000)
+    @RepeatedTest(100)
     public void setIfEmptyAndRequestRace() throws InterruptedException {
         final AtomicReference<Subscription> atomicSubscription = new AtomicReference<>();
         final AtomicLong r = new AtomicLong();

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/queues/DrainUtilsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/queues/DrainUtilsTest.java
@@ -7,8 +7,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
 
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.reactivex.internal.util.QueueDrainHelper;
 import io.smallrye.mutiny.test.AssertSubscriber;
@@ -45,7 +46,7 @@ public class DrainUtilsTest {
                 .assertReceived(1);
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void testCompleteVsRequestRace() throws InterruptedException {
         BooleanSupplier isCancelled = () -> false;
         Subscription subscription = mock(Subscription.class);

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/queues/QueuesTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/queues/QueuesTest.java
@@ -4,12 +4,13 @@ import static io.smallrye.mutiny.helpers.queues.Queues.BUFFER_S;
 import static io.smallrye.mutiny.helpers.queues.Queues.BUFFER_XS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({ "rawtypes", "unchecked", "MismatchedQueryAndUpdateOfCollection" })
 public class QueuesTest {
@@ -220,22 +221,28 @@ public class QueuesTest {
         assertThat(iterator.next()).isNull();
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testThatSpscArrayQueueCannotReceiveNull() {
-        SpscArrayQueue<Object> q = new SpscArrayQueue<>(16);
-        q.offer(null);
+        assertThrows(NullPointerException.class, () -> {
+            SpscArrayQueue<Object> q = new SpscArrayQueue<>(16);
+            q.offer(null);
+        });
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testThatSpscLinkedArrayQueueCannotReceiveNull() {
-        SpscLinkedArrayQueue<Object> q = new SpscLinkedArrayQueue<>(16);
-        q.offer(null);
+        assertThrows(NullPointerException.class, () -> {
+            SpscLinkedArrayQueue<Object> q = new SpscLinkedArrayQueue<>(16);
+            q.offer(null);
+        });
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testThatMpscLinkedQueueCannotReceiveNull() {
-        MpscLinkedQueue<Object> q = new MpscLinkedQueue<>();
-        q.offer(null);
+        assertThrows(NullPointerException.class, () -> {
+            MpscLinkedQueue<Object> q = new MpscLinkedQueue<>();
+            q.offer(null);
+        });
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/DroppedExceptionsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/DroppedExceptionsTest.java
@@ -8,8 +8,8 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.Cancellable;
@@ -18,7 +18,7 @@ public class DroppedExceptionsTest {
 
     private static final PrintStream systemErr = System.err;
 
-    @After
+    @AfterEach
     public void cleanup() {
         System.setErr(systemErr);
         Infrastructure.resetDroppedExceptionHandler();

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/MultiInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/MultiInterceptorTest.java
@@ -2,8 +2,8 @@ package io.smallrye.mutiny.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.AbstractMulti;

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/MutinySchedulerTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/MutinySchedulerTest.java
@@ -1,7 +1,6 @@
 package io.smallrye.mutiny.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -12,9 +11,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -22,7 +21,7 @@ import io.smallrye.mutiny.Uni;
 @SuppressWarnings("ConstantConditions")
 public class MutinySchedulerTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         ExecutorService exec = Executors.newFixedThreadPool(4, new ThreadFactory() {
             final AtomicInteger count = new AtomicInteger();
@@ -35,7 +34,7 @@ public class MutinySchedulerTest {
         Infrastructure.setDefaultExecutor(exec);
     }
 
-    @AfterClass
+    @AfterAll
     public static void reset() {
         Executor current = Infrastructure.getDefaultExecutor();
         if (current instanceof ExecutorService) {

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/UniInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/UniInterceptorTest.java
@@ -2,8 +2,8 @@ package io.smallrye.mutiny.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.AbstractUni;
@@ -14,7 +14,7 @@ import io.smallrye.mutiny.subscription.UniSubscription;
 
 public class UniInterceptorTest {
 
-    @AfterMethod
+    @AfterEach
     public void cleanup() {
         Infrastructure.clearInterceptors();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCacheTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCacheTest.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiEmitter;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCastTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCastTest.java
@@ -1,16 +1,18 @@
 package io.smallrye.mutiny.operators;
 
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCastTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatClassCannotBeNull() {
-        Multi.createFrom().item(1)
-                .onItem().castTo(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1)
+                .onItem().castTo(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCollectTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCollectTest.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCombineTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCombineTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -11,7 +12,7 @@ import java.util.concurrent.CompletionException;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;
@@ -270,9 +271,9 @@ public class MultiCombineTest {
                 .assertHasNotReceivedAnyItem();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatIterableCannotBeNull() {
-        Multi.createBy().combining().streams(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createBy().combining().streams(null));
     }
 
     @Test
@@ -359,14 +360,17 @@ public class MultiCombineTest {
                 .assertReceived(Tuple4.of(1, 1, 1, 1));
     }
 
-    @Test(expectedExceptions = CompletionException.class)
+    @Test
     public void testCombinationOfAFailingStream() {
-        Multi<Integer> stream = Multi.createFrom().items(1, 2, 3, 4);
-        Multi<Integer> fail = Multi.createFrom().failure(new IOException("boom"));
+        assertThrows(CompletionException.class, () -> {
 
-        Multi.createBy()
-                .combining().streams(stream, fail).asTuple()
-                .collectItems().asList().await().indefinitely();
+            Multi<Integer> stream = Multi.createFrom().items(1, 2, 3, 4);
+            Multi<Integer> fail = Multi.createFrom().failure(new IOException("boom"));
+
+            Multi.createBy()
+                    .combining().streams(stream, fail).asTuple()
+                    .collectItems().asList().await().indefinitely();
+        });
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiConcatTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiConcatTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.CompositeException;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromCompletionStageTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -9,21 +10,22 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCreateFromCompletionStageTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatTheCompletionStageCannotBeNull() {
-        Multi.createFrom().completionStage((CompletionStage<String>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().completionStage((CompletionStage<String>) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatTheCompletionStageSupplierCannotBeNull() {
-        Multi.createFrom().completionStage((Supplier<CompletionStage<String>>) null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Multi.createFrom().completionStage((Supplier<CompletionStage<String>>) null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromDeferredSupplierTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromDeferredSupplierTest.java
@@ -1,17 +1,19 @@
 package io.smallrye.mutiny.operators;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCreateFromDeferredSupplierTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatTheSupplierCannotBeNull() {
-        Multi.createFrom().deferred(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().deferred(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromEmitterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromEmitterTest.java
@@ -10,9 +10,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.BackPressureFailure;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromFailureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromFailureTest.java
@@ -1,26 +1,27 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCreateFromFailureTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFailureCannotBeNull() {
-        Multi.createFrom().failure((Throwable) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().failure((Throwable) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFailureSupplierCannotBeNull() {
-        Multi.createFrom().failure((Supplier<Throwable>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().failure((Supplier<Throwable>) null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromItemsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromItemsTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
@@ -11,7 +12,7 @@ import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;
@@ -174,7 +175,8 @@ public class MultiCreateFromItemsTest {
 
     @Test
     public void testNullWithStreams() {
-        assertThatThrownBy(() -> Multi.createFrom().items((Stream<String>) null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Multi.createFrom().items((Stream<String>) null))
+                .isInstanceOf(IllegalArgumentException.class);
 
         Multi.createFrom().items(() -> null)
                 .subscribe().withSubscriber(AssertSubscriber.create(10))
@@ -266,14 +268,14 @@ public class MultiCreateFromItemsTest {
                 .assertCompletedSuccessfully();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testCreationFromANullStream() {
-        Multi.createFrom().items((Stream<Integer>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().items((Stream<Integer>) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testCreationFromANullStreamSupplier() {
-        Multi.createFrom().items((Supplier<Stream<Integer>>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().items((Supplier<Stream<Integer>>) null));
     }
 
     @Test
@@ -305,14 +307,14 @@ public class MultiCreateFromItemsTest {
                 .assertReceived(1, 2, 3);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testCreationFromResultsContainingNull() {
-        Multi.createFrom().items(1, null, 3);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().items(1, null, 3));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testCreationFromResultsWithNull() {
-        Multi.createFrom().items((Integer[]) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().items((Integer[]) null));
     }
 
     @Test
@@ -328,9 +330,9 @@ public class MultiCreateFromItemsTest {
                 .assertReceived(1, 2, 3);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testCreationFromIterableWithNull() {
-        Multi.createFrom().iterable((Iterable<Integer>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().iterable((Iterable<Integer>) null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromOptionalTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromOptionalTest.java
@@ -1,12 +1,13 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;
@@ -14,14 +15,14 @@ import io.smallrye.mutiny.test.AssertSubscriber;
 public class MultiCreateFromOptionalTest {
 
     @SuppressWarnings("OptionalAssignedToNull")
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatTheOptionalCannotBeNull() {
-        Multi.createFrom().optional((Optional<String>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().optional((Optional<String>) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatOptionalSupplierCannotBeNull() {
-        Multi.createFrom().optional((Supplier<Optional<String>>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().optional((Supplier<Optional<String>>) null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromPublisherTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromPublisherTest.java
@@ -1,13 +1,14 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
@@ -15,9 +16,9 @@ import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiCreateFromPublisherTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatPublisherCannotBeNull() {
-        Multi.createFrom().publisher(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().publisher(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromRangeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromRangeTest.java
@@ -1,6 +1,8 @@
 package io.smallrye.mutiny.operators;
 
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;
@@ -30,9 +32,9 @@ public class MultiCreateFromRangeTest {
                 .assertCompletedSuccessfully();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatEndBoundaryCannotBeLessThanStart() {
-        Multi.createFrom().range(1, -1);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, -1));
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
@@ -8,8 +8,9 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
@@ -19,7 +20,7 @@ public class MultiCreateFromTimePeriodTest {
 
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
-    @AfterTest
+    @AfterEach
     public void cleanup() {
         executor.shutdown();
     }
@@ -79,7 +80,8 @@ public class MultiCreateFromTimePeriodTest {
         }
     }
 
-    @Test(timeOut = 1000)
+    @Test
+    @Timeout(1)
     public void testBackPressureOverflow() {
         AssertSubscriber<Long> subscriber = AssertSubscriber.create();
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiDistinctTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiDistinctTest.java
@@ -1,14 +1,16 @@
 package io.smallrye.mutiny.operators;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import org.testng.TestException;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.TestException;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.test.AssertSubscriber;
 
@@ -32,11 +34,11 @@ public class MultiDistinctTest {
     }
 
     @SuppressWarnings("ConstantConditions")
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testThatNullSubscriberAreRejected() {
-        Multi.createFrom().items(1, 2, 3, 4, 2, 4, 2, 4)
+        assertThrows(NullPointerException.class, () -> Multi.createFrom().items(1, 2, 3, 4, 2, 4, 2, 4)
                 .transform().byDroppingDuplicates()
-                .subscribe(null);
+                .subscribe(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmitOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmitOnTest.java
@@ -5,9 +5,9 @@ import static org.awaitility.Awaitility.await;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;
@@ -16,12 +16,12 @@ public class MultiEmitOnTest {
 
     private ExecutorService executor;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         executor = Executors.newFixedThreadPool(4);
     }
 
-    @AfterMethod
+    @AfterEach
     public void shutdown() {
         executor.shutdown();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmptyAndNeverTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmptyAndNeverTest.java
@@ -1,6 +1,6 @@
 package io.smallrye.mutiny.operators;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiFilterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiFilterTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -9,8 +10,8 @@ import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -21,23 +22,25 @@ import io.smallrye.mutiny.test.Mocks;
 
 public class MultiFilterTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatPredicateCannotBeNull() {
-        Multi.createFrom().range(1, 4)
-                .transform().byFilteringItemsWith(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 4)
+                .transform().byFilteringItemsWith(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFunctionCannotBeNull() {
-        Multi.createFrom().range(1, 4)
-                .transform().byTestingItemsWith(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 4)
+                .transform().byTestingItemsWith(null));
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testThatSubscriberCannotBeNull() {
-        Multi<Integer> multi = Multi.createFrom().range(1, 4);
-        MultiFilterOp<Integer> filter = new MultiFilterOp<>(multi, x -> x % 2 == 0);
-        filter.subscribe(null);
+        assertThrows(NullPointerException.class, () -> {
+            Multi<Integer> multi = Multi.createFrom().range(1, 4);
+            MultiFilterOp<Integer> filter = new MultiFilterOp<>(multi, x -> x % 2 == 0);
+            filter.subscribe(null);
+        });
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -12,7 +13,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.GroupedMulti;
 import io.smallrye.mutiny.Multi;
@@ -21,19 +22,19 @@ import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiGroupTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testGroupIntoListsWithSize0() {
-        Multi.createFrom().range(1, 5).groupItems().intoLists().of(0);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5).groupItems().intoLists().of(0));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testGroupIntoListsWithSize0AndSkip() {
-        Multi.createFrom().range(1, 5).groupItems().intoLists().of(0, 1);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5).groupItems().intoLists().of(0, 1));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testGroupIntoListsWithSkip0() {
-        Multi.createFrom().range(1, 5).groupItems().intoLists().of(1, 0);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5).groupItems().intoLists().of(1, 0));
     }
 
     @Test
@@ -125,9 +126,10 @@ public class MultiGroupTest {
                         .isNull();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testAsListsWithNegativeDuration() {
-        Multi.createFrom().range(1, 10).groupItems().intoLists().every(Duration.ofMillis(-2));
+        assertThrows(IllegalArgumentException.class,
+                () -> Multi.createFrom().range(1, 10).groupItems().intoLists().every(Duration.ofMillis(-2)));
     }
 
     @Test
@@ -141,19 +143,19 @@ public class MultiGroupTest {
         subscriber.cancel();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testGroupIntoMultisWithSize0() {
-        Multi.createFrom().range(1, 5).groupItems().intoMultis().of(0);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5).groupItems().intoMultis().of(0));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testGroupIntoMultisWithSize0AndSkip() {
-        Multi.createFrom().range(1, 5).groupItems().intoMultis().of(0, 1);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5).groupItems().intoMultis().of(0, 1));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testGroupIntoMultisWithSkip0() {
-        Multi.createFrom().range(1, 5).groupItems().intoMultis().of(1, 0);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5).groupItems().intoMultis().of(1, 0));
     }
 
     @Test
@@ -256,9 +258,10 @@ public class MultiGroupTest {
                         .isNull();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testAsMultisWithNegativeDuration() {
-        Multi.createFrom().range(1, 10).groupItems().intoMultis().every(Duration.ofMillis(-2));
+        assertThrows(IllegalArgumentException.class,
+                () -> Multi.createFrom().range(1, 10).groupItems().intoMultis().every(Duration.ofMillis(-2)));
     }
 
     @Test
@@ -350,14 +353,14 @@ public class MultiGroupTest {
         assertThat(numbers).hasSize(9);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testGroupByWithNullKeyMapper() {
-        Multi.createFrom().range(1, 10).groupItems().by(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 10).groupItems().by(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testGroupByWithNullValueMapper() {
-        Multi.createFrom().range(1, 10).groupItems().by(i -> i % 2, null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 10).groupItems().by(i -> i % 2, null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIfEmptyTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIfEmptyTest.java
@@ -1,13 +1,15 @@
 package io.smallrye.mutiny.operators;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
@@ -89,34 +91,34 @@ public class MultiIfEmptyTest {
                 .assertHasNotReceivedAnyItem();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testIfEmptyContinueWithNullItem() {
-        Multi.createFrom().empty()
-                .onCompletion().ifEmpty().continueWith((Integer) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().empty()
+                .onCompletion().ifEmpty().continueWith((Integer) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testIfEmptyContinueWithNullAsIterable() {
-        Multi.createFrom().empty()
-                .onCompletion().ifEmpty().continueWith((Iterable<Integer>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().empty()
+                .onCompletion().ifEmpty().continueWith((Iterable<Integer>) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testIfEmptyContinueWithItemsContainingNullItem() {
-        Multi.createFrom().empty()
-                .onCompletion().ifEmpty().continueWith(1, 2, 3, null, 4, 5);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().empty()
+                .onCompletion().ifEmpty().continueWith(1, 2, 3, null, 4, 5));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testIfEmptyContinueWithIterableContainingNullItem() {
-        Multi.createFrom().empty()
-                .onCompletion().ifEmpty().continueWith(Arrays.asList(1, 2, 3, null, 4, 5));
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().empty()
+                .onCompletion().ifEmpty().continueWith(Arrays.asList(1, 2, 3, null, 4, 5)));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testIfEmptyContinueWithNullSupplier() {
-        Multi.createFrom().empty()
-                .onCompletion().ifEmpty().continueWith((Supplier<? extends Iterable<? extends Integer>>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().empty()
+                .onCompletion().ifEmpty().continueWith((Supplier<? extends Iterable<? extends Integer>>) null));
     }
 
     @Test
@@ -183,11 +185,10 @@ public class MultiIfEmptyTest {
                 .assertHasNotReceivedAnyItem();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testIfEmptyFailWithNullException() {
-        Multi.createFrom().empty()
-                .onCompletion().ifEmpty().failWith((Throwable) null);
-
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().empty()
+                .onCompletion().ifEmpty().failWith((Throwable) null));
     }
 
     @Test
@@ -199,10 +200,10 @@ public class MultiIfEmptyTest {
                 .assertHasNotReceivedAnyItem();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testIfEmptyFailWithNullSupplier() {
-        Multi.createFrom().empty()
-                .onCompletion().ifEmpty().failWith((Supplier<Throwable>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().empty()
+                .onCompletion().ifEmpty().failWith((Supplier<Throwable>) null));
     }
 
     @Test
@@ -250,16 +251,16 @@ public class MultiIfEmptyTest {
                 .assertHasNotReceivedAnyItem();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testSwitchToWithConsumerBeingNull() {
-        Multi.createFrom().empty()
-                .onCompletion().ifEmpty().switchToEmitter(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().empty()
+                .onCompletion().ifEmpty().switchToEmitter(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testSwitchToWithSupplierBeingNull() {
-        Multi.createFrom().empty()
-                .onCompletion().ifEmpty().switchTo((Supplier<Publisher<?>>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().empty()
+                .onCompletion().ifEmpty().switchTo((Supplier<Publisher<?>>) null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIgnoreTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIgnoreTest.java
@@ -1,14 +1,15 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.MultiSubscribers;
@@ -37,18 +38,20 @@ public class MultiIgnoreTest {
         assertThat(future.join()).isNull();
     }
 
-    @Test(expectedExceptions = CompletionException.class, expectedExceptionsMessageRegExp = ".*boom.*")
+    @Test
     public void testAsUniWithFailure() {
-        CompletableFuture<Void> future = Multi.createFrom().items(1, 2, 3, 4)
-                .onItem().transform(i -> {
-                    if (i == 3) {
-                        throw new RuntimeException("boom");
-                    }
-                    return i;
-                })
-                .onItem().ignoreAsUni()
-                .subscribeAsCompletionStage();
-        assertThat(future.join()).isNull();
+        assertThrows(CompletionException.class, () -> {
+            CompletableFuture<Void> future = Multi.createFrom().items(1, 2, 3, 4)
+                    .onItem().transform(i -> {
+                        if (i == 3) {
+                            throw new RuntimeException("boom");
+                        }
+                        return i;
+                    })
+                    .onItem().ignoreAsUni()
+                    .subscribeAsCompletionStage();
+            assertThat(future.join()).isNull();
+        });
     }
 
     @Test
@@ -70,10 +73,12 @@ public class MultiIgnoreTest {
         future.cancel(true);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testSubscriberCannotBeNull() {
-        MultiIgnoreOp<Integer> ignore = new MultiIgnoreOp<>(Multi.createFrom().items(1, 2, 3, 4));
-        ignore.subscribe(null);
+        assertThrows(NullPointerException.class, () -> {
+            MultiIgnoreOp<Integer> ignore = new MultiIgnoreOp<>(Multi.createFrom().items(1, 2, 3, 4));
+            ignore.subscribe(null);
+        });
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiMergeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiMergeTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.CompositeException;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnCancellationInvokeUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnCancellationInvokeUniTest.java
@@ -6,7 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnCompletionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnCompletionTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -10,14 +11,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.test.AssertSubscriber;
 
+@SuppressWarnings("ConstantConditions")
 public class MultiOnCompletionTest {
 
     @Test
@@ -108,34 +111,34 @@ public class MultiOnCompletionTest {
         assertThat(called).isTrue();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testOnCompletionContinueWithNullItem() {
-        Multi.createFrom().range(1, 5)
-                .onCompletion().continueWith((Integer) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5)
+                .onCompletion().continueWith((Integer) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testOnCompletionContinueWithNullAsIterable() {
-        Multi.createFrom().range(1, 5)
-                .onCompletion().continueWith((Iterable<Integer>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5)
+                .onCompletion().continueWith((Iterable<Integer>) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testOnCompletionContinueWithItemsContainingNullItem() {
-        Multi.createFrom().range(1, 5)
-                .onCompletion().continueWith(1, 2, 3, null, 4, 5);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5)
+                .onCompletion().continueWith(1, 2, 3, null, 4, 5));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testOnCompletionContinueWithIterableContainingNullItem() {
-        Multi.createFrom().range(1, 5)
-                .onCompletion().continueWith(Arrays.asList(1, 2, 3, null, 4, 5));
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5)
+                .onCompletion().continueWith(Arrays.asList(1, 2, 3, null, 4, 5)));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testOnCompletionContinueWithNullSupplier() {
-        Multi.createFrom().range(1, 5)
-                .onCompletion().continueWith((Supplier<? extends Iterable<? extends Integer>>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5)
+                .onCompletion().continueWith((Supplier<? extends Iterable<? extends Integer>>) null));
     }
 
     @Test
@@ -203,10 +206,10 @@ public class MultiOnCompletionTest {
                 .assertHasFailedWith(IOException.class, "boom");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testOnCompletionFailWithNullException() {
-        Multi.createFrom().range(1, 5)
-                .onCompletion().failWith((Throwable) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5)
+                .onCompletion().failWith((Throwable) null));
 
     }
 
@@ -219,10 +222,10 @@ public class MultiOnCompletionTest {
                 .assertHasFailedWith(IOException.class, "boom");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testOnCompletionFailWithNullSupplier() {
-        Multi.createFrom().range(1, 5)
-                .onCompletion().failWith((Supplier<Throwable>) null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Multi.createFrom().range(1, 5).onCompletion().failWith((Supplier<Throwable>) null));
     }
 
     @Test
@@ -272,16 +275,16 @@ public class MultiOnCompletionTest {
                 .assertReceived(1, 2, 3, 4);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testSwitchToWithConsumerBeingNull() {
-        Multi.createFrom().range(1, 5)
-                .onCompletion().switchToEmitter(null);
+    @Test
+    public void testSwitchToWithSupplierBeingNull() {
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5)
+                .onCompletion().switchTo((Supplier<Publisher<? extends Integer>>) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testSwitchToWithSupplierBeingNull() {
-        Multi.createFrom().range(1, 5)
-                .onCompletion().switchTo((Supplier<Publisher<? extends Integer>>) null);
+    @Test
+    public void testSwitchToWithConsumerBeingNull() {
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 5)
+                .onCompletion().switchToEmitter(null));
     }
 
     @Test
@@ -377,7 +380,7 @@ public class MultiOnCompletionTest {
         assertThat(counter.get()).isEqualTo(2);
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void rogueEmittersInvoke() {
         AtomicInteger counter = new AtomicInteger();
 
@@ -401,7 +404,7 @@ public class MultiOnCompletionTest {
         assertThat(counter.get()).isEqualTo(1);
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void rogueEmittersInvokeUni() {
         AtomicInteger counter = new AtomicInteger();
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnEventTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnEventTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.List;
@@ -12,8 +13,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
@@ -744,24 +745,24 @@ public class MultiOnEventTest {
         assertThat(res).hasValue(2);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatInvokeConsumerMustNotBeNull() {
-        Multi.createFrom().item(1).onItem().invoke(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).onItem().invoke(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatInvokeUniMapperMustNotBeNull() {
-        Multi.createFrom().item(1).onItem().invokeUni(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).onItem().invokeUni(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatInvokeConsumerMustNotBeNullWithShortcut() {
-        Multi.createFrom().item(1).invoke(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).invoke(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatInvokeUniMapperMustNotBeNullWithShortcut() {
-        Multi.createFrom().item(1).invokeUni(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).invokeUni(null));
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureInvokeUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureInvokeUniTest.java
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryTest.java
@@ -2,13 +2,14 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.groups.MultiRetry;
@@ -19,7 +20,7 @@ public class MultiOnFailureRetryTest {
     private AtomicInteger numberOfSubscriptions;
     private Multi<Integer> failing;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         numberOfSubscriptions = new AtomicInteger();
         failing = Multi.createFrom()
@@ -27,21 +28,21 @@ public class MultiOnFailureRetryTest {
                 .onSubscribe().invoke(s -> numberOfSubscriptions.incrementAndGet());
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatUpstreamCannotBeNull() {
-        new MultiRetry<>(null);
+        assertThrows(IllegalArgumentException.class, () -> new MultiRetry<>(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatTheNumberOfAttemptMustBePositive() {
-        Multi.createFrom().nothing()
-                .onFailure().retry().atMost(-1);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().nothing()
+                .onFailure().retry().atMost(-1));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatTheNumberOfAttemptMustBePositive2() {
-        Multi.createFrom().nothing()
-                .onFailure().retry().atMost(0);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().nothing()
+                .onFailure().retry().atMost(0));
     }
 
     @Test
@@ -123,22 +124,22 @@ public class MultiOnFailureRetryTest {
                 .assertReceived(1, 2, 3, 4);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatYouCannotUseWhenIfBackoffIsConfigured() {
-        Multi.createFrom().item("hello")
-                .onFailure().retry().withBackOff(Duration.ofSeconds(1)).when(t -> Multi.createFrom().item(t));
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item("hello")
+                .onFailure().retry().withBackOff(Duration.ofSeconds(1)).when(t -> Multi.createFrom().item(t)));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatYouCannotUseUntilIfBackoffIsConfigured() {
-        Multi.createFrom().item("hello")
-                .onFailure().retry().withBackOff(Duration.ofSeconds(1)).until(t -> true);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item("hello")
+                .onFailure().retry().withBackOff(Duration.ofSeconds(1)).until(t -> true));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testJitterValidation() {
-        Multi.createFrom().item("hello")
-                .onFailure().retry().withJitter(2);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item("hello")
+                .onFailure().retry().withJitter(2));
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryUntilTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryUntilTest.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureTest.java
@@ -1,13 +1,14 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
@@ -239,16 +240,18 @@ public class MultiOnFailureTest {
                 .assertReceived(2);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testRecoverWithItemWithNull() {
-        Multi.createFrom().<String> failure(new IllegalStateException("boom"))
-                .onFailure().recoverWithItem((String) null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Multi.createFrom().<String> failure(new IllegalStateException("boom"))
+                        .onFailure().recoverWithItem((String) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testRecoverWithItemWithNullSupplier() {
-        Multi.createFrom().<String> failure(new IllegalStateException("boom"))
-                .onFailure().recoverWithItem((Supplier<String>) null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Multi.createFrom().<String> failure(new IllegalStateException("boom"))
+                        .onFailure().recoverWithItem((Supplier<String>) null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnItemTransformTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnItemTransformTest.java
@@ -1,9 +1,11 @@
 package io.smallrye.mutiny.operators;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.MultiMapOp;
@@ -12,14 +14,14 @@ import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiOnItemTransformTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testMapperCannotBeNull() {
-        new MultiMapOp<>(Multi.createFrom().item(1), null);
+        assertThrows(IllegalArgumentException.class, () -> new MultiMapOp<>(Multi.createFrom().item(1), null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testUpstreamCannotBeNull() {
-        new MultiMapOp<>(null, x -> x);
+        assertThrows(IllegalArgumentException.class, () -> new MultiMapOp<>(null, x -> x));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnOverflowTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnOverflowTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.List;
@@ -9,7 +10,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
@@ -18,9 +19,9 @@ import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiOnOverflowTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatDropCallbackCannotBeNull() {
-        Multi.createFrom().item(1).onOverflow().drop(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).onOverflow().drop(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnRequestTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnRequestTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnSubscribeTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
@@ -9,8 +10,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -157,27 +158,28 @@ public class MultiOnSubscribeTest {
                 .assertHasFailedWith(NullPointerException.class, "`null`");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatInvokeConsumerCannotBeNull() {
-        Multi.createFrom().items(1, 2, 3)
-                .onSubscribe().invoke(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().items(1, 2, 3)
+                .onSubscribe().invoke(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatInvokeUniFunctionCannotBeNull() {
-        Multi.createFrom().items(1, 2, 3)
-                .onSubscribe().invokeUni(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().items(1, 2, 3)
+                .onSubscribe().invokeUni(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatInvokeUpstreamCannotBeNull() {
-        new MultiOnSubscribeInvokeOp<>(null, s -> {
-        });
+        assertThrows(IllegalArgumentException.class, () -> new MultiOnSubscribeInvokeOp<>(null, s -> {
+        }));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatInvokeUniUpstreamCannotBeNull() {
-        new MultiOnSubscribeInvokeUniOp<>(null, s -> Uni.createFrom().nullItem());
+        assertThrows(IllegalArgumentException.class,
+                () -> new MultiOnSubscribeInvokeUniOp<>(null, s -> Uni.createFrom().nullItem()));
     }
 
     @Test
@@ -206,7 +208,8 @@ public class MultiOnSubscribeTest {
     public void testThatSubscriptionIsNotPassedDownstreamUntilProducedUniCompletes() {
         AtomicReference<UniEmitter<? super Integer>> emitter = new AtomicReference<>();
         AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3)
-                .onSubscribe().invokeUni(s -> Uni.createFrom().emitter((Consumer<UniEmitter<? super Integer>>) emitter::set))
+                .onSubscribe()
+                .invokeUni(s -> Uni.createFrom().emitter((Consumer<UniEmitter<? super Integer>>) emitter::set))
                 .subscribe().withSubscriber(AssertSubscriber.create(3));
 
         subscriber.assertNotSubscribed();
@@ -224,7 +227,8 @@ public class MultiOnSubscribeTest {
     public void testThatSubscriptionIsNotPassedDownstreamUntilProducedUniCompletesWithDifferentThread() {
         AtomicReference<UniEmitter<? super Integer>> emitter = new AtomicReference<>();
         AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3)
-                .onSubscribe().invokeUni(s -> Uni.createFrom().emitter((Consumer<UniEmitter<? super Integer>>) emitter::set))
+                .onSubscribe()
+                .invokeUni(s -> Uni.createFrom().emitter((Consumer<UniEmitter<? super Integer>>) emitter::set))
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor())
                 .subscribe().withSubscriber(AssertSubscriber.create(3));
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnTerminationUniInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnTerminationUniInvokeTest.java
@@ -8,8 +8,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiReceiveItemOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiReceiveItemOnTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.LinkedHashSet;
@@ -12,9 +13,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;
@@ -23,10 +24,10 @@ public class MultiReceiveItemOnTest {
 
     private ExecutorService executor;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         executor = Executors.newFixedThreadPool(4, new ThreadFactory() {
-            AtomicInteger count = new AtomicInteger();
+            final AtomicInteger count = new AtomicInteger();
 
             @Override
             public Thread newThread(Runnable r) {
@@ -37,24 +38,24 @@ public class MultiReceiveItemOnTest {
         });
     }
 
-    @AfterTest
+    @AfterEach
     public void cleanup() {
         executor.shutdownNow();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatExecutorCannotBeNull() {
-        Multi.createFrom().item(1).emitOn(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).emitOn(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatSubscribeOnExecutorCannotBeNull() {
-        Multi.createFrom().item(1).subscribeOn(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).subscribeOn(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatRunSubscriptionOnExecutorCannotBeNull() {
-        Multi.createFrom().item(1).runSubscriptionOn(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).runSubscriptionOn(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiScanTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiScanTest.java
@@ -1,25 +1,27 @@
 package io.smallrye.mutiny.operators;
 
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;
 
 public class MultiScanTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatSupplierMustNotBeNull() {
-        Multi.createFrom().empty().onItem().scan(null, (a, b) -> a);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().empty().onItem().scan(null, (a, b) -> a));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatScannerMustNotBeNull() {
-        Multi.createFrom().empty().onItem().scan(() -> 1, null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().empty().onItem().scan(() -> 1, null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatScannerMustNotBeNullWithoutSupplier() {
-        Multi.createFrom().empty().onItem().scan(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().empty().onItem().scan(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -9,10 +10,10 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.TestException;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.TestException;
 import io.smallrye.mutiny.operators.multi.MultiSkipUntilPublisherOp;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.test.AssertSubscriber;
@@ -151,9 +152,10 @@ public class MultiSkipTest {
                 .assertHasFailedWith(IOException.class, "boom");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testSkipWhileWithNullMethod() {
-        Multi.createFrom().nothing().transform().bySkippingItemsWhile(null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Multi.createFrom().nothing().transform().bySkippingItemsWhile(null));
     }
 
     @Test
@@ -209,9 +211,10 @@ public class MultiSkipTest {
                 .assertHasNotReceivedAnyItem();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testSkipByTimeWithInvalidDuration() {
-        Multi.createFrom().item(1).transform().bySkippingItemsFor(Duration.ofMillis(-1));
+        assertThrows(IllegalArgumentException.class,
+                () -> Multi.createFrom().item(1).transform().bySkippingItemsFor(Duration.ofMillis(-1)));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSubscribeTest.java
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.Cancellable;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTakeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTakeTest.java
@@ -2,13 +2,14 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiEmitter;
@@ -148,9 +149,9 @@ public class MultiTakeTest {
                 .assertHasFailedWith(IOException.class, "boom");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testTakeWhileWithNullMethod() {
-        Multi.createFrom().nothing().transform().byTakingItemsWhile(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().nothing().transform().byTakingItemsWhile(null));
     }
 
     @Test
@@ -218,9 +219,10 @@ public class MultiTakeTest {
         assertThat(subscriber.items()).hasSize(10);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testSkipByTimeWithInvalidDuration() {
-        Multi.createFrom().item(1).transform().byTakingItemsFor(Duration.ofMillis(-1));
+        assertThrows(IllegalArgumentException.class,
+                () -> Multi.createFrom().item(1).transform().byTakingItemsFor(Duration.ofMillis(-1)));
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiToUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiToUniTest.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformByMergingTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformByMergingTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -8,9 +9,9 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-import org.testng.annotations.Ignore;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.test.AssertSubscriber;
@@ -37,26 +38,26 @@ public class MultiTransformByMergingTest {
         assertThat(list).hasSize(13);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testMergingWithNull() {
-        Multi.createFrom().item(1).transform()
-                .byMergingWith(Multi.createFrom().item(2), null, Multi.createFrom().item(3));
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testMergingWithIterableContainingNull() {
-        Multi.createFrom().item(1).transform()
-                .byMergingWith(Arrays.asList(Multi.createFrom().item(2), null, Multi.createFrom().item(3)));
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testMergingWithNullIterable() {
-        Multi.createFrom().item(1).transform()
-                .byMergingWith((Iterable<Publisher<Integer>>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).transform()
+                .byMergingWith(Multi.createFrom().item(2), null, Multi.createFrom().item(3)));
     }
 
     @Test
-    @Ignore("this test is failing on CI - must be investigated")
+    public void testMergingWithIterableContainingNull() {
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).transform()
+                .byMergingWith(Arrays.asList(Multi.createFrom().item(2), null, Multi.createFrom().item(3))));
+    }
+
+    @Test
+    public void testMergingWithNullIterable() {
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).transform()
+                .byMergingWith((Iterable<Publisher<Integer>>) null));
+    }
+
+    @Test
+    @Disabled("this test is failing on CI - must be investigated")
     public void testConcurrentEmissionWithMerge() {
         ExecutorService service = Executors.newFixedThreadPool(10);
         Multi<Integer> m1 = Multi.createFrom().range(1, 100).emitOn(service);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToMultiTest.java
@@ -2,9 +2,8 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -17,8 +16,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscriber;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
@@ -87,7 +88,8 @@ public class MultiTransformToMultiTest {
         subscriber.assertReceived(1, 1, 2, 2, 3, 3).assertCompletedSuccessfully();
     }
 
-    @Test(timeOut = 60000)
+    @Test
+    @Timeout(60)
     public void testConcatMapWithLotsOfItems() {
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
@@ -108,7 +110,8 @@ public class MultiTransformToMultiTest {
         }
     }
 
-    @Test(timeOut = 60000)
+    @Test
+    @Timeout(60)
     public void testConcatMapWithLotsOfItemsAndFailurePropagation() {
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
@@ -129,7 +132,8 @@ public class MultiTransformToMultiTest {
         }
     }
 
-    @Test(timeOut = 60000)
+    @Test
+    @Timeout(60)
     public void testConcatMapWithLotsOfItemsAndFailuresAndFailurePropagation() {
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
@@ -157,7 +161,8 @@ public class MultiTransformToMultiTest {
         }
     }
 
-    @Test(timeOut = 60000)
+    @Test
+    @Timeout(60)
     public void testConcatMapWithLotsOfItemsAndFailuresWithoutFailurePropagation() {
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
@@ -419,11 +424,11 @@ public class MultiTransformToMultiTest {
         assertThat(subscriber.items()).hasSize(20000);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testTransformToMultiWithInvalidConcurrency() {
-        Multi.createFrom().range(1, 10001)
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, 10001)
                 .onItem().transformToMulti(i -> Multi.createFrom().items(i, i))
-                .merge(-1);
+                .merge(-1));
     }
 
     @Test
@@ -757,7 +762,7 @@ public class MultiTransformToMultiTest {
         verify(subscriber).onError(any(IllegalArgumentException.class));
     }
 
-    @Test(invocationCount = 10)
+    @RepeatedTest(10)
     public void testMaxConcurrency() {
         final int maxConcurrency = 4;
         final AtomicInteger subscriptionTracker = new AtomicInteger();
@@ -829,7 +834,7 @@ public class MultiTransformToMultiTest {
         verify(mock, never()).onError(any(Throwable.class));
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(10)
     public void testThatConcurrencyDontMissItems() {
         int max = 10000;
         List<Integer> expected = Multi.createFrom().range(0, max).collectItems().asList().await().indefinitely();
@@ -845,7 +850,7 @@ public class MultiTransformToMultiTest {
         assertThat(subscriber.items()).containsExactlyInAnyOrderElementsOf(expected);
     }
 
-    @Test(invocationCount = 10)
+    @RepeatedTest(10)
     public void testThatConcatenateDontMissItemsAndPreserveOrder() {
         int max = 10000;
         List<Integer> expected = Multi.createFrom().range(0, max).collectItems().asList().await().indefinitely();
@@ -861,7 +866,7 @@ public class MultiTransformToMultiTest {
         assertThat(subscriber.items()).containsExactlyElementsOf(expected);
     }
 
-    @Test(invocationCount = 10)
+    @RepeatedTest(10)
     public void testFlatMapSimplePassThroughWithExecutor() {
         AssertSubscriber<Integer> subscriber = Multi.createFrom().range(1, 1001)
                 .flatMap(i -> Multi.createFrom().item(i).runSubscriptionOn(Infrastructure.getDefaultExecutor()))
@@ -871,7 +876,7 @@ public class MultiTransformToMultiTest {
         assertThat(subscriber.items()).hasSize(1000);
     }
 
-    @Test(invocationCount = 10)
+    @RepeatedTest(10)
     public void testFlatMapSimplePassThroughWithoutExecutor() {
         AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2)
                 .flatMap(i -> Multi.createFrom().items(i + 1, i + 2))

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToUniTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAndTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAndTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -9,7 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.TimeoutException;
@@ -40,13 +41,15 @@ public class UniAndTest {
         subscriber.assertFailure(IOException.class, "boom");
     }
 
-    @Test(expectedExceptions = TimeoutException.class)
+    @Test
     public void testWithNever() {
-        Uni<Tuple3<Integer, Integer, Object>> tuple = Uni.combine().all().unis(
-                Uni.createFrom().item(1),
-                Uni.createFrom().item(2),
-                Uni.createFrom().nothing()).asTuple();
-        tuple.await().atMost(Duration.ofMillis(1000));
+        assertThrows(TimeoutException.class, () -> {
+            Uni<Tuple3<Integer, Integer, Object>> tuple = Uni.combine().all().unis(
+                    Uni.createFrom().item(1),
+                    Uni.createFrom().item(2),
+                    Uni.createFrom().nothing()).asTuple();
+            tuple.await().atMost(Duration.ofMillis(100));
+        });
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -9,24 +10,28 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 
 public class UniAwaitTest {
 
-    @Test(timeOut = 1000)
+    @Test
+    @Timeout(1)
     public void testAwaitingOnAnAlreadyResolvedUni() {
         assertThat(Uni.createFrom().item(1).await().indefinitely()).isEqualTo(1);
     }
 
-    @Test(timeOut = 100)
+    @Test
+    @Timeout(10)
     public void testAwaitingOnAnAlreadyResolvedWitNullUni() {
         assertThat(Uni.createFrom().item((Object) null).await().indefinitely()).isNull();
     }
 
-    @Test(timeOut = 100)
+    @Test
+    @Timeout(10)
     public void testAwaitingOnAnAlreadyFailedUni() {
         try {
             Uni.createFrom().failure(new IOException("boom")).await().indefinitely();
@@ -36,14 +41,16 @@ public class UniAwaitTest {
         }
     }
 
-    @Test(timeOut = 1000)
+    @Test
+    @Timeout(10)
     public void testAwaitingOnAnAsyncUni() {
         assertThat(
                 Uni.createFrom().emitter(emitter -> new Thread(() -> emitter.complete(1)).start()).await()
                         .indefinitely()).isEqualTo(1);
     }
 
-    @Test(timeOut = 1000)
+    @Test
+    @Timeout(10)
     public void testAwaitingOnAnAsyncFailingUni() {
         try {
             Uni.createFrom().emitter(emitter -> new Thread(() -> emitter.fail(new IOException("boom"))).start()).await()
@@ -54,17 +61,20 @@ public class UniAwaitTest {
         }
     }
 
-    @Test(timeOut = 100)
+    @Test
+    @Timeout(10)
     public void testAwaitWithTimeOut() {
         assertThat(Uni.createFrom().item(1).await().atMost(Duration.ofMillis(1000))).isEqualTo(1);
     }
 
-    @Test(timeOut = 100, expectedExceptions = TimeoutException.class)
+    @Test
+    @Timeout(10)
     public void testTimeout() {
-        Uni.createFrom().nothing().await().atMost(Duration.ofMillis(10));
+        assertThrows(TimeoutException.class, () -> Uni.createFrom().nothing().await().atMost(Duration.ofMillis(10)));
     }
 
-    @Test(timeOut = 5000)
+    @Test
+    @Timeout(5)
     public void testInterruptedTimeout() {
         AtomicBoolean awaiting = new AtomicBoolean();
         AtomicReference<RuntimeException> exception = new AtomicReference<>();
@@ -115,9 +125,11 @@ public class UniAwaitTest {
                         .atMost(Duration.ofMillis(1000))).contains(1);
     }
 
-    @Test(timeOut = 100, expectedExceptions = TimeoutException.class)
+    @Test
+    @Timeout(1)
     public void testTimeoutAndOptional() {
-        Uni.createFrom().nothing().await().asOptional().atMost(Duration.ofMillis(10));
+        assertThrows(TimeoutException.class,
+                () -> Uni.createFrom().nothing().await().asOptional().atMost(Duration.ofMillis(10)));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCacheTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCacheTest.java
@@ -1,5 +1,7 @@
 package io.smallrye.mutiny.operators;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -11,7 +13,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.reactivex.Flowable;
 import io.reactivex.processors.UnicastProcessor;
@@ -69,9 +71,9 @@ public class UniCacheTest {
         }
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatSourceCannotBeNull() {
-        new UniCache<>(null);
+        assertThrows(IllegalArgumentException.class, () -> new UniCache<>(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromCompletionStageTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -9,7 +10,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
@@ -214,14 +215,15 @@ public class UniCreateFromCompletionStageTest {
         subscriber.assertItem(1);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatCompletionStageCannotBeNull() {
-        Uni.createFrom().completionStage((CompletionStage<Void>) null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().completionStage((CompletionStage<Void>) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatCompletionStageSupplierCannotBeNull() {
-        Uni.createFrom().completionStage((Supplier<CompletionStage<Void>>) null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Uni.createFrom().completionStage((Supplier<CompletionStage<Void>>) null));
     }
 
     @Test
@@ -282,16 +284,16 @@ public class UniCreateFromCompletionStageTest {
         s2.assertFailure(IllegalStateException.class, "Invalid shared state");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatStateSupplierCannotBeNull() {
-        Uni.createFrom().completionStage(null,
-                x -> CompletableFuture.completedFuture("x"));
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().completionStage(null,
+                x -> CompletableFuture.completedFuture("x")));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFunctionCannotBeNull() {
-        Uni.createFrom().completionStage(() -> "hello",
-                null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().completionStage(() -> "hello",
+                null));
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplierTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromDeferredSupplierTest.java
@@ -1,11 +1,12 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
@@ -21,9 +22,9 @@ public class UniCreateFromDeferredSupplierTest {
         }
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testWithNull() {
-        Uni.createFrom().deferred(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().deferred(null));
     }
 
     @Test
@@ -93,16 +94,16 @@ public class UniCreateFromDeferredSupplierTest {
         s2.assertFailure(IllegalStateException.class, "Invalid shared state");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatStateSupplierCannotBeNull() {
-        Uni.createFrom().deferred(null,
-                x -> Uni.createFrom().item("x"));
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().deferred(null,
+                x -> Uni.createFrom().item("x")));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFunctionCannotBeNull() {
-        Uni.createFrom().deferred(() -> "hello",
-                null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().deferred(() -> "hello",
+                null));
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromEmitterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromEmitterTest.java
@@ -1,7 +1,8 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -9,7 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniEmitter;
@@ -17,9 +18,9 @@ import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
 
 public class UniCreateFromEmitterTest {
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatConsumerCannotBeNull() {
-        Uni.createFrom().emitter(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().emitter(null));
     }
 
     @SuppressWarnings("rawtypes")
@@ -257,16 +258,16 @@ public class UniCreateFromEmitterTest {
         s2.assertFailure(IllegalStateException.class, "Invalid shared state");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatStateSupplierCannotBeNull() {
-        Uni.createFrom().emitter(null,
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().emitter(null,
                 (x, emitter) -> {
-                });
+                }));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFunctionCannotBeNull() {
-        Uni.createFrom().emitter(() -> "hello",
-                null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().emitter(() -> "hello",
+                null));
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromFailureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromFailureTest.java
@@ -2,12 +2,14 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
@@ -55,18 +57,17 @@ public class UniCreateFromFailureTest {
                     .hasMessage("boom");
             return;
         }
-        fail("Exception expected");
-
+        Assertions.fail("Exception expected");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testCreationWithNull() {
-        Uni.createFrom().failure((Throwable) null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().failure((Throwable) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testCreationWithNullAsSupplier() {
-        Uni.createFrom().failure((Supplier<Throwable>) null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().failure((Supplier<Throwable>) null));
     }
 
     @Test
@@ -78,7 +79,7 @@ public class UniCreateFromFailureTest {
             assertThat(e).isInstanceOf(NullPointerException.class);
             return;
         }
-        fail("Exception expected");
+        Assertions.fail("Exception expected");
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromItemTest.java
@@ -1,13 +1,14 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
@@ -35,9 +36,10 @@ public class UniCreateFromItemTest {
     }
 
     @SuppressWarnings({ "OptionalAssignedToNull", "unchecked", "rawtypes" })
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatNullIfNotAcceptedByFromOptional() {
-        Uni.createFrom().optional((Optional) null); // Immediate failure, no need for subscription
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().optional((Optional) null) // Immediate failure, no need for subscription
+        );
     }
 
     @Test
@@ -157,16 +159,16 @@ public class UniCreateFromItemTest {
         s2.assertFailure(IllegalStateException.class, "Invalid shared state");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatStateSupplierCannotBeNull() {
-        Uni.createFrom().item(null,
-                x -> "x");
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(null,
+                x -> "x"));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFunctionCannotBeNull() {
-        Uni.createFrom().item(() -> "hello",
-                null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(() -> "hello",
+                null));
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniFromPublisherTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniFromPublisherTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniGenericHintTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniGenericHintTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 import java.util.Optional;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
@@ -9,7 +9,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniNeverTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniNeverTest.java
@@ -1,6 +1,6 @@
 package io.smallrye.mutiny.operators;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
@@ -10,8 +10,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
@@ -711,7 +712,7 @@ public class UniOnEventTest {
         assertThat(count).hasValue(1);
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void testOnCancellationInvokeUniWithDoubleCancellation() throws InterruptedException {
         AtomicBoolean emitterTerminationCalled = new AtomicBoolean();
         AtomicBoolean cancellationUniCalled = new AtomicBoolean();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureInvokeTest.java
@@ -2,13 +2,14 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
@@ -19,14 +20,14 @@ public class UniOnFailureInvokeTest {
     private static final IOException BOOM = new IOException("boom");
     private final Uni<Integer> failure = Uni.createFrom().failure(BOOM);
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatConsumeMustNotBeNull() {
-        Uni.createFrom().item(1).onFailure().invoke(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onFailure().invoke(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatFunctionMustNotBeNull() {
-        Uni.createFrom().item(1).onFailure().invokeUni(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onFailure().invokeUni(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRecoveryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRecoveryTest.java
@@ -2,13 +2,14 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
@@ -17,7 +18,7 @@ public class UniOnFailureRecoveryTest {
 
     private Uni<Integer> failed;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         failed = Uni.createFrom().failure(IOException::new);
     }
@@ -106,10 +107,11 @@ public class UniOnFailureRecoveryTest {
         assertThat(value).isEqualTo(null);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testRecoverWithUniFail() {
-        failed.onFailure().recoverWithUni(Uni.createFrom().failure(IllegalArgumentException::new)).await()
-                .indefinitely();
+        assertThrows(IllegalArgumentException.class,
+                () -> failed.onFailure().recoverWithUni(Uni.createFrom().failure(IllegalArgumentException::new)).await()
+                        .indefinitely());
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRetryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRetryTest.java
@@ -1,21 +1,23 @@
 package io.smallrye.mutiny.operators;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
 public class UniOnFailureRetryTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testInvalidNumberOfAttempts() {
-        Uni.createFrom().nothing().onFailure().retry().atMost(-10);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().nothing().onFailure().retry().atMost(-10));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testInvalidNumberOfAttemptsWithZero() {
-        Uni.createFrom().nothing().onFailure().retry().atMost(0);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().nothing().onFailure().retry().atMost(0));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRetryUntilTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRetryUntilTest.java
@@ -1,14 +1,16 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
+import io.smallrye.mutiny.TestException;
 import io.smallrye.mutiny.Uni;
 
 public class UniOnFailureRetryUntilTest {
@@ -52,14 +54,14 @@ public class UniOnFailureRetryUntilTest {
         assertThat(result).isEqualTo(1);
     }
 
-    @Test(expectedExceptions = Exception.class, expectedExceptionsMessageRegExp = ".*boom.*")
+    @Test
     public void testTwoRetriesAndGiveUp() {
-        Uni<Integer> upstream = Uni.createFrom().emitter(em -> {
-            em.fail(new Exception("boom"));
+        assertThrows(TestException.class, () -> {
+            Uni<Integer> upstream = Uni.createFrom().emitter(em -> em.fail(new TestException("boom")));
+            upstream
+                    .onFailure().retry().until(retryTwice)
+                    .await().indefinitely();
         });
-        upstream
-                .onFailure().retry().until(retryTwice)
-                .await().indefinitely();
     }
 
     @Test
@@ -78,90 +80,97 @@ public class UniOnFailureRetryUntilTest {
         assertThat(result).isEqualTo(2);
     }
 
-    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*kaboom.*")
+    @Test
     public void testRetryOnSpecificExceptionAndNotOther() {
-        final IOException exception = new IOException("boom");
-        final IllegalStateException ise = new IllegalStateException("kaboom");
+        assertThrows(IllegalStateException.class, () -> {
+            final IOException exception = new IOException("boom");
+            final IllegalStateException ise = new IllegalStateException("kaboom");
 
-        AtomicInteger count = new AtomicInteger();
-        Uni<Integer> upstream = Uni.createFrom().emitter(em -> {
-            int attempt = count.incrementAndGet();
-            if (attempt == 1) {
-                em.fail(exception);
-            }
-            em.fail(ise);
+            AtomicInteger count = new AtomicInteger();
+            Uni<Integer> upstream = Uni.createFrom().emitter(em -> {
+                int attempt = count.incrementAndGet();
+                if (attempt == 1) {
+                    em.fail(exception);
+                }
+                em.fail(ise);
+            });
+
+            upstream
+                    .onFailure().retry().until(retryOnIoException)
+                    .await().indefinitely();
         });
-
-        upstream
-                .onFailure().retry().until(retryOnIoException)
-                .await().indefinitely();
     }
 
-    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*boom.*")
+    @Test
     public void testWithPredicateThrowingException() {
-        AtomicInteger count = new AtomicInteger();
-        Uni<Integer> upstream = Uni.createFrom().emitter(em -> {
-            int i = count.incrementAndGet();
-            if (i == 1) {
-                em.fail(new Exception("boom"));
-                return;
-            }
-            em.complete(3);
-        });
+        assertThrows(IllegalStateException.class, () -> {
+            AtomicInteger count = new AtomicInteger();
+            Uni<Integer> upstream = Uni.createFrom().emitter(em -> {
+                int i = count.incrementAndGet();
+                if (i == 1) {
+                    em.fail(new Exception("boom"));
+                    return;
+                }
+                em.complete(3);
+            });
 
-        upstream
-                .onFailure().retry().until(t -> {
-                    throw new IllegalStateException("boom");
-                })
-                .await().indefinitely();
+            upstream
+                    .onFailure().retry().until(t -> {
+                        throw new IllegalStateException("boom");
+                    })
+                    .await().indefinitely();
+        });
     }
 
-    @Test(expectedExceptions = Exception.class, expectedExceptionsMessageRegExp = ".*boom.*")
+    @Test
     public void testWithPredicateReturningFalse() {
-        AtomicInteger count = new AtomicInteger();
-        Uni<Integer> upstream = Uni.createFrom().emitter(em -> {
-            int i = count.incrementAndGet();
-            if (i == 1) {
-                em.fail(new Exception("boom"));
-                return;
-            }
-            em.complete(2);
-        });
+        assertThrows(TestException.class, () -> {
+            AtomicInteger count = new AtomicInteger();
+            Uni<Integer> upstream = Uni.createFrom().emitter(em -> {
+                int i = count.incrementAndGet();
+                if (i == 1) {
+                    em.fail(new TestException("boom"));
+                    return;
+                }
+                em.complete(2);
+            });
 
-        upstream
-                .onFailure().retry().until(t -> false)
-                .await().indefinitely();
+            upstream
+                    .onFailure().retry().until(t -> false)
+                    .await().indefinitely();
+        });
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*kaboom.*")
+    @Test
     public void testWithPredicateThrowException() {
-        AtomicInteger count = new AtomicInteger();
-        Uni<Integer> upstream = Uni.createFrom().emitter(em -> {
-            int i = count.incrementAndGet();
-            if (i == 1) {
-                em.fail(new Exception("boom"));
-                return;
-            }
-            em.complete(2);
+        assertThrows(RuntimeException.class, () -> {
+            AtomicInteger count = new AtomicInteger();
+            Uni<Integer> upstream = Uni.createFrom().emitter(em -> {
+                int i = count.incrementAndGet();
+                if (i == 1) {
+                    em.fail(new Exception("boom"));
+                    return;
+                }
+                em.complete(2);
+            });
+            upstream
+                    .onFailure().retry().until(t -> {
+                        throw new RuntimeException("kaboom");
+                    })
+                    .await().indefinitely();
         });
-
-        upstream
-                .onFailure().retry().until(t -> {
-                    throw new RuntimeException("kaboom");
-                })
-                .await().indefinitely();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testJitterValidation() {
-        Uni.createFrom().item(1)
-                .onFailure().retry().withJitter(2);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1)
+                .onFailure().retry().withJitter(2));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatYouCannotUseUntilIfBackoffIsConfigured() {
-        Uni.createFrom().item("hello")
-                .onFailure().retry().withBackOff(Duration.ofSeconds(1)).until(t -> true);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item("hello")
+                .onFailure().retry().withBackOff(Duration.ofSeconds(1)).until(t -> true));
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureTransformTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureTransformTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
@@ -11,8 +12,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
@@ -22,19 +23,21 @@ public class UniOnFailureTransformTest {
 
     private Uni<Integer> failure;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         failure = Uni.createFrom().failure(new IOException("boom"));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatMapperMustNotBeNull() {
-        Uni.createFrom().item(1).onFailure().transform(null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Uni.createFrom().item(1).onFailure().transform(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatSourceMustNotBeNull() {
-        new UniOnFailureTransform<>(null, t -> true, Function.identity());
+        assertThrows(IllegalArgumentException.class,
+                () -> new UniOnFailureTransform<>(null, t -> true, Function.identity()));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayTest.java
@@ -2,22 +2,17 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
@@ -27,7 +22,7 @@ public class UniOnItemDelayTest {
 
     private Uni<Void> delayed;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         executor = Executors.newScheduledThreadPool(4);
         delayed = Uni.createFrom().voidItem().onItem().delayIt()
@@ -35,14 +30,14 @@ public class UniOnItemDelayTest {
                 .by(Duration.ofMillis(100));
     }
 
-    @AfterMethod
+    @AfterEach
     public void shutdown() {
         executor.shutdown();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testWithNullDuration() {
-        Uni.createFrom().item(1).onItem().delayIt().by(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onItem().delayIt().by(null));
     }
 
     @Test
@@ -62,18 +57,18 @@ public class UniOnItemDelayTest {
         assertThat(subscriber.getOnItemThreadName()).isNotEqualTo(Thread.currentThread().getName());
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testWithNegativeDuration() {
-        Uni.createFrom().item(1).onItem().delayIt()
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onItem().delayIt()
                 .onExecutor(executor)
-                .by(Duration.ofDays(-1));
+                .by(Duration.ofDays(-1)));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testWithZeroAsDuration() {
-        Uni.createFrom().item(1).onItem().delayIt()
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onItem().delayIt()
                 .onExecutor(executor)
-                .by(Duration.ZERO);
+                .by(Duration.ZERO));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDisjointTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDisjointTest.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemFailTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemFailTest.java
@@ -1,19 +1,21 @@
 package io.smallrye.mutiny.operators;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
 public class UniOnItemFailTest {
 
-    private Uni<Integer> one = Uni.createFrom().item(1);
+    private final Uni<Integer> one = Uni.createFrom().item(1);
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatMapperCannotBeNull() {
-        one.onItem().failWith(null);
+        assertThrows(IllegalArgumentException.class, () -> one.onItem().failWith(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemIgnoreTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemIgnoreTest.java
@@ -1,16 +1,18 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import org.assertj.core.api.Assertions;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
+@SuppressWarnings("ConstantConditions")
 public class UniOnItemIgnoreTest {
 
     @Test
@@ -19,11 +21,11 @@ public class UniOnItemIgnoreTest {
                 .onItem().ignore().andContinueWithNull().await().indefinitely()).isNull();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testIgnoreOnFailure() {
-        Uni.createFrom().item(24).map(i -> {
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(24).map(i -> {
             throw new IllegalArgumentException("BOOM");
-        }).onItem().ignore().andContinueWithNull().await().indefinitely();
+        }).onItem().ignore().andContinueWithNull().await().indefinitely());
     }
 
     @Test
@@ -35,7 +37,8 @@ public class UniOnItemIgnoreTest {
 
     @Test
     public void testIgnoreAndFailWith() {
-        UniAssertSubscriber<Integer> subscriber = Uni.createFrom().item(22).onItem().ignore().andFail(new IOException("boom"))
+        UniAssertSubscriber<Integer> subscriber = Uni.createFrom().item(22).onItem().ignore()
+                .andFail(new IOException("boom"))
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
         subscriber.assertFailure(IOException.class, "boom");
@@ -52,14 +55,16 @@ public class UniOnItemIgnoreTest {
         s2.assertFailure(IOException.class, "boom 2");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testIgnoreAndFailWithWithNullFailure() {
-        Uni.createFrom().item(22).onItem().ignore().andFail((Exception) null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Uni.createFrom().item(22).onItem().ignore().andFail((Exception) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testIgnoreAndFailWithWithNullSupplier() {
-        Uni.createFrom().item(22).onItem().ignore().andFail((Supplier<Throwable>) null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Uni.createFrom().item(22).onItem().ignore().andFail((Supplier<Throwable>) null));
     }
 
     @Test
@@ -78,7 +83,8 @@ public class UniOnItemIgnoreTest {
 
     @Test
     public void testIgnoreAndContinueWithValueSupplierReturningNull() {
-        Assertions.assertThat(Uni.createFrom().item(24).onItem().ignore().andContinueWith(() -> null).await().indefinitely())
+        Assertions.assertThat(
+                Uni.createFrom().item(24).onItem().ignore().andContinueWith(() -> null).await().indefinitely())
                 .isEqualTo(null);
     }
 
@@ -100,13 +106,15 @@ public class UniOnItemIgnoreTest {
         assertThat(uni.await().indefinitely()).isEqualTo(2);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testIgnoreAndSwitchToNullSupplier() {
-        Uni.createFrom().item(22).onItem().ignore().andSwitchTo((Supplier<Uni<?>>) null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Uni.createFrom().item(22).onItem().ignore().andSwitchTo((Supplier<Uni<?>>) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testIgnoreAndSwitchToNull() {
-        Uni.createFrom().item(22).onItem().ignore().andSwitchTo((Uni<?>) null);
+        assertThrows(IllegalArgumentException.class,
+                () -> Uni.createFrom().item(22).onItem().ignore().andSwitchTo((Uni<?>) null));
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemInvokeTest.java
@@ -2,13 +2,14 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.Cancellable;
@@ -19,24 +20,24 @@ public class UniOnItemInvokeTest {
     private final Uni<Integer> failed = Uni.createFrom().failure(new IOException("boom"));
     private final Uni<Integer> two = Uni.createFrom().item(2);
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatConsumerMustNotBeNull() {
-        Uni.createFrom().item(1).onItem().invoke(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onItem().invoke(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatMapperMustNotBeNull() {
-        Uni.createFrom().item(1).onItem().invokeUni(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onItem().invokeUni(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatConsumerMustNotBeNullWithShortcut() {
-        Uni.createFrom().item(1).invoke(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).invoke(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatMapperMustNotBeNullWithShortcut() {
-        Uni.createFrom().item(1).invokeUni(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).invokeUni(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureInvokeTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
@@ -10,7 +11,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
@@ -23,19 +24,19 @@ public class UniOnItemOrFailureInvokeTest {
     private final Uni<Void> none = Uni.createFrom().nullItem();
     private final Uni<Integer> failed = Uni.createFrom().failure(new IOException("boom"));
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatCallbackMustNotBeNull() {
-        Uni.createFrom().item(1).onItemOrFailure().invoke(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onItemOrFailure().invoke(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatSourceMustNotBeNull() {
-        new UniOnItemOrFailureMap<>(null, (x, f) -> x);
+        assertThrows(IllegalArgumentException.class, () -> new UniOnItemOrFailureMap<>(null, (x, f) -> x));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatCallbackMustNotBeNullWithInvokeUni() {
-        Uni.createFrom().item(1).onItemOrFailure().invokeUni(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onItemOrFailure().invokeUni(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureMapTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureMapTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
@@ -8,7 +9,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
@@ -20,14 +21,14 @@ public class UniOnItemOrFailureMapTest {
     private final Uni<Void> none = Uni.createFrom().nullItem();
     private final Uni<Integer> failed = Uni.createFrom().failure(new IOException("boom"));
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatMapperMustNotBeNull() {
-        Uni.createFrom().item(1).onItemOrFailure().transform(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onItemOrFailure().transform(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatSourceMustNotBeNull() {
-        new UniOnItemOrFailureMap<>(null, (x, f) -> x);
+        assertThrows(IllegalArgumentException.class, () -> new UniOnItemOrFailureMap<>(null, (x, f) -> x));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemProduceCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemProduceCompletionStageTest.java
@@ -1,11 +1,12 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
@@ -91,9 +92,9 @@ public class UniOnItemProduceCompletionStageTest {
         assertThat(called).isTrue();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatTheMapperCannotBeNull() {
-        Uni.createFrom().item(1).onItem().produceCompletionStage(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onItem().produceCompletionStage(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -10,7 +11,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniEmitter;
@@ -19,14 +20,14 @@ public class UniOnItemTransformTest {
 
     private final Uni<Integer> one = Uni.createFrom().item(1);
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatMapperMustNotBeNull() {
-        Uni.createFrom().item(1).map(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).map(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatSourceMustNotBeNull() {
-        new UniOnItemTransform<>(null, Function.identity());
+        assertThrows(IllegalArgumentException.class, () -> new UniOnItemTransform<>(null, Function.identity()));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToMultiTest.java
@@ -1,11 +1,12 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -14,10 +15,12 @@ import io.smallrye.mutiny.test.AssertSubscriber;
 @SuppressWarnings("ConstantConditions")
 public class UniOnItemTransformToMultiTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testTransformToMultiWithNullMapper() {
-        Uni<Integer> uni = Uni.createFrom().item(1);
-        uni.onItem().transformToMulti(null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Uni<Integer> uni = Uni.createFrom().item(1);
+            uni.onItem().transformToMulti(null);
+        });
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToUniWithEmitterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToUniWithEmitterTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -8,7 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniEmitter;
@@ -108,9 +109,10 @@ public class UniOnItemTransformToUniWithEmitterTest {
         assertThat(called).isTrue();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatTheMapperCannotBeNull() {
-        Uni.createFrom().item(1).onItem().transformToUni((BiConsumer<Integer, UniEmitter<? super Integer>>) null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onItem()
+                .transformToUni((BiConsumer<Integer, UniEmitter<? super Integer>>) null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNotNullItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNotNullItemTest.java
@@ -6,7 +6,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNullContinueWithTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNullContinueWithTest.java
@@ -2,12 +2,13 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
@@ -49,40 +50,46 @@ public class UniOnNullContinueWithTest {
 
     @Test
     public void testContinueNotCalledOnFailure() {
-        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> Uni.createFrom().failure(new IOException("boom"))
-                .onItem().castTo(Integer.class)
-                .onItem().ifNull().continueWith(42)
-                .await().indefinitely()).withCauseExactlyInstanceOf(IOException.class).withMessageEndingWith("boom");
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> Uni.createFrom().failure(new IOException("boom"))
+                        .onItem().castTo(Integer.class)
+                        .onItem().ifNull().continueWith(42)
+                        .await().indefinitely())
+                .withCauseExactlyInstanceOf(IOException.class)
+                .withMessageEndingWith("boom");
     }
 
     @Test
     public void testContinueWithSupplierNotCalledOnFailure() {
-        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> Uni.createFrom().failure(new IOException("boom"))
-                .onItem().castTo(Integer.class)
-                .onItem().ifNull().continueWith(() -> 42)
-                .await().indefinitely()).withCauseExactlyInstanceOf(IOException.class).withMessageEndingWith("boom");
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> Uni.createFrom().failure(new IOException("boom"))
+                        .onItem().castTo(Integer.class)
+                        .onItem().ifNull().continueWith(() -> 42)
+                        .await().indefinitely())
+                .withCauseExactlyInstanceOf(IOException.class)
+                .withMessageEndingWith("boom");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatContinueWithCannotUseNull() {
-        Uni.createFrom().item(23)
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(23)
                 .onItem().castTo(Integer.class)
-                .onItem().ifNull().continueWith((Integer) null);
+                .onItem().ifNull().continueWith((Integer) null));
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testThatContinueWithSupplierCannotReturnNull() {
-        Uni.createFrom().item(23)
+        assertThrows(NullPointerException.class, () -> Uni.createFrom().item(23)
                 .map(x -> null)
                 .onItem().ifNull().continueWith(() -> null)
-                .await().indefinitely();
+                .await().indefinitely());
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatContinueWithSupplierCannotBeNull() {
-        Uni.createFrom().item(23)
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(23)
                 .onItem().castTo(Integer.class)
-                .onItem().ifNull().continueWith((Supplier<Integer>) null);
+                .onItem().ifNull().continueWith((Supplier<Integer>) null));
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNullFailTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNullFailTest.java
@@ -2,22 +2,23 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
 public class UniOnNullFailTest {
 
-    @Test(expectedExceptions = NoSuchElementException.class)
+    @Test
     public void testFail() {
-        Uni.createFrom().item((Object) null)
-                .onItem().ifNull().fail().await().indefinitely();
+        assertThrows(NoSuchElementException.class, () -> Uni.createFrom().item((Object) null)
+                .onItem().ifNull().fail().await().indefinitely());
     }
 
     @Test
@@ -25,14 +26,17 @@ public class UniOnNullFailTest {
         assertThat(Uni.createFrom().item(1).onItem().ifNull().fail().await().indefinitely()).isEqualTo(1);
     }
 
-    @Test(expectedExceptions = RuntimeException.class)
+    @Test
     public void testFailWithException() {
-        Uni.createFrom().item((Object) null).onItem().ifNull().failWith(new RuntimeException("boom")).await().indefinitely();
+        assertThrows(RuntimeException.class,
+                () -> Uni.createFrom().item((Object) null).onItem().ifNull().failWith(new RuntimeException("boom")).await()
+                        .indefinitely());
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testFailWithExceptionSetToNull() {
-        Uni.createFrom().item((Object) null).onItem().ifNull().failWith((Exception) null).await().indefinitely();
+        assertThrows(IllegalArgumentException.class,
+                () -> Uni.createFrom().item((Object) null).onItem().ifNull().failWith((Exception) null).await().indefinitely());
     }
 
     @Test
@@ -54,9 +58,11 @@ public class UniOnNullFailTest {
                 .withMessageEndingWith("2");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testFailWithExceptionSupplierSetToNull() {
-        Uni.createFrom().item((Object) null).onItem().ifNull().failWith((Supplier<Throwable>) null).await().indefinitely();
+        assertThrows(IllegalArgumentException.class,
+                () -> Uni.createFrom().item((Object) null).onItem().ifNull().failWith((Supplier<Throwable>) null).await()
+                        .indefinitely());
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNullSwitchToTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNullSwitchToTest.java
@@ -2,18 +2,19 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
 public class UniOnNullSwitchToTest {
 
-    private Uni<Integer> fallback = Uni.createFrom().item(23);
-    private Uni<Integer> failure = Uni.createFrom().failure(new IOException("boom"));
+    private final Uni<Integer> fallback = Uni.createFrom().item(23);
+    private final Uni<Integer> failure = Uni.createFrom().failure(new IOException("boom"));
 
     @Test
     public void testSwitchToFallback() {
@@ -54,18 +55,18 @@ public class UniOnNullSwitchToTest {
 
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testSwitchToNull() {
-        Uni.createFrom().item((Object) null).onItem().castTo(Integer.class)
+        assertThrows(NullPointerException.class, () -> Uni.createFrom().item((Object) null).onItem().castTo(Integer.class)
                 .onItem().ifNull().switchTo((Uni<Integer>) null)
-                .await().indefinitely();
+                .await().indefinitely());
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testSwitchToNullSupplier() {
-        Uni.createFrom().item((Object) null).onItem().castTo(Integer.class)
+        assertThrows(NullPointerException.class, () -> Uni.createFrom().item((Object) null).onItem().castTo(Integer.class)
                 .onItem().ifNull().switchTo((Uni<? extends Integer>) null)
-                .await().indefinitely();
+                .await().indefinitely());
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnSubscribeTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
@@ -9,7 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
@@ -156,27 +157,29 @@ public class UniOnSubscribeTest {
 
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatInvokeConsumerCannotBeNull() {
-        Uni.createFrom().item(1)
-                .onSubscribe().invoke(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1)
+                .onSubscribe().invoke(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatInvokeUniFunctionCannotBeNull() {
-        Uni.createFrom().item(1)
-                .onSubscribe().invokeUni(null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1)
+                .onSubscribe().invokeUni(null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatInvokeUpstreamCannotBeNull() {
-        new UniOnSubscribeInvoke<>(null, s -> {
-        });
+        assertThrows(IllegalArgumentException.class, () -> new UniOnSubscribeInvoke<>(null, s -> {
+        }));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatInvokeUniUpstreamCannotBeNull() {
-        new UniOnSubscribeInvokeUni<>(null, s -> Uni.createFrom().nullItem());
+        assertThrows(IllegalArgumentException.class,
+                () -> new UniOnSubscribeInvokeUni<>(null, s -> Uni.createFrom().nullItem()));
+
     }
 
     @Test
@@ -205,7 +208,8 @@ public class UniOnSubscribeTest {
     public void testThatSubscriptionIsNotPassedDownstreamUntilProducedUniCompletes() {
         AtomicReference<UniEmitter<? super Integer>> emitter = new AtomicReference<>();
         UniAssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> 1)
-                .onSubscribe().invokeUni(s -> Uni.createFrom().emitter((Consumer<UniEmitter<? super Integer>>) emitter::set))
+                .onSubscribe()
+                .invokeUni(s -> Uni.createFrom().emitter((Consumer<UniEmitter<? super Integer>>) emitter::set))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber.assertNotSubscribed();
@@ -223,7 +227,8 @@ public class UniOnSubscribeTest {
     public void testThatSubscriptionIsNotPassedDownstreamUntilProducedUniCompletesWithDifferentThread() {
         AtomicReference<UniEmitter<? super Integer>> emitter = new AtomicReference<>();
         UniAssertSubscriber<Integer> subscriber = Uni.createFrom().item(() -> 1)
-                .onSubscribe().invokeUni(s -> Uni.createFrom().emitter((Consumer<UniEmitter<? super Integer>>) emitter::set))
+                .onSubscribe()
+                .invokeUni(s -> Uni.createFrom().emitter((Consumer<UniEmitter<? super Integer>>) emitter::set))
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor())
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRepeatTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRepeatTest.java
@@ -2,10 +2,8 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -15,8 +13,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -64,28 +62,28 @@ public class UniRepeatTest {
                 .assertReceived(1, 2, 3, 4, 5, 6, 7, 8);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testRepeat0() {
-        Uni.createFrom().item(0)
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(0)
                 .repeat().atMost(0)
                 .collectItems().asList()
-                .await().indefinitely();
+                .await().indefinitely());
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testRepeatUntilWithNullPredicate() {
-        Uni.createFrom().item(0)
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(0)
                 .repeat().until(null)
                 .collectItems().asList()
-                .await().indefinitely();
+                .await().indefinitely());
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testRepeatWhilstWithNullPredicate() {
-        Uni.createFrom().item(0)
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(0)
                 .repeat().whilst(null)
                 .collectItems().asList()
-                .await().indefinitely();
+                .await().indefinitely());
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
@@ -9,7 +9,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniSerializedSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniSerializedSubscriberTest.java
@@ -12,8 +12,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
@@ -24,7 +25,7 @@ import io.smallrye.mutiny.subscription.UniSubscription;
 
 public class UniSerializedSubscriberTest {
 
-    @AfterMethod
+    @AfterEach
     public void cleanup() {
         Infrastructure.resetDroppedExceptionHandler();
     }
@@ -170,7 +171,7 @@ public class UniSerializedSubscriberTest {
 
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void testRaceBetweenItemAndFailure() {
         AtomicReference<UniEmitter<? super Integer>> reference = new AtomicReference<>();
         Uni<Integer> uni = Uni.createFrom().<Integer> emitter(reference::set);
@@ -210,7 +211,7 @@ public class UniSerializedSubscriberTest {
         }
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void testRaceBetweenMultipleItems() {
         AtomicReference<UniEmitter<? super Integer>> reference = new AtomicReference<>();
         Uni<Integer> uni = Uni.createFrom().<Integer> emitter(reference::set);
@@ -250,7 +251,7 @@ public class UniSerializedSubscriberTest {
         assertThat(subscriber.getItem()).isBetween(1, 3);
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void testRaceBetweenItemAndCancellation() {
         AtomicReference<UniEmitter<? super Integer>> reference = new AtomicReference<>();
         AtomicBoolean cancelled = new AtomicBoolean();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniSubscribeAsCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniSubscribeAsCompletionStageTest.java
@@ -12,8 +12,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 
@@ -21,7 +21,7 @@ public class UniSubscribeAsCompletionStageTest {
 
     private ScheduledExecutorService executor;
 
-    @AfterTest
+    @AfterEach
     public void shutdown() {
         if (executor != null) {
             executor.shutdown();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniToMultiTest.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniToPublisherTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniToPublisherTest.java
@@ -8,9 +8,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.Test;
 
 import io.reactivex.Flowable;
 import io.reactivex.subscribers.TestSubscriber;
@@ -21,7 +21,7 @@ public class UniToPublisherTest {
 
     private ExecutorService executor;
 
-    @AfterTest
+    @AfterEach
     public void shutdown() {
         if (executor != null) {
             executor.shutdown();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -11,7 +12,7 @@ import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.TimeoutException;
@@ -42,11 +43,13 @@ public class UniZipTest {
         subscriber.assertFailure(IOException.class, "boom");
     }
 
-    @Test(expectedExceptions = TimeoutException.class)
+    @Test
     public void testWithNever() {
-        Uni<Tuple3<Integer, Integer, Object>> tuple = Uni.combine().all().unis(Uni.createFrom().item(1),
-                Uni.createFrom().item(2), Uni.createFrom().nothing()).asTuple();
-        tuple.await().atMost(Duration.ofMillis(1000));
+        assertThrows(TimeoutException.class, () -> {
+            Uni<Tuple3<Integer, Integer, Object>> tuple = Uni.combine().all().unis(Uni.createFrom().item(1),
+                    Uni.createFrom().item(2), Uni.createFrom().nothing()).asTuple();
+            tuple.await().atMost(Duration.ofMillis(100));
+        });
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/FlatMapMainSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/FlatMapMainSubscriberTest.java
@@ -5,9 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.reactivex.processors.PublishProcessor;
 import io.smallrye.mutiny.Multi;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiToHotStreamTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiToHotStreamTest.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/EmitterBasedMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/EmitterBasedMultiTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.operators.multi.builders;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -9,24 +10,25 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.BackPressureStrategy;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.test.AssertSubscriber;
 
+@SuppressWarnings("ConstantConditions")
 public class EmitterBasedMultiTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatConsumerCannotBeNull() {
-        Multi.createFrom().emitter(null, BackPressureStrategy.BUFFER);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().emitter(null, BackPressureStrategy.BUFFER));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testThatStrategyCannotBeNull() {
-        Multi.createFrom().emitter(e -> {
-        }, null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().emitter(e -> {
+        }, null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
@@ -1,10 +1,9 @@
 package io.smallrye.mutiny.operators.multi.builders;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -15,10 +14,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
@@ -28,9 +27,9 @@ import io.smallrye.mutiny.test.Mocks;
 
 public class MultiFromIterableTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void nullMustBeRejected() {
-        Multi.createFrom().iterable(null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().iterable(null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.operators.multi.builders;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -14,8 +15,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
@@ -52,12 +53,12 @@ public class MultiFromResourceTest {
                 .assertHasNotReceivedAnyItem();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testWithNullAsResourceSupplier() {
-        Multi.createFrom().resource(null,
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().resource(null,
                 s -> Multi.createFrom().items(s))
                 .withFinalizer(r -> {
-                });
+                }));
     }
 
     @Test
@@ -88,46 +89,52 @@ public class MultiFromResourceTest {
                 .assertHasNotReceivedAnyItem();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testWithNullAsStreamSupplier() {
-        Multi.createFrom().resource(() -> "hello", null)
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().resource(() -> "hello", null)
                 .withFinalizer(r -> {
-                });
+                }));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testWithNullAsFinalizer() {
-        Multi.createFrom().resource(() -> "hello", null)
-                .withFinalizer((Consumer<String>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().resource(() -> "hello", null)
+                .withFinalizer((Consumer<String>) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testWithNullAsFinalizer2() {
-        Multi.createFrom().resource(() -> "hello", null)
-                .withFinalizer((Function<String, Uni<Void>>) null);
+        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().resource(() -> "hello", null)
+                .withFinalizer((Function<String, Uni<Void>>) null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testWithNullAsFinalizer3() {
-        Function<String, Uni<Void>> function = s -> Uni.createFrom().item(() -> null);
-        Multi.createFrom().resource(() -> "hello", null)
-                .withFinalizer(function, null, function);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Function<String, Uni<Void>> function = s -> Uni.createFrom().item(() -> null);
+            Multi.createFrom().resource(() -> "hello", null)
+                    .withFinalizer(function, null, function);
+        });
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testWithNullAsFinalizer4() {
-        Function<String, Uni<Void>> function = s -> Uni.createFrom().item(() -> null);
-        BiFunction<String, Throwable, Uni<Void>> onFailure = (s, f) -> Uni.createFrom().item(() -> null);
-        Multi.createFrom().resource(() -> "hello", null)
-                .withFinalizer(null, onFailure, function);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Function<String, Uni<Void>> function = s -> Uni.createFrom().item(() -> null);
+            BiFunction<String, Throwable, Uni<Void>> onFailure = (s, f) -> Uni.createFrom().item(() -> null);
+            Multi.createFrom().resource(() -> "hello", null)
+                    .withFinalizer(null, onFailure, function);
+        });
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testWithNullAsFinalizer5() {
-        Function<String, Uni<Void>> function = s -> Uni.createFrom().item(() -> null);
-        BiFunction<String, Throwable, Uni<Void>> onFailure = (s, f) -> Uni.createFrom().item(() -> null);
-        Multi.createFrom().resource(() -> "hello", null)
-                .withFinalizer(function, onFailure, null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Function<String, Uni<Void>> function = s -> Uni.createFrom().item(() -> null);
+            BiFunction<String, Throwable, Uni<Void>> onFailure = (s, f) -> Uni.createFrom().item(() -> null);
+            Multi.createFrom().resource(() -> "hello", null)
+                    .withFinalizer(function, onFailure, null);
+        });
     }
 
     @Test
@@ -629,7 +636,8 @@ public class MultiFromResourceTest {
     public void testOnFailureWithSingleFinalizer() {
         AtomicBoolean subscribed = new AtomicBoolean();
         Multi<Integer> multi = Multi.createFrom()
-                .resource(() -> 1, x -> Multi.createFrom().range(x, 11).onCompletion().failWith(new IOException("boom")))
+                .resource(() -> 1,
+                        x -> Multi.createFrom().range(x, 11).onCompletion().failWith(new IOException("boom")))
                 .withFinalizer(r -> {
                     return Uni.createFrom().item("ok")
                             .onSubscribe().invoke(s -> subscribed.set(true))

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/BroadcastProcessorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/BroadcastProcessorTest.java
@@ -11,9 +11,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
@@ -23,12 +24,12 @@ public class BroadcastProcessorTest {
 
     private ExecutorService executor;
 
-    @BeforeMethod
+    @BeforeEach
     public void setup() {
         executor = Executors.newFixedThreadPool(4);
     }
 
-    @AfterMethod
+    @AfterEach
     public void cleanup() {
         executor.shutdownNow();
     }
@@ -379,7 +380,7 @@ public class BroadcastProcessorTest {
         subscriber1.assertHasNotReceivedAnyItem().assertNotTerminated();
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void testCompletionRace() {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
         AssertSubscriber<Object> subscriber = AssertSubscriber.create(1);
@@ -400,7 +401,7 @@ public class BroadcastProcessorTest {
         subscriber.await(Duration.ofSeconds(5)).assertCompletedSuccessfully();
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void testCompletionVsSubscriptionRace() throws InterruptedException {
         BroadcastProcessor<Integer> processor = BroadcastProcessor.create();
         AssertSubscriber<Object> subscriber = AssertSubscriber.create(1);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/SerializedProcessorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/SerializedProcessorTest.java
@@ -11,9 +11,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.Subscriptions;
@@ -104,7 +105,7 @@ public class SerializedProcessorTest {
         processor.onComplete();
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void verifyOnNextThreadSafety() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
@@ -129,7 +130,7 @@ public class SerializedProcessorTest {
         assertThat(items).hasSize(2).contains(1, 2);
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void verifyOnErrorThreadSafety() {
         Exception failure = new Exception("boom");
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
@@ -151,7 +152,7 @@ public class SerializedProcessorTest {
                 .assertHasFailedWith(Exception.class, "boom");
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void verifyOnNextOnErrorThreadSafety() {
         Exception failure = new Exception("boom");
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
@@ -183,7 +184,7 @@ public class SerializedProcessorTest {
         }
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void verifyOnNextOnCompleteThreadSafety() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
@@ -211,7 +212,7 @@ public class SerializedProcessorTest {
         }
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void verifyOnSubscribeOnCompleteThreadSafety() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
@@ -239,7 +240,7 @@ public class SerializedProcessorTest {
         }
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void verifyOnSubscribeOnSubscribeThreadSafety() throws InterruptedException {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
@@ -267,7 +268,7 @@ public class SerializedProcessorTest {
                 .assertSubscribed();
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void verifyOnFailureOnCompleteThreadSafety() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
@@ -295,7 +296,7 @@ public class SerializedProcessorTest {
         }
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void verifyOnFailureOnFailureThreadSafety() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
@@ -326,7 +327,7 @@ public class SerializedProcessorTest {
         verify(subscription).cancel();
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void testRaceBetweenOnNextAndOnComplete() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);
@@ -358,7 +359,7 @@ public class SerializedProcessorTest {
 
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void testRaceBetweenOnNextAndOnSubscribe() {
         final Processor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(100);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/UnicastProcessorTest.java
@@ -8,8 +8,8 @@ import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.helpers.queues.Queues;
 import io.smallrye.mutiny.subscription.BackPressureFailure;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/builders/KnownFailureUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/builders/KnownFailureUniTest.java
@@ -1,10 +1,11 @@
 package io.smallrye.mutiny.operators.uni.builders;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.UniAssertSubscriber;
@@ -17,9 +18,9 @@ public class KnownFailureUniTest {
                 .hasCauseInstanceOf(IOException.class).hasMessageContaining("io");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testCreationWithNull() {
-        Uni.createFrom().failure((Throwable) null);
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().failure((Throwable) null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/builders/KnownItemUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/builders/KnownItemUniTest.java
@@ -2,7 +2,7 @@ package io.smallrye.mutiny.operators.uni.builders;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.UniAssertSubscriber;

--- a/implementation/src/test/java/io/smallrye/mutiny/stack/StackTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/stack/StackTest.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import org.assertj.core.api.Assertions;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/CallbackBasedSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/CallbackBasedSubscriberTest.java
@@ -6,9 +6,9 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
@@ -17,7 +17,7 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
 @SuppressWarnings("ConstantConditions")
 public class CallbackBasedSubscriberTest {
 
-    @AfterMethod
+    @AfterEach
     public void cleanup() {
         Infrastructure.resetDroppedExceptionHandler();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/SafeSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/SafeSubscriberTest.java
@@ -8,11 +8,11 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.internal.stubbing.answers.ThrowsException;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
@@ -23,7 +23,7 @@ import io.smallrye.mutiny.test.Mocks;
 @SuppressWarnings("unchecked")
 public class SafeSubscriberTest {
 
-    @AfterMethod
+    @AfterEach
     public void cleanup() {
         Infrastructure.resetDroppedExceptionHandler();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/SerializedSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/SerializedSubscriberTest.java
@@ -10,14 +10,15 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.testng.TestException;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
+import io.smallrye.mutiny.TestException;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.test.AssertSubscriber;
 import io.smallrye.mutiny.test.Mocks;
@@ -26,12 +27,12 @@ public class SerializedSubscriberTest {
 
     Subscriber<Integer> subscriber;
 
-    @BeforeMethod
+    @BeforeEach
     public void before() {
         subscriber = Mocks.subscriber(Long.MAX_VALUE);
     }
 
-    @AfterMethod
+    @AfterEach
     public void clean() {
         Infrastructure.resetDroppedExceptionHandler();
     }
@@ -95,7 +96,7 @@ public class SerializedSubscriberTest {
         assertThat(busy.maxConcurrentThreads.get()).isEqualTo(1);
     }
 
-    @Test(invocationCount = 10)
+    @RepeatedTest(10)
     public void testMultiThreadedEmissionWithFailureInTheMiddleOfTheStream() throws InterruptedException {
         MultiThreadedPublisher publisher = new MultiThreadedPublisher(1, 2, 3, -1, 4, 5, 6, 7, 8, 9);
         BusySubscriber busy = new BusySubscriber();
@@ -280,7 +281,7 @@ public class SerializedSubscriberTest {
         }
     }
 
-    @Test(invocationCount = 10)
+    @RepeatedTest(10)
     public void testOnCompleteRace() {
         AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(Long.MAX_VALUE);
         SerializedSubscriber<Integer> serialized = new SerializedSubscriber<>(subscriber);
@@ -298,7 +299,7 @@ public class SerializedSubscriberTest {
         subscriber.await().assertCompletedSuccessfully();
     }
 
-    @Test(invocationCount = 10)
+    @RepeatedTest(10)
     public void testOnNextOnCompleteRace() {
         AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(Long.MAX_VALUE);
         SerializedSubscriber<Integer> serialized = new SerializedSubscriber<>(subscriber);
@@ -327,7 +328,7 @@ public class SerializedSubscriberTest {
         assertThat(subscriber.items()).hasSizeBetween(0, 1);
     }
 
-    @Test(invocationCount = 10)
+    @RepeatedTest(10)
     public void testOnNextOnErrorRace() {
         AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(Long.MAX_VALUE);
         SerializedSubscriber<Integer> serialized = new SerializedSubscriber<>(subscriber);
@@ -356,7 +357,7 @@ public class SerializedSubscriberTest {
         assertThat(subscriber.items()).hasSizeBetween(0, 1);
     }
 
-    @Test(invocationCount = 10)
+    @RepeatedTest(10)
     public void testOnCompleteOnErrorRace() {
         AssertSubscriber<Integer> subscriber = new AssertSubscriber<>(Long.MAX_VALUE);
         SerializedSubscriber<Integer> serialized = new SerializedSubscriber<>(subscriber);

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/SwitchableSubscriptionSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/SwitchableSubscriptionSubscriberTest.java
@@ -10,9 +10,10 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.test.AssertSubscriber;
 
@@ -22,7 +23,7 @@ public class SwitchableSubscriptionSubscriberTest {
     private MultiSubscriber<Integer> downstream;
     private SwitchableSubscriptionSubscriber<Integer> switchable;
 
-    @BeforeTest
+    @BeforeEach
     public void init() {
         subscriber = AssertSubscriber.create(10);
         downstream = new MultiSubscriber<Integer>() {
@@ -153,7 +154,7 @@ public class SwitchableSubscriptionSubscriberTest {
         verify(third, times(1)).request(8);
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void testRaceOnSwitch() throws InterruptedException {
         switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
             @Override
@@ -212,7 +213,7 @@ public class SwitchableSubscriptionSubscriberTest {
         verify(third, atMost(1)).request(5);
     }
 
-    @Test(invocationCount = 100)
+    @RepeatedTest(100)
     public void testRaceOnSwitchWithCancellationOnSwitch() throws InterruptedException {
         switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
             @Override
@@ -276,7 +277,7 @@ public class SwitchableSubscriptionSubscriberTest {
         verify(third, atMost(1)).request(5);
     }
 
-    @Test(invocationCount = 50)
+    @RepeatedTest(50)
     public void testRaceOnSwitchAndEmitted() throws InterruptedException {
         switchable = new SwitchableSubscriptionSubscriber<Integer>(downstream) {
             @Override

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/UniSubscriptionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/UniSubscriptionTest.java
@@ -2,7 +2,7 @@ package io.smallrye.mutiny.subscription;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class UniSubscriptionTest {
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/FunctionsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/FunctionsTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class FunctionsTest {
 

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple2Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple2Test.java
@@ -2,17 +2,16 @@ package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tuple2Test {
 
-    // TODO Test tuples
-
-    private Tuple2<Integer, Integer> somePair = Tuple2.of(1, 3);
+    private final Tuple2<Integer, Integer> somePair = Tuple2.of(1, 3);
 
     @Test
     public void testThatNullIsAcceptedAsItem1() {
@@ -102,14 +101,14 @@ public class Tuple2Test {
                 })).withMessage("boom");
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingNegative() {
-        somePair.nth(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> somePair.nth(-1));
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingOutOfIndex() {
-        somePair.nth(3);
+        assertThrows(IndexOutOfBoundsException.class, () -> somePair.nth(3));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple3Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple3Test.java
@@ -2,11 +2,12 @@ package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tuple3Test {
 
@@ -27,14 +28,14 @@ public class Tuple3Test {
         assertThat(someTuple.mapItem3(i -> i + 1)).containsExactly(1, 2, 4);
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingNegative() {
-        someTuple.nth(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(-1));
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingOutOfIndex() {
-        someTuple.nth(4);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(4));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple4Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple4Test.java
@@ -2,11 +2,12 @@ package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tuple4Test {
 
@@ -29,14 +30,14 @@ public class Tuple4Test {
         assertThat(someTuple.mapItem4(i -> i + 1)).containsExactly(1, 2, 3, 5);
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingNegative() {
-        someTuple.nth(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(-1));
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingOutOfIndex() {
-        someTuple.nth(10);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(10));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple5Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple5Test.java
@@ -2,11 +2,12 @@ package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tuple5Test {
 
@@ -32,14 +33,14 @@ public class Tuple5Test {
         assertThat(someTuple.mapItem5(i -> i + 1)).containsExactly(1, 2, 3, 4, 6);
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingNegative() {
-        someTuple.nth(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(-1));
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingOutOfIndex() {
-        someTuple.nth(10);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(10));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple6Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple6Test.java
@@ -2,11 +2,12 @@ package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tuple6Test {
 
@@ -33,14 +34,14 @@ public class Tuple6Test {
         assertThat(someTuple.mapItem6(i -> i + 1)).containsExactly(1, 2, 3, 4, 5, 7);
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingNegative() {
-        someTuple.nth(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(-1));
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingOutOfIndex() {
-        someTuple.nth(10);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(10));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple7Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple7Test.java
@@ -2,11 +2,12 @@ package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tuple7Test {
 
@@ -37,14 +38,14 @@ public class Tuple7Test {
         assertThat(someTuple.mapItem7(i -> i + 1)).containsExactly(1, 2, 3, 4, 5, 6, 8);
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingNegative() {
-        someTuple.nth(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(-1));
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingOutOfIndex() {
-        someTuple.nth(10);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(10));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple8Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple8Test.java
@@ -2,15 +2,17 @@ package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tuple8Test {
 
-    private Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> someTuple = new Tuple8<>(1, 2, 3, 4,
+    private final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> someTuple = new Tuple8<>(1,
+            2, 3, 4,
             5, 6, 7, 8);
 
     @Test
@@ -40,14 +42,14 @@ public class Tuple8Test {
         assertThat(someTuple.mapItem8(i -> i + 1)).containsExactly(1, 2, 3, 4, 5, 6, 7, 9);
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingNegative() {
-        someTuple.nth(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(-1));
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingOutOfIndex() {
-        someTuple.nth(10);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(10));
     }
 
     @Test
@@ -82,9 +84,11 @@ public class Tuple8Test {
 
     @Test
     public void testHashCode() {
-        Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> same = Tuple8.of(1, 2, 3, 4, 5, 6, 7, 8);
-        Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> different = Tuple8.of(1, 2, 1, 4, 6, 7,
-                8, 10);
+        Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> same = Tuple8
+                .of(1, 2, 3, 4, 5, 6, 7, 8);
+        Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> different = Tuple8
+                .of(1, 2, 1, 4, 6, 7,
+                        8, 10);
 
         assertThat(someTuple.hashCode())
                 .isEqualTo(same.hashCode())

--- a/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple9Test.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/tuples/Tuple9Test.java
@@ -2,11 +2,12 @@ package io.smallrye.mutiny.tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class Tuple9Test {
 
@@ -42,14 +43,14 @@ public class Tuple9Test {
         assertThat(someTuple.mapItem9(i -> i + 1)).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 10);
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingNegative() {
-        someTuple.nth(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(-1));
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test
     public void testAccessingOutOfIndex() {
-        someTuple.nth(10);
+        assertThrows(IndexOutOfBoundsException.class, () -> someTuple.nth(10));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedBiFunctionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedBiFunctionTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.IOException;
 import java.util.function.BiFunction;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class UncheckedBiFunctionTest {
 

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedConsumerTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedConsumerTest.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedFunctionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedFunctionTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedSupplierTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedSupplierTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.IOException;
 import java.util.function.Supplier;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 

--- a/implementation/src/test/java/tck/AbstractBlackBoxSubscriberTck.java
+++ b/implementation/src/test/java/tck/AbstractBlackBoxSubscriberTck.java
@@ -1,7 +1,7 @@
 package tck;
 
-import org.reactivestreams.tck.SubscriberBlackboxVerification;
 import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.junit5.SubscriberBlackboxVerification;
 
 public abstract class AbstractBlackBoxSubscriberTck extends SubscriberBlackboxVerification<Integer> {
 

--- a/implementation/src/test/java/tck/AbstractPublisherTck.java
+++ b/implementation/src/test/java/tck/AbstractPublisherTck.java
@@ -6,9 +6,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import org.reactivestreams.Publisher;
-import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
 import org.reactivestreams.tck.flow.support.TestException;
+import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import io.smallrye.mutiny.Multi;
 
@@ -25,11 +25,6 @@ public abstract class AbstractPublisherTck<T> extends PublisherVerification<T> {
     @Override
     public Publisher<T> createFailedPublisher() {
         return Multi.createFrom().failure(new TestException());
-    }
-
-    @Override
-    public long maxElementsFromPublisher() {
-        return 1024;
     }
 
     /**

--- a/implementation/src/test/java/tck/AbstractWhiteBoxSubscriberTck.java
+++ b/implementation/src/test/java/tck/AbstractWhiteBoxSubscriberTck.java
@@ -1,8 +1,8 @@
 package tck;
 
 import org.reactivestreams.Subscription;
-import org.reactivestreams.tck.SubscriberWhiteboxVerification;
 import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.junit5.SubscriberWhiteboxVerification;
 
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 

--- a/implementation/src/test/java/tck/BroadcastProcessorSubscriberTckTest.java
+++ b/implementation/src/test/java/tck/BroadcastProcessorSubscriberTckTest.java
@@ -1,7 +1,7 @@
 package tck;
 
+import org.junit.jupiter.api.Disabled;
 import org.reactivestreams.Subscriber;
-import org.testng.annotations.Ignore;
 
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 
@@ -13,7 +13,7 @@ public class BroadcastProcessorSubscriberTckTest extends AbstractBlackBoxSubscri
     }
 
     @Override
-    @Ignore
+    @Disabled
     public void required_spec205_blackbox_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal()
             throws Exception {
         // Ignoring test

--- a/implementation/src/test/java/tck/BroadcastSerializedProcessorSubscriberTckTest.java
+++ b/implementation/src/test/java/tck/BroadcastSerializedProcessorSubscriberTckTest.java
@@ -1,7 +1,7 @@
 package tck;
 
+import org.junit.jupiter.api.Disabled;
 import org.reactivestreams.Subscriber;
-import org.testng.annotations.Ignore;
 
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 
@@ -13,7 +13,7 @@ public class BroadcastSerializedProcessorSubscriberTckTest extends AbstractBlack
     }
 
     @Override
-    @Ignore
+    @Disabled
     public void required_spec205_blackbox_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal()
             throws Exception {
         // Ignoring test

--- a/implementation/src/test/java/tck/MultiConcatTckTest.java
+++ b/implementation/src/test/java/tck/MultiConcatTckTest.java
@@ -1,14 +1,15 @@
 package tck;
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static tck.Await.await;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.stream.LongStream;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -24,13 +25,13 @@ public class MultiConcatTckTest extends AbstractPublisherTck<Long> {
                 Arrays.asList(1, 2, 3, 4, 5, 6));
     }
 
-    @Test(expectedExceptions = QuietRuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+    @Test
     public void concatStageShouldPropagateExceptionsFromSecondStage() {
-        await(
+        assertThrows(QuietRuntimeException.class, () -> await(
                 Multi.createBy().concatenating().streams(
                         Multi.createFrom().items(1, 2, 3),
                         Multi.createFrom().failure(new QuietRuntimeException("failed"))).collectItems().asList()
-                        .subscribeAsCompletionStage());
+                        .subscribeAsCompletionStage()));
     }
 
     @Test
@@ -90,5 +91,10 @@ public class MultiConcatTckTest extends AbstractPublisherTck<Long> {
                         () -> LongStream.rangeClosed(1, toEmitFromFirst).boxed().iterator()),
                 Multi.createFrom().iterable(
                         () -> LongStream.rangeClosed(toEmitFromFirst + 1, elements).boxed().iterator()));
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024;
     }
 }

--- a/implementation/src/test/java/tck/MultiDisjointTckTest.java
+++ b/implementation/src/test/java/tck/MultiDisjointTckTest.java
@@ -13,4 +13,9 @@ public class MultiDisjointTckTest extends AbstractPublisherTck<Long> {
         return Multi.createFrom().item(list)
                 .onItem().disjoint();
     }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024;
+    }
 }

--- a/implementation/src/test/java/tck/MultiEmitOnTckTest.java
+++ b/implementation/src/test/java/tck/MultiEmitOnTckTest.java
@@ -2,11 +2,10 @@ package tck;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.stream.LongStream;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.reactivestreams.Publisher;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 
 import io.smallrye.mutiny.Multi;
 
@@ -14,20 +13,19 @@ public class MultiEmitOnTckTest extends AbstractPublisherTck<Long> {
 
     private ExecutorService executor;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         executor = Executors.newFixedThreadPool(3);
     }
 
-    @AfterMethod
+    @AfterEach
     public void cleanup() {
         executor.shutdown();
     }
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi
-                .createFrom().items(LongStream.rangeClosed(1, (int) elements).boxed())
+        return Multi.createFrom().iterable(iterate(elements))
                 .emitOn(executor);
     }
 

--- a/implementation/src/test/java/tck/MultiFirstTckTest.java
+++ b/implementation/src/test/java/tck/MultiFirstTckTest.java
@@ -1,12 +1,11 @@
 package tck;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static tck.Await.await;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -30,7 +29,7 @@ public class MultiFirstTckTest extends AbstractTck {
     @Test
     public void findFirstStageShouldReturnEmptyForEmptyStream() {
         assertNull(await(Multi.createFrom().items()
-                .collectItems().first().subscribeAsCompletionStage()), null);
+                .collectItems().first().subscribeAsCompletionStage()));
     }
 
     @Test
@@ -43,10 +42,10 @@ public class MultiFirstTckTest extends AbstractTck {
         await(cancelled);
     }
 
-    @Test(expectedExceptions = QuietRuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+    @Test
     public void findFirstStageShouldPropagateErrors() {
-        await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
-                .collectItems().first().subscribeAsCompletionStage());
+        assertThrows(QuietRuntimeException.class, () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
+                .collectItems().first().subscribeAsCompletionStage()));
     }
 
     @Test

--- a/implementation/src/test/java/tck/MultiFromCollectionTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromCollectionTckTest.java
@@ -16,4 +16,9 @@ public class MultiFromCollectionTckTest extends AbstractPublisherTck<Long> {
         }
         return Multi.createFrom().items(list.toArray(new Long[0]));
     }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024;
+    }
 }

--- a/implementation/src/test/java/tck/MultiFromItemsTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromItemsTckTest.java
@@ -12,4 +12,9 @@ public class MultiFromItemsTckTest extends AbstractPublisherTck<Long> {
         Long[] list = LongStream.rangeClosed(1, elements).boxed().toArray(Long[]::new);
         return Multi.createFrom().items(list);
     }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024;
+    }
 }

--- a/implementation/src/test/java/tck/MultiFromIterableTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromIterableTckTest.java
@@ -14,4 +14,10 @@ public class MultiFromIterableTckTest extends AbstractPublisherTck<Long> {
         List<Long> list = LongStream.rangeClosed(1, elements).boxed().collect(Collectors.toList());
         return Multi.createFrom().iterable(list);
     }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024;
+    }
+
 }

--- a/implementation/src/test/java/tck/MultiFromResourceTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromResourceTckTest.java
@@ -16,4 +16,10 @@ public class MultiFromResourceTckTest extends AbstractPublisherTck<Long> {
         })
                 .onItem().transform(i -> (long) i);
     }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024;
+    }
+
 }

--- a/implementation/src/test/java/tck/MultiFromStreamTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromStreamTckTest.java
@@ -13,4 +13,9 @@ public class MultiFromStreamTckTest extends AbstractPublisherTck<Long> {
         Stream<Long> list = LongStream.rangeClosed(1, elements).boxed();
         return Multi.createFrom().items(list);
     }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024;
+    }
 }

--- a/implementation/src/test/java/tck/MultiOnCompletionInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnCompletionInvokeTckTest.java
@@ -1,7 +1,5 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
@@ -10,7 +8,7 @@ public class MultiOnCompletionInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return Multi.createFrom().iterable(iterate(elements))
                 .onCompletion().invoke(() -> {
                     // Do nothing
                 });

--- a/implementation/src/test/java/tck/MultiOnCompletionInvokeUniTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnCompletionInvokeUniTckTest.java
@@ -1,7 +1,5 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
@@ -10,7 +8,7 @@ import io.smallrye.mutiny.Uni;
 public class MultiOnCompletionInvokeUniTckTest extends AbstractPublisherTck<Long> {
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return Multi.createFrom().iterable(iterate(elements))
                 .onCompletion().invokeUni(() -> Uni.createFrom().nullItem());
     }
 

--- a/implementation/src/test/java/tck/MultiOnFailureInvokeUniTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureInvokeUniTckTest.java
@@ -1,7 +1,5 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
@@ -11,7 +9,7 @@ public class MultiOnFailureInvokeUniTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return Multi.createFrom().iterable(iterate(elements))
                 .onFailure().invokeUni(x -> Uni.createFrom().nullItem());
     }
 

--- a/implementation/src/test/java/tck/MultiOnFailureRecoverWithFailureTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureRecoverWithFailureTckTest.java
@@ -1,7 +1,6 @@
 package tck;
 
 import java.util.function.Function;
-import java.util.stream.LongStream;
 
 import org.reactivestreams.Publisher;
 
@@ -11,7 +10,7 @@ public class MultiOnFailureRecoverWithFailureTckTest extends AbstractPublisherTc
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return Multi.createFrom().iterable(iterate(elements))
                 .onFailure().recoverWithMulti(t -> {
                     if (t instanceof RuntimeException) {
                         throw (RuntimeException) t;

--- a/implementation/src/test/java/tck/MultiOnFailureResumeTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureResumeTest.java
@@ -1,6 +1,7 @@
 package tck;
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static tck.Await.await;
 
 import java.util.Arrays;
@@ -8,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -80,31 +81,33 @@ public class MultiOnFailureResumeTest {
         assertEquals(exception.get().getMessage(), "failed");
     }
 
-    @Test(expectedExceptions = RuntimeException.class)
+    @Test
     public void onErrorResumeStageShouldPropagateRuntimeExceptions() {
-        await(Multi.createFrom().<String> failure(new Exception("source-failure"))
+        assertThrows(RuntimeException.class, () -> await(Multi.createFrom().<String> failure(new Exception("source-failure"))
                 .onFailure().recoverWithMulti(t -> {
                     throw new QuietRuntimeException("failed");
                 })
                 .collectItems().asList()
-                .subscribeAsCompletionStage());
+                .subscribeAsCompletionStage()));
     }
 
-    @Test(expectedExceptions = RuntimeException.class)
+    @Test
     public void onErrorResumeWithStageShouldPropagateRuntimeExceptions() {
-        await(Multi.createFrom().<String> failure(new Exception("source-failure"))
+        assertThrows(RuntimeException.class, () -> await(Multi.createFrom().<String> failure(new Exception("source-failure"))
                 .onFailure().recoverWithItem(t -> {
                     throw new QuietRuntimeException("failed");
                 })
                 .collectItems().asList()
-                .subscribeAsCompletionStage());
+                .subscribeAsCompletionStage()));
     }
 
-    @Test(expectedExceptions = QuietRuntimeException.class, expectedExceptionsMessageRegExp = ".*boom.*")
+    @Test
     public void onErrorResumeWithShouldBeAbleToInjectAFailure() {
-        await(Multi.createFrom().<String> failure(new QuietRuntimeException("failed"))
-                .onFailure().recoverWithMulti(err -> Multi.createFrom().failure(new QuietRuntimeException("boom")))
-                .collectItems().asList()
-                .subscribeAsCompletionStage());
+        assertThrows(QuietRuntimeException.class,
+                () -> await(Multi.createFrom().<String> failure(new QuietRuntimeException("failed"))
+                        .onFailure()
+                        .recoverWithMulti(err -> Multi.createFrom().failure(new QuietRuntimeException("boom")))
+                        .collectItems().asList()
+                        .subscribeAsCompletionStage()));
     }
 }

--- a/implementation/src/test/java/tck/MultiOnItemTransformTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnItemTransformTckTest.java
@@ -1,6 +1,7 @@
 package tck;
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static tck.Await.await;
 
 import java.util.Arrays;
@@ -10,8 +11,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -25,37 +26,41 @@ public class MultiOnItemTransformTckTest extends AbstractPublisherTck<Integer> {
                 .subscribeAsCompletionStage()), Arrays.asList("1", "2", "3"));
     }
 
-    @Test(expectedExceptions = QuietRuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+    @Test
     public void mapStageShouldHandleExceptions() {
-        CompletableFuture<Void> cancelled = new CompletableFuture<>();
-        CompletionStage<List<Object>> result = infiniteStream()
-                .onTermination().invoke(() -> cancelled.complete(null))
-                .map(foo -> {
-                    throw new QuietRuntimeException("failed");
-                })
-                .collectItems().asList()
-                .subscribeAsCompletionStage();
-        await(cancelled);
-        await(result);
+        assertThrows(QuietRuntimeException.class, () -> {
+            CompletableFuture<Void> cancelled = new CompletableFuture<>();
+            CompletionStage<List<Object>> result = infiniteStream()
+                    .onTermination().invoke(() -> cancelled.complete(null))
+                    .map(foo -> {
+                        throw new QuietRuntimeException("failed");
+                    })
+                    .collectItems().asList()
+                    .subscribeAsCompletionStage();
+            await(cancelled);
+            await(result);
+        });
     }
 
-    @Test(expectedExceptions = QuietRuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+    @Test
     public void mapStageShouldPropagateUpstreamExceptions() {
-        await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
+        assertThrows(QuietRuntimeException.class, () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
                 .map(Function.identity())
                 .collectItems().asList()
-                .subscribeAsCompletionStage());
+                .subscribeAsCompletionStage()));
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void mapStageShouldFailIfNullReturned() {
-        CompletableFuture<Void> cancelled = new CompletableFuture<>();
-        CompletionStage<List<Object>> result = infiniteStream()
-                .onTermination().invoke(() -> cancelled.complete(null))
-                .map(t -> null)
-                .collectItems().asList().subscribeAsCompletionStage();
-        await(cancelled);
-        await(result);
+        assertThrows(NullPointerException.class, () -> {
+            CompletableFuture<Void> cancelled = new CompletableFuture<>();
+            CompletionStage<List<Object>> result = infiniteStream()
+                    .onTermination().invoke(() -> cancelled.complete(null))
+                    .map(t -> null)
+                    .collectItems().asList().subscribeAsCompletionStage();
+            await(cancelled);
+            await(result);
+        });
     }
 
     @Override

--- a/implementation/src/test/java/tck/MultiOnRequestInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnRequestInvokeTckTest.java
@@ -1,7 +1,5 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
@@ -10,7 +8,7 @@ public class MultiOnRequestInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return Multi.createFrom().iterable(iterate(elements))
                 .onRequest().invoke((count) -> {
                     // Do nothing
                 });
@@ -23,4 +21,10 @@ public class MultiOnRequestInvokeTckTest extends AbstractPublisherTck<Long> {
                     // noop
                 });
     }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024;
+    }
+
 }

--- a/implementation/src/test/java/tck/MultiOnRequestInvokeUniTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnRequestInvokeUniTckTest.java
@@ -1,7 +1,5 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
@@ -11,7 +9,7 @@ public class MultiOnRequestInvokeUniTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return Multi.createFrom().iterable(iterate(elements))
                 .onRequest().invokeUni((count) -> Uni.createFrom().nullItem());
     }
 
@@ -19,5 +17,10 @@ public class MultiOnRequestInvokeUniTckTest extends AbstractPublisherTck<Long> {
     public Publisher<Long> createFailedPublisher() {
         return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
                 .onRequest().invokeUni((count) -> Uni.createFrom().nullItem());
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024;
     }
 }

--- a/implementation/src/test/java/tck/MultiOnSubscribeInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnSubscribeInvokeTckTest.java
@@ -1,7 +1,5 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
@@ -10,7 +8,7 @@ public class MultiOnSubscribeInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return Multi.createFrom().iterable(iterate(elements))
                 .onSubscribe().invoke(x -> {
                     // noop
                 });

--- a/implementation/src/test/java/tck/MultiOnSubscribeInvokeUniTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnSubscribeInvokeUniTckTest.java
@@ -1,7 +1,5 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
@@ -11,7 +9,7 @@ public class MultiOnSubscribeInvokeUniTckTest extends AbstractPublisherTck<Long>
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return Multi.createFrom().iterable(iterate(elements))
                 .onSubscribe().invokeUni(x -> Uni.createFrom().nullItem());
     }
 

--- a/implementation/src/test/java/tck/MultiOnTerminationInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnTerminationInvokeTckTest.java
@@ -1,7 +1,5 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
@@ -10,7 +8,7 @@ public class MultiOnTerminationInvokeTckTest extends AbstractPublisherTck<Long> 
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return Multi.createFrom().iterable(iterate(elements))
                 .onTermination().invoke(() -> {
                     // Do nothing
                 });

--- a/implementation/src/test/java/tck/MultiRunSubscriptionOnTckTest.java
+++ b/implementation/src/test/java/tck/MultiRunSubscriptionOnTckTest.java
@@ -4,9 +4,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.LongStream;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.reactivestreams.Publisher;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 
 import io.smallrye.mutiny.Multi;
 
@@ -14,12 +14,12 @@ public class MultiRunSubscriptionOnTckTest extends AbstractPublisherTck<Long> {
 
     private ExecutorService executor;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         executor = Executors.newFixedThreadPool(3);
     }
 
-    @AfterMethod
+    @AfterEach
     public void cleanup() {
         executor.shutdown();
     }

--- a/implementation/src/test/java/tck/MultiTakeFirstItemsTckTest.java
+++ b/implementation/src/test/java/tck/MultiTakeFirstItemsTckTest.java
@@ -1,6 +1,6 @@
 package tck;
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static tck.Await.await;
 
 import java.util.Arrays;
@@ -8,9 +8,9 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.LongStream;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 

--- a/implementation/src/test/java/tck/MultiTakeItemsWhileTckTest.java
+++ b/implementation/src/test/java/tck/MultiTakeItemsWhileTckTest.java
@@ -1,6 +1,7 @@
 package tck;
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static tck.Await.await;
 
 import java.util.Arrays;
@@ -10,8 +11,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.LongStream;
 
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-import org.testng.annotations.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -61,18 +62,20 @@ public class MultiTakeItemsWhileTckTest extends AbstractPublisherTck<Long> {
                 Arrays.asList(1, 2));
     }
 
-    @Test(expectedExceptions = QuietRuntimeException.class, expectedExceptionsMessageRegExp = "failed")
+    @Test
     public void takeWhileStageShouldHandleErrors() {
-        CompletableFuture<Void> cancelled = new CompletableFuture<>();
-        CompletionStage<List<Integer>> result = infiniteStream()
-                .onTermination().invoke(() -> cancelled.complete(null))
-                .transform().byTakingItemsWhile(i -> {
-                    throw new QuietRuntimeException("failed");
-                })
-                .collectItems().asList()
-                .subscribeAsCompletionStage();
-        await(cancelled);
-        await(result);
+        assertThrows(QuietRuntimeException.class, () -> {
+            CompletableFuture<Void> cancelled = new CompletableFuture<>();
+            CompletionStage<List<Integer>> result = infiniteStream()
+                    .onTermination().invoke(() -> cancelled.complete(null))
+                    .transform().byTakingItemsWhile(i -> {
+                        throw new QuietRuntimeException("failed");
+                    })
+                    .collectItems().asList()
+                    .subscribeAsCompletionStage();
+            await(cancelled);
+            await(result);
+        });
     }
 
     @Override

--- a/implementation/src/test/java/tck/ScheduledPublisher.java
+++ b/implementation/src/test/java/tck/ScheduledPublisher.java
@@ -1,6 +1,6 @@
 package tck;
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -17,10 +17,10 @@ import org.reactivestreams.Subscription;
  * and then completes 100ms later. It also uses activePublishers to ensure
  * that it is the only publisher that is subscribed to at any one time.
  */
-@SuppressWarnings("PublisherImplementation")
+@SuppressWarnings("ReactiveStreamsPublisherImplementation")
 class ScheduledPublisher implements Publisher<Integer> {
     private final int id;
-    private AtomicBoolean published = new AtomicBoolean(false);
+    private final AtomicBoolean published = new AtomicBoolean(false);
     private final AtomicInteger activePublishers;
     private final Supplier<ScheduledExecutorService> supplier;
 

--- a/implementation/src/test/java/tck/SerializedUnicastProcessorPublisherTckTest.java
+++ b/implementation/src/test/java/tck/SerializedUnicastProcessorPublisherTckTest.java
@@ -1,23 +1,26 @@
 package tck;
 
-import java.util.stream.IntStream;
-
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.SerializedProcessor;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 
-public class SerializedUnicastProcessorPublisherTckTest extends AbstractPublisherTck<Integer> {
+public class SerializedUnicastProcessorPublisherTckTest extends AbstractPublisherTck<Long> {
 
     @Override
-    public Publisher<Integer> createPublisher(long elements) {
-        Multi<Integer> multi = Multi.createFrom().items(IntStream.rangeClosed(1, (int) elements).boxed());
-        SerializedProcessor<Integer, Integer> processor = UnicastProcessor.<Integer> create().serialized();
+    public Publisher<Long> createPublisher(long elements) {
+        Multi<Long> multi = Multi.createFrom().iterable(iterate(elements));
+        SerializedProcessor<Long, Long> processor = UnicastProcessor.<Long> create().serialized();
 
         multi.subscribe(processor);
 
         return processor;
+    }
 
+    @Override
+    public long maxElementsFromPublisher() {
+        // Because we store the elements for the other subscribers.
+        return 1024;
     }
 }

--- a/implementation/src/test/java/tck/UniTransformToMultiTckTest.java
+++ b/implementation/src/test/java/tck/UniTransformToMultiTckTest.java
@@ -5,17 +5,17 @@ import org.reactivestreams.Publisher;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
-public class UniTransformToMultiTckTest extends AbstractPublisherTck<Integer> {
+public class UniTransformToMultiTckTest extends AbstractPublisherTck<Long> {
 
     @Override
-    public Publisher<Integer> createPublisher(long elements) {
+    public Publisher<Long> createPublisher(long elements) {
         return Uni.createFrom().item(elements)
-                .onItem().transformToMulti(max -> Multi.createFrom().range(0, (int) elements));
+                .onItem().transformToMulti(max -> Multi.createFrom().iterable(iterate(elements)));
     }
 
     @Override
-    public Publisher<Integer> createFailedPublisher() {
+    public Publisher<Long> createFailedPublisher() {
         return Uni.createFrom().<Integer> failure(new RuntimeException("failed"))
-                .onItem().transformToMulti(max -> Multi.createFrom().range(0, 100));
+                .onItem().transformToMulti(max -> Multi.createFrom().iterable(iterate(100)));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>reactive-streams-operators</module>
         <module>documentation</module>
         <module>context-propagation</module>
+        <module>reactive-streams-junit5-tck</module>
     </modules>
 
     <properties>
@@ -70,6 +71,8 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <smallrye-context-propagation.version>1.0.16</smallrye-context-propagation.version>
         <smallrye-config.version>1.8.6</smallrye-config.version>
+
+        <junit.version>5.6.2</junit.version>
     </properties>
 
     <dependencyManagement>
@@ -127,6 +130,12 @@
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config</artifactId>
                 <version>${smallrye-config.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/reactive-streams-junit5-tck/README.md
+++ b/reactive-streams-junit5-tck/README.md
@@ -1,0 +1,41 @@
+# Reactive Streams TCK for Junit 5 
+
+_This module is a fork of the Reactive Streams TCK (https://github.com/reactive-streams/reactive-streams-jvm/tree/master/tck)
+ but use Junit 5 instead of TestNG. This project does not depend on Mutiny._
+
+The purpose of the *Reactive Streams Technology Compatibility Kit* (from here on referred to as: *the TCK*) is to guide
+and help Reactive Streams library implementers to validate their implementations against the rules defined in
+ [the Specification](https://github.com/reactive-streams/reactive-streams-jvm).
+
+## Structure of the TCK
+
+The TCK aims to cover all rules defined in the Specification, however for some rules outlined in the Specification it is
+not possible (or viable) to construct automated tests, thus the TCK can not claim to fully verify an implementation, however it 
+is very helpful and is able to validate the most important rules.
+
+The TCK is split up into 4 test classes which are to be extended by implementers, providing their `Publisher` / `Subscriber` 
+/ `Processor` implementations for the test harness to validate.
+
+The tests are split in the following way:
+
+* `PublisherVerification`
+* `SubscriberWhiteboxVerification`
+* `SubscriberBlackboxVerification`
+* `IdentityProcessorVerification`
+
+The sections below include examples on how these can be used and describe the various configuration options.
+
+
+```xml
+<dependency>
+  <groupId>io.smallrye.reactive</groupId>
+  <artifactId>reactive-streams-junit5-tck</artifactId>
+  <version>${last mutiny release}</version>
+  <classifier>tests</classifier>
+  <type>test-jar</type>
+  <scope>test</scope>
+</dependency>
+```
+
+Please refer to the [Reactive Streams Specification](https://github.com/reactive-streams/reactive-streams-jvm) for the official,
+ and to the last Mutiny release to find the latest version. Make sure that your Reactive Streams API and TCK dependency versions match.

--- a/reactive-streams-junit5-tck/pom.xml
+++ b/reactive-streams-junit5-tck/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>mutiny-project</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>reactive-streams-junit5-tck</artifactId>
+
+    <description>The Reactive Streams TCK using Junit 5 instead of TestNG</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+            <version>${reactive-streams.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/IdentityProcessorVerification.java
+++ b/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/IdentityProcessorVerification.java
@@ -1,0 +1,469 @@
+/************************************************************************
+ * Licensed under Public Domain (CC0)                                    *
+ *                                                                       *
+ * To the extent possible under law, the person who associated CC0 with  *
+ * this code has waived all copyright and related or neighboring         *
+ * rights to this code.                                                  *
+ *                                                                       *
+ * You should have received a copy of the CC0 legalcode along with this  *
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.*
+ ************************************************************************/
+
+package org.reactivestreams.tck.junit5;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.tck.TestEnvironment;
+
+public abstract class IdentityProcessorVerification<T>
+        extends org.reactivestreams.tck.IdentityProcessorVerification<T> {
+
+    public IdentityProcessorVerification(TestEnvironment env) {
+        super(env);
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Override
+    @Test
+    public void required_validate_maxElementsFromPublisher() throws Exception {
+        super.required_validate_maxElementsFromPublisher();
+    }
+
+    @Override
+    @Test
+    public void required_validate_boundedDepthOfOnNextAndRequestRecursion() throws Exception {
+        super.required_validate_boundedDepthOfOnNextAndRequestRecursion();
+    }
+
+    @Override
+    @Test
+    public void required_createPublisher1MustProduceAStreamOfExactly1Element() throws Throwable {
+        super.required_createPublisher1MustProduceAStreamOfExactly1Element();
+    }
+
+    @Override
+    @Test
+    public void required_createPublisher3MustProduceAStreamOfExactly3Elements() throws Throwable {
+        super.required_createPublisher3MustProduceAStreamOfExactly3Elements();
+    }
+
+    @Override
+    @Test
+    public void required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements()
+            throws Throwable {
+        super.required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements();
+    }
+
+    @Override
+    @Test
+    public void required_spec102_maySignalLessThanRequestedAndTerminateSubscription() throws Throwable {
+        super.required_spec102_maySignalLessThanRequestedAndTerminateSubscription();
+    }
+
+    @Override
+    @Test
+    public void stochastic_spec103_mustSignalOnMethodsSequentially() throws Throwable {
+        super.stochastic_spec103_mustSignalOnMethodsSequentially();
+    }
+
+    @Override
+    @Test
+    public void optional_spec104_mustSignalOnErrorWhenFails() throws Throwable {
+        super.optional_spec104_mustSignalOnErrorWhenFails();
+    }
+
+    @Override
+    @Test
+    public void required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates() throws Throwable {
+        super.required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates();
+    }
+
+    @Override
+    @Test
+    public void optional_spec105_emptyStreamMustTerminateBySignallingOnComplete() throws Throwable {
+        super.optional_spec105_emptyStreamMustTerminateBySignallingOnComplete();
+    }
+
+    @Override
+    @Test
+    public void untested_spec106_mustConsiderSubscriptionCancelledAfterOnErrorOrOnCompleteHasBeenCalled() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled()
+            throws Throwable {
+        super.required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled();
+    }
+
+    @Override
+    @Test
+    public void untested_spec107_mustNotEmitFurtherSignalsOnceOnErrorHasBeenSignalled() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec108_possiblyCanceledSubscriptionShouldNotReceiveOnErrorOrOnCompleteSignals() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec109_subscribeShouldNotThrowNonFatalThrowable() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void required_spec109_subscribeThrowNPEOnNullSubscriber() throws Throwable {
+        super.required_spec109_subscribeThrowNPEOnNullSubscriber();
+    }
+
+    @Override
+    public void required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe()
+            throws Throwable {
+        super.required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe();
+    }
+
+    @Override
+    @Test
+    public void required_spec109_mustIssueOnSubscribeForNonNullSubscriber() throws Throwable {
+        super.required_spec109_mustIssueOnSubscribeForNonNullSubscriber();
+    }
+
+    @Override
+    @Test
+    public void untested_spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice()
+            throws Throwable {
+        super.untested_spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice();
+    }
+
+    @Override
+    @Test
+    public void optional_spec111_maySupportMultiSubscribe() throws Throwable {
+        super.optional_spec111_maySupportMultiSubscribe();
+    }
+
+    @Override
+    @Test
+    public void optional_spec111_registeredSubscribersMustReceiveOnNextOrOnCompleteSignals()
+            throws Throwable {
+        super.optional_spec111_registeredSubscribersMustReceiveOnNextOrOnCompleteSignals();
+    }
+
+    @Override
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne()
+            throws Throwable {
+        super.optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne();
+    }
+
+    @Override
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront()
+            throws Throwable {
+        super.optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront();
+    }
+
+    @Override
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected()
+            throws Throwable {
+        super.optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected();
+    }
+
+    @Override
+    @Test
+    public void required_spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe()
+            throws Throwable {
+        super.required_spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe();
+    }
+
+    @Override
+    @Test
+    public void required_spec303_mustNotAllowUnboundedRecursion() throws Throwable {
+        super.required_spec303_mustNotAllowUnboundedRecursion();
+    }
+
+    @Override
+    @Test
+    public void untested_spec304_requestShouldNotPerformHeavyComputations() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec305_cancelMustNotSynchronouslyPerformHeavyComputation() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void required_spec306_afterSubscriptionIsCancelledRequestMustBeNops() throws Throwable {
+        super.required_spec306_afterSubscriptionIsCancelledRequestMustBeNops();
+    }
+
+    @Override
+    @Test
+    public void required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops()
+            throws Throwable {
+        super.required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops();
+    }
+
+    @Override
+    @Test
+    public void required_spec309_requestZeroMustSignalIllegalArgumentException() throws Throwable {
+        super.required_spec309_requestZeroMustSignalIllegalArgumentException();
+    }
+
+    @Override
+    @Test
+    public void required_spec309_requestNegativeNumberMustSignalIllegalArgumentException()
+            throws Throwable {
+        super.required_spec309_requestNegativeNumberMustSignalIllegalArgumentException();
+    }
+
+    @Override
+    @Test
+    public void optional_spec309_requestNegativeNumberMaySignalIllegalArgumentExceptionWithSpecificMessage()
+            throws Throwable {
+        super.optional_spec309_requestNegativeNumberMaySignalIllegalArgumentExceptionWithSpecificMessage();
+    }
+
+    @Override
+    @Test
+    public void required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling()
+            throws Throwable {
+        super.required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling();
+    }
+
+    @Override
+    @Test
+    public void required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber()
+            throws Throwable {
+        super.required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber();
+    }
+
+    @Override
+    @Test
+    public void required_spec317_mustSupportAPendingElementCountUpToLongMaxValue() throws Throwable {
+        super.required_spec317_mustSupportAPendingElementCountUpToLongMaxValue();
+    }
+
+    @Override
+    @Test
+    public void required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue()
+            throws Throwable {
+        super.required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue();
+    }
+
+    @Override
+    @Test
+    public void required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue() throws Throwable {
+        super.required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue();
+    }
+
+    @Override
+    @Test
+    public void required_spec104_mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError()
+            throws Throwable {
+        super.required_spec104_mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError();
+    }
+
+    @Override
+    @Test
+    public void mustImmediatelyPassOnOnErrorEventsReceivedFromItsUpstreamToItsDownstream()
+            throws Exception {
+        super.mustImmediatelyPassOnOnErrorEventsReceivedFromItsUpstreamToItsDownstream();
+    }
+
+    @Override
+    @Test
+    public void required_exerciseWhiteboxHappyPath() throws Throwable {
+        super.required_exerciseWhiteboxHappyPath();
+    }
+
+    @Override
+    @Test
+    public void required_spec201_mustSignalDemandViaSubscriptionRequest() throws Throwable {
+        super.required_spec201_mustSignalDemandViaSubscriptionRequest();
+    }
+
+    @Override
+    @Test
+    public void untested_spec202_shouldAsynchronouslyDispatch() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete()
+            throws Throwable {
+        super.required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete();
+    }
+
+    @Override
+    @Test
+    public void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError()
+            throws Throwable {
+        super.required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError();
+    }
+
+    @Override
+    @Test
+    public void untested_spec204_mustConsiderTheSubscriptionAsCancelledInAfterRecievingOnCompleteOrOnError() {
+        // Do nothing - untested
+    }
+
+    @Override
+    public void required_spec205_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal()
+            throws Throwable {
+        super.required_spec205_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal();
+    }
+
+    @Override
+    @Test
+    public void untested_spec206_mustCallSubscriptionCancelIfItIsNoLongerValid() {
+        // Do nothing - untested
+    }
+
+    @Override
+    public void untested_spec207_mustEnsureAllCallsOnItsSubscriptionTakePlaceFromTheSameThreadOrTakeCareOfSynchronization() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void required_spec208_mustBePreparedToReceiveOnNextSignalsAfterHavingCalledSubscriptionCancel()
+            throws Throwable {
+        super.required_spec208_mustBePreparedToReceiveOnNextSignalsAfterHavingCalledSubscriptionCancel();
+    }
+
+    @Override
+    @Test
+    public void required_spec209_mustBePreparedToReceiveAnOnCompleteSignalWithPrecedingRequestCall()
+            throws Throwable {
+        super.required_spec209_mustBePreparedToReceiveAnOnCompleteSignalWithPrecedingRequestCall();
+    }
+
+    @Override
+    @Test
+    public void required_spec209_mustBePreparedToReceiveAnOnCompleteSignalWithoutPrecedingRequestCall()
+            throws Throwable {
+        super.required_spec209_mustBePreparedToReceiveAnOnCompleteSignalWithoutPrecedingRequestCall();
+    }
+
+    @Override
+    @Test
+    public void required_spec210_mustBePreparedToReceiveAnOnErrorSignalWithPrecedingRequestCall()
+            throws Throwable {
+        super.required_spec210_mustBePreparedToReceiveAnOnErrorSignalWithPrecedingRequestCall();
+    }
+
+    @Override
+    @Test
+    public void required_spec210_mustBePreparedToReceiveAnOnErrorSignalWithoutPrecedingRequestCall()
+            throws Throwable {
+        super.required_spec210_mustBePreparedToReceiveAnOnErrorSignalWithoutPrecedingRequestCall();
+    }
+
+    @Override
+    public void untested_spec211_mustMakeSureThatAllCallsOnItsMethodsHappenBeforeTheProcessingOfTheRespectiveEvents() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec212_mustNotCallOnSubscribeMoreThanOnceBasedOnObjectEquality_specViolation() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec213_failingOnSignalInvocation() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void required_spec213_onSubscribe_mustThrowNullPointerExceptionWhenParametersAreNull()
+            throws Throwable {
+        super.required_spec213_onSubscribe_mustThrowNullPointerExceptionWhenParametersAreNull();
+    }
+
+    @Override
+    @Test
+    public void required_spec213_onNext_mustThrowNullPointerExceptionWhenParametersAreNull()
+            throws Throwable {
+        super.required_spec213_onNext_mustThrowNullPointerExceptionWhenParametersAreNull();
+    }
+
+    @Override
+    @Test
+    public void required_spec213_onError_mustThrowNullPointerExceptionWhenParametersAreNull()
+            throws Throwable {
+        super.required_spec213_onError_mustThrowNullPointerExceptionWhenParametersAreNull();
+    }
+
+    @Override
+    @Test
+    public void untested_spec301_mustNotBeCalledOutsideSubscriberContext() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void required_spec308_requestMustRegisterGivenNumberElementsToBeProduced() throws Throwable {
+        super.required_spec308_requestMustRegisterGivenNumberElementsToBeProduced();
+    }
+
+    @Override
+    @Test
+    public void untested_spec310_requestMaySynchronouslyCallOnNextOnSubscriber() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec311_requestMaySynchronouslyCallOnCompleteOrOnError() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec314_cancelMayCauseThePublisherToShutdownIfNoOtherSubscriptionExists() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec315_cancelMustNotThrowExceptionAndMustSignalOnError() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec316_requestMustNotThrowExceptionAndMustOnErrorTheSubscriber() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void required_mustRequestFromUpstreamForElementsThatHaveBeenRequestedLongAgo()
+            throws Throwable {
+        super.required_mustRequestFromUpstreamForElementsThatHaveBeenRequestedLongAgo();
+    }
+
+    @Override
+    public void notVerified() {
+        System.err.println("Not verified by this TCK");
+    }
+
+    @Override
+    public void notVerified(String message) {
+        System.err.println("[Not Verified] " + message);
+    }
+}

--- a/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/NotVerifiedException.java
+++ b/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/NotVerifiedException.java
@@ -1,0 +1,7 @@
+package org.reactivestreams.tck.junit5;
+
+public class NotVerifiedException extends RuntimeException {
+    public NotVerifiedException(String message) {
+        super(message);
+    }
+}

--- a/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/PublisherVerification.java
+++ b/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/PublisherVerification.java
@@ -1,0 +1,288 @@
+/************************************************************************
+ * Licensed under Public Domain (CC0)                                    *
+ *                                                                       *
+ * To the extent possible under law, the person who associated CC0 with  *
+ * this code has waived all copyright and related or neighboring         *
+ * rights to this code.                                                  *
+ *                                                                       *
+ * You should have received a copy of the CC0 legalcode along with this  *
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.*
+ ************************************************************************/
+
+package org.reactivestreams.tck.junit5;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Provides tests for verifying {@code Publisher} specification rules.
+ *
+ * @see org.reactivestreams.Publisher
+ */
+public abstract class PublisherVerification<T> extends org.reactivestreams.tck.PublisherVerification<T> {
+
+    public PublisherVerification(org.reactivestreams.tck.TestEnvironment env) {
+        super(env);
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Test
+    @Override
+    public void required_createPublisher1MustProduceAStreamOfExactly1Element() throws Throwable {
+        super.required_createPublisher1MustProduceAStreamOfExactly1Element();
+    }
+
+    @Test
+    @Override
+    public void required_createPublisher3MustProduceAStreamOfExactly3Elements() throws Throwable {
+        super.required_createPublisher3MustProduceAStreamOfExactly3Elements();
+    }
+
+    @Test
+    @Override
+    public void required_validate_maxElementsFromPublisher() throws Exception {
+        super.required_validate_maxElementsFromPublisher();
+    }
+
+    @Test
+    @Override
+    public void required_validate_boundedDepthOfOnNextAndRequestRecursion() throws Exception {
+        super.required_validate_boundedDepthOfOnNextAndRequestRecursion();
+    }
+
+    @Test
+    @Override
+    public void required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements()
+            throws Throwable {
+        super.required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements();
+    }
+
+    @Test
+    @Override
+    public void required_spec102_maySignalLessThanRequestedAndTerminateSubscription() throws Throwable {
+        super.required_spec102_maySignalLessThanRequestedAndTerminateSubscription();
+    }
+
+    @Test
+    @Override
+    public void stochastic_spec103_mustSignalOnMethodsSequentially() throws Throwable {
+        super.stochastic_spec103_mustSignalOnMethodsSequentially();
+    }
+
+    @Test
+    @Override
+    public void optional_spec104_mustSignalOnErrorWhenFails() throws Throwable {
+        super.optional_spec104_mustSignalOnErrorWhenFails();
+    }
+
+    @Test
+    @Override
+    public void required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates() throws Throwable {
+        super.required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates();
+    }
+
+    @Test
+    @Override
+    public void optional_spec105_emptyStreamMustTerminateBySignallingOnComplete() throws Throwable {
+        super.optional_spec105_emptyStreamMustTerminateBySignallingOnComplete();
+    }
+
+    @Test
+    @Override
+    public void untested_spec106_mustConsiderSubscriptionCancelledAfterOnErrorOrOnCompleteHasBeenCalled()
+            throws Throwable {
+        // Untested - do nothing
+    }
+
+    @Test
+    @Override
+    public void required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled() throws Throwable {
+        super.required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled();
+    }
+
+    @Test
+    @Override
+    public void untested_spec107_mustNotEmitFurtherSignalsOnceOnErrorHasBeenSignalled() {
+        // Untested - do nothing
+    }
+
+    @Test
+    @Override
+    public void untested_spec108_possiblyCanceledSubscriptionShouldNotReceiveOnErrorOrOnCompleteSignals() {
+        // Do nothing - untested
+    }
+
+    @Test
+    @Override
+    public void untested_spec109_subscribeShouldNotThrowNonFatalThrowable() {
+        // Do nothing - untested
+    }
+
+    @Test
+    @Override
+    public void required_spec109_subscribeThrowNPEOnNullSubscriber() throws Throwable {
+        super.required_spec109_subscribeThrowNPEOnNullSubscriber();
+    }
+
+    @Test
+    @Override
+    public void required_spec109_mustIssueOnSubscribeForNonNullSubscriber() throws Throwable {
+        super.required_spec109_mustIssueOnSubscribeForNonNullSubscriber();
+    }
+
+    @Test
+    @Override
+    public void required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe()
+            throws Throwable {
+        super.required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe();
+    }
+
+    @Test
+    @Override
+    public void untested_spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice()
+            throws Throwable {
+        // Do nothing - untested
+    }
+
+    @Test
+    @Override
+    public void optional_spec111_maySupportMultiSubscribe() throws Throwable {
+        super.optional_spec111_maySupportMultiSubscribe();
+    }
+
+    @Test
+    @Override
+    public void optional_spec111_registeredSubscribersMustReceiveOnNextOrOnCompleteSignals()
+            throws Throwable {
+        super.optional_spec111_registeredSubscribersMustReceiveOnNextOrOnCompleteSignals();
+    }
+
+    @Test
+    @Override
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne()
+            throws Throwable {
+        super.optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne();
+    }
+
+    @Test
+    @Override
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront()
+            throws Throwable {
+        super.optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront();
+    }
+
+    @Test
+    @Override
+    public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected()
+            throws Throwable {
+        super.optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected();
+    }
+
+    @Test
+    @Override
+    public void required_spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe() throws Throwable {
+        super.required_spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe();
+    }
+
+    @Test
+    @Override
+    public void required_spec303_mustNotAllowUnboundedRecursion() throws Throwable {
+        super.required_spec303_mustNotAllowUnboundedRecursion();
+    }
+
+    @Test
+    @Override
+    public void untested_spec304_requestShouldNotPerformHeavyComputations() throws Exception {
+        // Do nothing - untested
+    }
+
+    @Test
+    @Override
+    public void untested_spec305_cancelMustNotSynchronouslyPerformHeavyComputation() throws Exception {
+        // Do nothing - untested
+    }
+
+    @Test
+    @Override
+    public void required_spec306_afterSubscriptionIsCancelledRequestMustBeNops() throws Throwable {
+        super.required_spec306_afterSubscriptionIsCancelledRequestMustBeNops();
+    }
+
+    @Test
+    @Override
+    public void required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops()
+            throws Throwable {
+        super.required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops();
+    }
+
+    @Test
+    @Override
+    public void required_spec309_requestZeroMustSignalIllegalArgumentException() throws Throwable {
+        super.required_spec309_requestZeroMustSignalIllegalArgumentException();
+    }
+
+    @Test
+    @Override
+    public void required_spec309_requestNegativeNumberMustSignalIllegalArgumentException() throws Throwable {
+        super.required_spec309_requestNegativeNumberMustSignalIllegalArgumentException();
+    }
+
+    @Test
+    @Override
+    public void optional_spec309_requestNegativeNumberMaySignalIllegalArgumentExceptionWithSpecificMessage()
+            throws Throwable {
+        super.optional_spec309_requestNegativeNumberMaySignalIllegalArgumentExceptionWithSpecificMessage();
+    }
+
+    @Test
+    @Override
+    public void required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling() throws Throwable {
+        super.required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling();
+    }
+
+    @Test
+    @Override
+    public void required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber()
+            throws Throwable {
+        super.required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber();
+    }
+
+    @Test
+    @Override
+    public void required_spec317_mustSupportAPendingElementCountUpToLongMaxValue() throws Throwable {
+        super.required_spec317_mustSupportAPendingElementCountUpToLongMaxValue();
+    }
+
+    @Test
+    @Override
+    public void required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue()
+            throws Throwable {
+        super.required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue();
+    }
+
+    @Test
+    @Override
+    public void required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue() throws Throwable {
+        if (maxElementsFromPublisher() < Long.MAX_VALUE - 1) {
+            System.err.println("[Not Verified] Unable to run this test, as required elements nr: 2147483647 is higher "
+                    + "than supported by given producer: " + maxElementsFromPublisher());
+            return;
+        }
+        super.required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue();
+    }
+
+    @Override
+    public void notVerified() {
+        System.err.println("Not verified by this TCK");
+    }
+
+    @Override
+    public void notVerified(String message) {
+        System.err.println("[Not Verified] " + message);
+    }
+
+}

--- a/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/SubscriberBlackboxVerification.java
+++ b/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/SubscriberBlackboxVerification.java
@@ -1,0 +1,217 @@
+/************************************************************************
+ * Licensed under Public Domain (CC0)                                    *
+ *                                                                       *
+ * To the extent possible under law, the person who associated CC0 with  *
+ * this code has waived all copyright and related or neighboring         *
+ * rights to this code.                                                  *
+ *                                                                       *
+ * You should have received a copy of the CC0 legalcode along with this  *
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.*
+ ************************************************************************/
+
+package org.reactivestreams.tck.junit5;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.tck.TestEnvironment;
+
+/**
+ * Provides tests for verifying {@link org.reactivestreams.Subscriber} and {@link org.reactivestreams.Subscription}
+ * specification rules, without any modifications to the tested implementation (also known as "Black Box" testing).
+ * <p>
+ * This verification is NOT able to check many of the rules of the spec, and if you want more
+ * verification of your implementation you'll have to implement {@code org.reactivestreams.tck.SubscriberWhiteboxVerification}
+ * instead.
+ *
+ * @see org.reactivestreams.Subscriber
+ * @see org.reactivestreams.Subscription
+ */
+public abstract class SubscriberBlackboxVerification<T>
+        extends org.reactivestreams.tck.SubscriberBlackboxVerification<T> {
+
+    protected SubscriberBlackboxVerification(TestEnvironment env) {
+        super(env);
+    }
+
+    @BeforeEach
+    public void startPublisherExecutorService() {
+        super.startPublisherExecutorService();
+    }
+
+    @AfterEach
+    public void shutdownPublisherExecutorService() {
+        super.shutdownPublisherExecutorService();
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Override
+    @Test
+    public void required_spec201_blackbox_mustSignalDemandViaSubscriptionRequest() throws Throwable {
+        super.required_spec201_blackbox_mustSignalDemandViaSubscriptionRequest();
+    }
+
+    @Override
+    @Test
+    public void untested_spec202_blackbox_shouldAsynchronouslyDispatch() throws Exception {
+        // Untested - do nothing
+    }
+
+    @Override
+    @Test
+    public void required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete()
+            throws Throwable {
+        super.required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete();
+    }
+
+    @Override
+    @Test
+    public void required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnError()
+            throws Throwable {
+        super.required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnError();
+    }
+
+    @Override
+    public void untested_spec204_blackbox_mustConsiderTheSubscriptionAsCancelledInAfterRecievingOnCompleteOrOnError()
+            throws Exception {
+        super.untested_spec204_blackbox_mustConsiderTheSubscriptionAsCancelledInAfterRecievingOnCompleteOrOnError();
+    }
+
+    @Override
+    public void required_spec205_blackbox_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal()
+            throws Exception {
+        super.required_spec205_blackbox_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal();
+    }
+
+    @Override
+    @Test
+    public void untested_spec206_blackbox_mustCallSubscriptionCancelIfItIsNoLongerValid() {
+        // Do nothing - untested
+    }
+
+    @Override
+    public void untested_spec207_blackbox_mustEnsureAllCallsOnItsSubscriptionTakePlaceFromTheSameThreadOrTakeCareOfSynchronization() {
+        // Do nothing - untested
+    }
+
+    @Override
+    public void untested_spec208_blackbox_mustBePreparedToReceiveOnNextSignalsAfterHavingCalledSubscriptionCancel() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void required_spec209_blackbox_mustBePreparedToReceiveAnOnCompleteSignalWithPrecedingRequestCall()
+            throws Throwable {
+        super.required_spec209_blackbox_mustBePreparedToReceiveAnOnCompleteSignalWithPrecedingRequestCall();
+    }
+
+    @Override
+    public void required_spec209_blackbox_mustBePreparedToReceiveAnOnCompleteSignalWithoutPrecedingRequestCall()
+            throws Throwable {
+        super.required_spec209_blackbox_mustBePreparedToReceiveAnOnCompleteSignalWithoutPrecedingRequestCall();
+    }
+
+    @Override
+    @Test
+    public void required_spec210_blackbox_mustBePreparedToReceiveAnOnErrorSignalWithPrecedingRequestCall()
+            throws Throwable {
+        super.required_spec210_blackbox_mustBePreparedToReceiveAnOnErrorSignalWithPrecedingRequestCall();
+    }
+
+    @Override
+    @Test
+    public void required_spec210_blackbox_mustBePreparedToReceiveAnOnErrorSignalWithoutPrecedingRequestCall()
+            throws Throwable {
+        super.required_spec210_blackbox_mustBePreparedToReceiveAnOnErrorSignalWithoutPrecedingRequestCall();
+    }
+
+    @Override
+    public void untested_spec211_blackbox_mustMakeSureThatAllCallsOnItsMethodsHappenBeforeTheProcessingOfTheRespectiveEvents() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec212_blackbox_mustNotCallOnSubscribeMoreThanOnceBasedOnObjectEquality() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec213_blackbox_failingOnSignalInvocation() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void required_spec213_blackbox_onSubscribe_mustThrowNullPointerExceptionWhenParametersAreNull()
+            throws Throwable {
+        super.required_spec213_blackbox_onSubscribe_mustThrowNullPointerExceptionWhenParametersAreNull();
+    }
+
+    @Override
+    @Test
+    public void required_spec213_blackbox_onNext_mustThrowNullPointerExceptionWhenParametersAreNull()
+            throws Throwable {
+        super.required_spec213_blackbox_onNext_mustThrowNullPointerExceptionWhenParametersAreNull();
+    }
+
+    @Override
+    @Test
+    public void required_spec213_blackbox_onError_mustThrowNullPointerExceptionWhenParametersAreNull()
+            throws Throwable {
+        super.required_spec213_blackbox_onError_mustThrowNullPointerExceptionWhenParametersAreNull();
+    }
+
+    @Override
+    @Test
+    public void untested_spec301_blackbox_mustNotBeCalledOutsideSubscriberContext() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec308_blackbox_requestMustRegisterGivenNumberElementsToBeProduced() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec310_blackbox_requestMaySynchronouslyCallOnNextOnSubscriber() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec311_blackbox_requestMaySynchronouslyCallOnCompleteOrOnError() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec314_blackbox_cancelMayCauseThePublisherToShutdownIfNoOtherSubscriptionExists() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec315_blackbox_cancelMustNotThrowExceptionAndMustSignalOnError() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec316_blackbox_requestMustNotThrowExceptionAndMustOnErrorTheSubscriber() {
+        // Do nothing - untested
+    }
+
+    @Override
+    public void notVerified() {
+        System.err.println("Not verified by this TCK");
+    }
+}

--- a/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/SubscriberWhiteboxVerification.java
+++ b/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/SubscriberWhiteboxVerification.java
@@ -1,0 +1,231 @@
+/************************************************************************
+ * Licensed under Public Domain (CC0)                                    *
+ *                                                                       *
+ * To the extent possible under law, the person who associated CC0 with  *
+ * this code has waived all copyright and related or neighboring         *
+ * rights to this code.                                                  *
+ *                                                                       *
+ * You should have received a copy of the CC0 legalcode along with this  *
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.*
+ ************************************************************************/
+
+package org.reactivestreams.tck.junit5;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.tck.TestEnvironment;
+
+/**
+ * Provides whitebox style tests for verifying {@link org.reactivestreams.Subscriber}
+ * and {@link org.reactivestreams.Subscription} specification rules.
+ *
+ * @see org.reactivestreams.Subscriber
+ * @see org.reactivestreams.Subscription
+ */
+public abstract class SubscriberWhiteboxVerification<T>
+        extends org.reactivestreams.tck.SubscriberWhiteboxVerification<T> {
+
+    protected SubscriberWhiteboxVerification(TestEnvironment env) {
+        super(env);
+    }
+
+    @BeforeEach
+    public void startPublisherExecutorService() {
+        super.startPublisherExecutorService();
+    }
+
+    @AfterEach
+    public void shutdownPublisherExecutorService() {
+        super.shutdownPublisherExecutorService();
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Override
+    @Test
+    public void required_exerciseWhiteboxHappyPath() throws Throwable {
+        super.required_exerciseWhiteboxHappyPath();
+    }
+
+    @Override
+    @Test
+    public void required_spec201_mustSignalDemandViaSubscriptionRequest() throws Throwable {
+        super.required_spec201_mustSignalDemandViaSubscriptionRequest();
+    }
+
+    @Override
+    @Test
+    public void untested_spec202_shouldAsynchronouslyDispatch() throws Exception {
+        // Untested - do nothing
+    }
+
+    @Override
+    @Test
+    public void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete()
+            throws Throwable {
+        super.required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete();
+    }
+
+    @Override
+    @Test
+    public void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError()
+            throws Throwable {
+        super.required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError();
+    }
+
+    @Override
+    @Test
+    public void untested_spec204_mustConsiderTheSubscriptionAsCancelledInAfterRecievingOnCompleteOrOnError()
+            throws Exception {
+        // Untested - do nothing
+    }
+
+    @Override
+    public void required_spec205_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal()
+            throws Throwable {
+        super.required_spec205_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal();
+    }
+
+    @Override
+    @Test
+    public void untested_spec206_mustCallSubscriptionCancelIfItIsNoLongerValid() throws Exception {
+        // Untested - do nothing
+    }
+
+    @Override
+    public void untested_spec207_mustEnsureAllCallsOnItsSubscriptionTakePlaceFromTheSameThreadOrTakeCareOfSynchronization()
+            throws Exception {
+        // Untested - do nothing
+    }
+
+    @Override
+    @Test
+    public void required_spec208_mustBePreparedToReceiveOnNextSignalsAfterHavingCalledSubscriptionCancel()
+            throws Throwable {
+        super.required_spec208_mustBePreparedToReceiveOnNextSignalsAfterHavingCalledSubscriptionCancel();
+    }
+
+    @Override
+    @Test
+    public void required_spec209_mustBePreparedToReceiveAnOnCompleteSignalWithPrecedingRequestCall()
+            throws Throwable {
+        super.required_spec209_mustBePreparedToReceiveAnOnCompleteSignalWithPrecedingRequestCall();
+    }
+
+    @Override
+    @Test
+    public void required_spec209_mustBePreparedToReceiveAnOnCompleteSignalWithoutPrecedingRequestCall()
+            throws Throwable {
+        super.required_spec209_mustBePreparedToReceiveAnOnCompleteSignalWithoutPrecedingRequestCall();
+    }
+
+    @Override
+    @Test
+    public void required_spec210_mustBePreparedToReceiveAnOnErrorSignalWithPrecedingRequestCall()
+            throws Throwable {
+        super.required_spec210_mustBePreparedToReceiveAnOnErrorSignalWithPrecedingRequestCall();
+    }
+
+    @Override
+    @Test
+    public void required_spec210_mustBePreparedToReceiveAnOnErrorSignalWithoutPrecedingRequestCall()
+            throws Throwable {
+        super.required_spec210_mustBePreparedToReceiveAnOnErrorSignalWithoutPrecedingRequestCall();
+    }
+
+    @Override
+    public void untested_spec211_mustMakeSureThatAllCallsOnItsMethodsHappenBeforeTheProcessingOfTheRespectiveEvents()
+            throws Exception {
+        // Untested - do nothing
+    }
+
+    @Override
+    @Test
+    public void untested_spec212_mustNotCallOnSubscribeMoreThanOnceBasedOnObjectEquality_specViolation()
+            throws Throwable {
+        // Untested - do nothing
+    }
+
+    @Override
+    @Test
+    public void untested_spec213_failingOnSignalInvocation() throws Exception {
+        // Untested - do nothing
+    }
+
+    @Override
+    @Test
+    public void required_spec213_onSubscribe_mustThrowNullPointerExceptionWhenParametersAreNull()
+            throws Throwable {
+        super.required_spec213_onSubscribe_mustThrowNullPointerExceptionWhenParametersAreNull();
+    }
+
+    @Override
+    @Test
+    public void required_spec213_onNext_mustThrowNullPointerExceptionWhenParametersAreNull()
+            throws Throwable {
+        super.required_spec213_onNext_mustThrowNullPointerExceptionWhenParametersAreNull();
+    }
+
+    @Override
+    @Test
+    public void required_spec213_onError_mustThrowNullPointerExceptionWhenParametersAreNull()
+            throws Throwable {
+        super.required_spec213_onError_mustThrowNullPointerExceptionWhenParametersAreNull();
+    }
+
+    @Override
+    @Test
+    public void untested_spec301_mustNotBeCalledOutsideSubscriberContext() throws Exception {
+        // Untested - do nothing
+    }
+
+    @Override
+    @Test
+    public void required_spec308_requestMustRegisterGivenNumberElementsToBeProduced() throws Throwable {
+        super.required_spec308_requestMustRegisterGivenNumberElementsToBeProduced();
+    }
+
+    @Override
+    @Test
+    public void untested_spec310_requestMaySynchronouslyCallOnNextOnSubscriber() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec311_requestMaySynchronouslyCallOnCompleteOrOnError() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec314_cancelMayCauseThePublisherToShutdownIfNoOtherSubscriptionExists() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec315_cancelMustNotThrowExceptionAndMustSignalOnError() {
+        // Do nothing - untested
+    }
+
+    @Override
+    @Test
+    public void untested_spec316_requestMustNotThrowExceptionAndMustOnErrorTheSubscriber() {
+        // Do nothing - untested
+    }
+
+    @Override
+    public void notVerified() {
+        System.err.println("Not verified by this TCK");
+    }
+
+    @Override
+    public void notVerified(String message) {
+        System.err.println("[Not Verified] " + message);
+    }
+}

--- a/reactive-streams-operators/pom.xml
+++ b/reactive-streams-operators/pom.xml
@@ -36,6 +36,11 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny-test-utils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/reactive-streams-operators/pom.xml
+++ b/reactive-streams-operators/pom.xml
@@ -74,6 +74,12 @@
                                 <exclude>**/tck/SubscriberWhitebox*</exclude>
                             </excludes>
                             <junitArtifactName>none:none</junitArtifactName>
+                            <properties>
+                                <property>
+                                    <name>surefire.testng.verbose</name>
+                                    <value>10</value>
+                                </property>
+                            </properties>
                         </configuration>
                     </execution>
                 </executions>

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/APITest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/APITest.java
@@ -24,7 +24,7 @@ import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/EngineTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/EngineTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,7 +13,7 @@ import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.spi.Graph;
 import org.eclipse.microprofile.reactive.streams.operators.spi.Stage;
 import org.eclipse.microprofile.reactive.streams.operators.spi.UnsupportedStageException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -46,26 +47,30 @@ public class EngineTest {
         assertThat(integer).contains(6);
     }
 
-    @Test(expected = UnsupportedStageException.class)
+    @Test
     public void testUnknownTerminalStage() {
-        engine = new Engine();
-        List<Stage> stages = new ArrayList<>();
-        stages.add((Stage.Map) () -> i -> (int) i + 1);
-        stages.add(new Stage() {
-            // Unknown stage
+        assertThrows(UnsupportedStageException.class, () -> {
+            engine = new Engine();
+            List<Stage> stages = new ArrayList<>();
+            stages.add((Stage.Map) () -> i -> (int) i + 1);
+            stages.add(new Stage() {
+                // Unknown stage
+            });
+            Graph graph = () -> stages;
+            engine.buildSubscriber(graph);
         });
-        Graph graph = () -> stages;
-        engine.buildSubscriber(graph);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidSubscriber() {
-        engine = new Engine();
-        List<Stage> stages = new ArrayList<>();
-        stages.add((Stage.Map) () -> i -> (int) i + 1);
-        // This graph is not closed - so it's invalid
-        Graph graph = () -> stages;
-        engine.buildSubscriber(graph);
+        assertThrows(IllegalArgumentException.class, () -> {
+            engine = new Engine();
+            List<Stage> stages = new ArrayList<>();
+            stages.add((Stage.Map) () -> i -> (int) i + 1);
+            // This graph is not closed - so it's invalid
+            Graph graph = () -> stages;
+            engine.buildSubscriber(graph);
+        });
     }
 
     @Test
@@ -80,30 +85,34 @@ public class EngineTest {
         assertThat(engine.buildCompletion(graph)).isNotNull();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidCompletion() {
-        engine = new Engine();
-        List<Stage> stages = new ArrayList<>();
-        stages.add((Stage.PublisherStage) () -> Multi.createFrom().empty());
-        stages.add((Stage.Map) () -> i -> (int) i + 1);
-        // This graph is not closed - so it's invalid
-        Graph graph = () -> stages;
-        engine.buildCompletion(graph);
+        assertThrows(IllegalArgumentException.class, () -> {
+            engine = new Engine();
+            List<Stage> stages = new ArrayList<>();
+            stages.add((Stage.PublisherStage) () -> Multi.createFrom().empty());
+            stages.add((Stage.Map) () -> i -> (int) i + 1);
+            // This graph is not closed - so it's invalid
+            Graph graph = () -> stages;
+            engine.buildCompletion(graph);
+        });
     }
 
-    @Test(expected = UnsupportedStageException.class)
+    @Test
     public void testCompletionWithUnknownStage() {
-        engine = new Engine();
-        List<Stage> stages = new ArrayList<>();
-        stages.add((Stage.PublisherStage) () -> Multi.createFrom().empty());
-        stages.add((Stage.Map) () -> i -> (int) i + 1);
-        stages.add(new Stage() {
-            // Unknown stage.
+        assertThrows(UnsupportedStageException.class, () -> {
+            engine = new Engine();
+            List<Stage> stages = new ArrayList<>();
+            stages.add((Stage.PublisherStage) () -> Multi.createFrom().empty());
+            stages.add((Stage.Map) () -> i -> (int) i + 1);
+            stages.add(new Stage() {
+                // Unknown stage.
+            });
+            stages.add(new Stage.FindFirst() {
+            });
+            Graph graph = () -> stages;
+            assertThat(engine.buildCompletion(graph)).isNotNull();
         });
-        stages.add(new Stage.FindFirst() {
-        });
-        Graph graph = () -> stages;
-        assertThat(engine.buildCompletion(graph)).isNotNull();
     }
 
     @Test
@@ -116,28 +125,32 @@ public class EngineTest {
         assertThat(engine.buildPublisher(graph)).isNotNull();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidPublisher() {
-        engine = new Engine();
-        List<Stage> stages = new ArrayList<>();
-        stages.add((Stage.Map) () -> i -> (int) i + 1);
-        stages.add(new Stage.FindFirst() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            engine = new Engine();
+            List<Stage> stages = new ArrayList<>();
+            stages.add((Stage.Map) () -> i -> (int) i + 1);
+            stages.add(new Stage.FindFirst() {
+            });
+            // This graph is closed, invalid as publisher
+            Graph graph = () -> stages;
+            engine.buildPublisher(graph);
         });
-        // This graph is closed, invalid as publisher
-        Graph graph = () -> stages;
-        engine.buildPublisher(graph);
     }
 
-    @Test(expected = UnsupportedStageException.class)
+    @Test
     public void testCreatingPublisherWithUnknownStage() {
-        engine = new Engine();
-        List<Stage> stages = new ArrayList<>();
-        stages.add(new Stage() {
-            // Unknown stage.
+        assertThrows(UnsupportedStageException.class, () -> {
+            engine = new Engine();
+            List<Stage> stages = new ArrayList<>();
+            stages.add(new Stage() {
+                // Unknown stage.
+            });
+            stages.add((Stage.Map) () -> i -> (int) i + 1);
+            Graph graph = () -> stages;
+            engine.buildPublisher(graph);
         });
-        stages.add((Stage.Map) () -> i -> (int) i + 1);
-        Graph graph = () -> stages;
-        engine.buildPublisher(graph);
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/CancelStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/CancelStageFactoryTest.java
@@ -3,6 +3,7 @@ package io.smallrye.mutiny.streams.stages;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -15,7 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.spi.Stage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Multi;
@@ -27,6 +28,7 @@ import io.smallrye.mutiny.streams.operators.TerminalStage;
  *
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */
+@SuppressWarnings("ConstantConditions")
 public class CancelStageFactoryTest extends StageTestBase {
 
     private final CancelStageFactory factory = new CancelStageFactory();
@@ -40,7 +42,7 @@ public class CancelStageFactoryTest extends StageTestBase {
         Multi<Long> publisher = Multi.createFrom().ticks().every(Duration.ofMillis(1000))
                 .emitOn(Infrastructure.getDefaultExecutor())
                 .onItem().invoke(list::add)
-                .on().cancellation(() -> cancelled.set(true));
+                .onCancellation().invoke(() -> cancelled.set(true));
         CompletionStage<Void> stage = terminal.apply(publisher);
         stage.toCompletableFuture().get();
 
@@ -49,9 +51,9 @@ public class CancelStageFactoryTest extends StageTestBase {
         assertThat(cancelled).isTrue();
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
     @Test

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/ConcatStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/ConcatStageFactoryTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,7 +17,7 @@ import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.spi.Graph;
 import org.eclipse.microprofile.reactive.streams.operators.spi.Stage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.streams.Engine;
@@ -30,25 +31,27 @@ public class ConcatStageFactoryTest extends StageTestBase {
 
     private final ConcatStageFactory factory = new ConcatStageFactory();
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testWithoutAStage() {
-        factory.create(new Engine(), null);
+        assertThrows(NullPointerException.class, () -> factory.create(new Engine(), null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testWithoutEngine() {
-        Graph g1 = () -> Collections.singletonList((Stage.Of) () -> Arrays.asList(1, 2, 3));
-        Graph g2 = () -> Collections.singletonList((Stage.Of) () -> Arrays.asList(1, 2, 3));
-        factory.create(null, new Stage.Concat() {
-            @Override
-            public Graph getFirst() {
-                return g1;
-            }
+        assertThrows(NullPointerException.class, () -> {
+            Graph g1 = () -> Collections.singletonList((Stage.Of) () -> Arrays.asList(1, 2, 3));
+            Graph g2 = () -> Collections.singletonList((Stage.Of) () -> Arrays.asList(1, 2, 3));
+            factory.create(null, new Stage.Concat() {
+                @Override
+                public Graph getFirst() {
+                    return g1;
+                }
 
-            @Override
-            public Graph getSecond() {
-                return g2;
-            }
+                @Override
+                public Graph getSecond() {
+                    return g2;
+                }
+            });
         });
     }
 

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/CoupledStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/CoupledStageFactoryTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -29,9 +29,7 @@ public class CoupledStageFactoryTest {
                 .via(
                         ReactiveStreams.coupled(ReactiveStreams.builder().cancel().build(),
                                 idlePublisher()
-                                        .onTerminate(() -> {
-                                            publisherCancelled.complete(null);
-                                        }).buildRs()))
+                                        .onTerminate(() -> publisherCancelled.complete(null)).buildRs()))
                 .onComplete(() -> downstreamCompleted.complete(null))
                 .ignore()
                 .run();
@@ -80,13 +78,9 @@ public class CoupledStageFactoryTest {
         CompletableFuture<Void> subscriberCompleted = new CompletableFuture<>();
         CompletableFuture<Void> upstreamCancelled = new CompletableFuture<>();
         idlePublisher()
-                .onTerminate(() -> {
-                    upstreamCancelled.complete(null);
-                })
+                .onTerminate(() -> upstreamCancelled.complete(null))
                 .via(ReactiveStreams.coupled(ReactiveStreams.builder()
-                        .onComplete(() -> {
-                            subscriberCompleted.complete(null);
-                        })
+                        .onComplete(() -> subscriberCompleted.complete(null))
                         .ignore(), ReactiveStreams.empty()))
                 .ignore().run();
         await(subscriberCompleted);

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/CoupledStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/CoupledStageFactoryTest.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeoutException;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.tck.spi.QuietRuntimeException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CoupledStageFactoryTest {
 

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/DistinctStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/DistinctStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Objects;
@@ -10,7 +11,7 @@ import java.util.concurrent.Executors;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -50,9 +51,9 @@ public class DistinctStageFactoryTest extends StageTestBase {
         return Objects.toString(i);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/DropWhileStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/DropWhileStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -10,7 +11,7 @@ import java.util.concurrent.Executors;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.tck.spi.QuietRuntimeException;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -40,23 +41,24 @@ public class DropWhileStageFactoryTest extends StageTestBase {
         assertThat(list).hasSize(5).containsExactly(6, 7, 8, 9, 10);
     }
 
-    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutPredicate() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
-    @Test(expected = QuietRuntimeException.class)
+    @Test
     public void dropWhileStageShouldPropagateUpstreamErrorsAfterFinishedDropping() {
-        this.awaitCompletion(this.infiniteStream().peek((i) -> {
+        assertThrows(QuietRuntimeException.class, () -> this.awaitCompletion(this.infiniteStream().peek((i) -> {
             if (i == 4) {
                 throw new QuietRuntimeException("failed");
             }
-        }).dropWhile((i) -> i < 3).toList().run());
+        }).dropWhile((i) -> i < 3).toList().run()));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FailedPublisherStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FailedPublisherStageFactoryTest.java
@@ -1,6 +1,8 @@
 package io.smallrye.mutiny.streams.stages;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.streams.operators.PublisherStage;
 import io.smallrye.mutiny.test.AssertSubscriber;
@@ -22,13 +24,14 @@ public class FailedPublisherStageFactoryTest extends StageTestBase {
                 .assertHasFailedWith(Exception.class, "Boom");
     }
 
-    @Test(expected = NullPointerException.class)
-    public void createWithoutError() {
-        factory.create(null, () -> null);
+    @Test
+    public void createWithoutStage() {
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
-    public void createWithoutStage() {
-        factory.create(null, null);
+    @Test
+    public void createWithoutError() {
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
+
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FilterStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FilterStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -10,7 +11,7 @@ import java.util.function.Predicate;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -41,14 +42,14 @@ public class FilterStageFactoryTest extends StageTestBase {
         assertThat(list).hasSize(5).containsExactly(2, 4, 6, 8, 10);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutPredicate() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FindFirstStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FindFirstStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -8,7 +9,7 @@ import java.util.concurrent.Executors;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -21,7 +22,7 @@ public class FindFirstStageFactoryTest extends StageTestBase {
 
     private final FindFirstStageFactory factory = new FindFirstStageFactory();
 
-    private ExecutorService executor = Executors.newFixedThreadPool(4);
+    private final ExecutorService executor = Executors.newFixedThreadPool(4);
 
     @After
     public void shutdown() {
@@ -39,9 +40,9 @@ public class FindFirstStageFactoryTest extends StageTestBase {
         assertThat(optional).contains(6);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FlatMapCompletionStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FlatMapCompletionStageFactoryTest.java
@@ -2,6 +2,7 @@ package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Objects;
@@ -15,7 +16,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
@@ -66,14 +67,14 @@ public class FlatMapCompletionStageFactoryTest extends StageTestBase {
         return cf;
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutFunction() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
     @Test
@@ -99,7 +100,8 @@ public class FlatMapCompletionStageFactoryTest extends StageTestBase {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    @Test
     public void testInjectingANullItem() {
         AtomicReference<Subscriber<? super String>> reference = new AtomicReference<>();
         Publisher<String> publisher = s -> {
@@ -113,17 +115,22 @@ public class FlatMapCompletionStageFactoryTest extends StageTestBase {
                 .run()
                 .toCompletableFuture();
 
-        reference.get().onNext(null);
+        assertThrows(NullPointerException.class, () -> {
+            reference.get().onNext(null);
+        });
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void flatMapCsStageShouldFailIfNullIsReturned() {
-        CompletableFuture<Void> cancelled = new CompletableFuture<>();
-        CompletionStage<List<Object>> result = this.infiniteStream()
-                .onTerminate(() -> cancelled.complete(null))
-                .flatMapCompletionStage(t -> CompletableFuture.completedFuture(null)).toList().run();
-        this.awaitCompletion(cancelled);
-        this.awaitCompletion(result);
+        assertThrows(NullPointerException.class, () -> {
+
+            CompletableFuture<Void> cancelled = new CompletableFuture<>();
+            CompletionStage<List<Object>> result = this.infiniteStream()
+                    .onTerminate(() -> cancelled.complete(null))
+                    .flatMapCompletionStage(t -> CompletableFuture.completedFuture(null)).toList().run();
+            this.awaitCompletion(cancelled);
+            this.awaitCompletion(result);
+        });
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FlatMapIterableStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FlatMapIterableStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
@@ -13,7 +14,7 @@ import java.util.concurrent.Executors;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -66,14 +67,15 @@ public class FlatMapIterableStageFactoryTest extends StageTestBase {
         return cf;
     }
 
-    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutFunction() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FlatMapStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FlatMapStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Objects;
@@ -13,7 +14,7 @@ import java.util.concurrent.Executors;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -62,14 +63,15 @@ public class FlatMapStageFactoryTest extends StageTestBase {
         return cf;
     }
 
-    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutFunction() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromCompletionStageFactoryNullableTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromCompletionStageFactoryNullableTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.spi.Stage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Checks the behavior of the {@link Stage.FromCompletionStageNullable} class.
@@ -92,14 +93,14 @@ public class FromCompletionStageFactoryNullableTest extends StageTestBase {
         await().untilAtomic(done, is(true));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithNullResult() {
-        factory.create(null, () -> null).get();
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null).get());
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromCompletionStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromCompletionStageFactoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,7 +13,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Checks the behavior of the {@link org.eclipse.microprofile.reactive.streams.spi.Stage.FromCompletionStage} class.
@@ -91,14 +92,14 @@ public class FromCompletionStageFactoryTest extends StageTestBase {
         await().untilAtomic(done, is(true));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithNullAsResult() {
-        factory.create(null, () -> null).get();
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null).get());
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromIterableStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromIterableStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.List;
@@ -8,7 +9,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Checks the behavior of the {@link FromIterableStageFactory} class.
@@ -32,14 +33,13 @@ public class FromIterableStageFactoryTest extends StageTestBase {
         assertThat(empty).isEmpty();
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutFunction() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
-
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromPublisherStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/FromPublisherStageFactoryTest.java
@@ -2,13 +2,14 @@ package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -47,13 +48,14 @@ public class FromPublisherStageFactoryTest extends StageTestBase {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutFunction() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/LimitStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/LimitStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -9,7 +10,7 @@ import java.util.concurrent.Executors;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -38,9 +39,10 @@ public class LimitStageFactoryTest extends StageTestBase {
         assertThat(list).hasSize(5).containsExactly(1, 2, 3, 4, 5);
     }
 
-    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/MapStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/MapStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Objects;
@@ -10,7 +11,7 @@ import java.util.concurrent.Executors;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -53,14 +54,15 @@ public class MapStageFactoryTest extends StageTestBase {
         return Objects.toString(i);
     }
 
-    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutFunction() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnCompleteStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnCompleteStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
@@ -10,7 +11,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -54,14 +55,14 @@ public class OnCompleteStageFactoryTest extends StageTestBase {
         return Objects.toString(i);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutFunction() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnErrorResumeWithStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnErrorResumeWithStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.List;
@@ -11,7 +12,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -58,14 +59,14 @@ public class OnErrorResumeWithStageFactoryTest extends StageTestBase {
         assertThat(error.get()).hasMessage("Failed");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutFunction() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnErrorStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnErrorStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.Objects;
@@ -11,7 +12,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -58,14 +59,14 @@ public class OnErrorStageFactoryTest extends StageTestBase {
         return Objects.toString(i);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutFunction() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnTerminateStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/OnTerminateStageFactoryTest.java
@@ -3,6 +3,7 @@ package io.smallrye.mutiny.streams.stages;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.Objects;
@@ -13,7 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -82,14 +83,14 @@ public class OnTerminateStageFactoryTest extends StageTestBase {
         return Objects.toString(i);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutFunction() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/PeekStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/PeekStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,7 +12,7 @@ import java.util.concurrent.Executors;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -60,14 +61,14 @@ public class PeekStageFactoryTest extends StageTestBase {
         return Objects.toString(i);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutFunction() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/ProcessorStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/ProcessorStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
@@ -11,7 +12,7 @@ import java.util.concurrent.Executors;
 import org.eclipse.microprofile.reactive.streams.operators.ProcessorBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Processor;
 
 import io.smallrye.mutiny.Multi;
@@ -77,14 +78,14 @@ public class ProcessorStageFactoryTest extends StageTestBase {
         return asStringProcessorBuilder().buildRs();
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutFunction() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/SkipStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/SkipStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -9,7 +10,7 @@ import java.util.concurrent.Executors;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -22,7 +23,7 @@ public class SkipStageFactoryTest extends StageTestBase {
 
     private final SkipStageFactory factory = new SkipStageFactory();
 
-    private ExecutorService executor = Executors.newFixedThreadPool(4);
+    private final ExecutorService executor = Executors.newFixedThreadPool(4);
 
     @After
     public void shutdown() {
@@ -38,9 +39,10 @@ public class SkipStageFactoryTest extends StageTestBase {
         assertThat(list).hasSize(5).containsExactly(6, 7, 8, 9, 10);
     }
 
-    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/SubscriberStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/SubscriberStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -9,7 +10,7 @@ import java.util.concurrent.Executors;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.streams.Engine;
@@ -43,14 +44,14 @@ public class SubscriberStageFactoryTest extends StageTestBase {
         assertThat(optional).contains(6);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutStage() {
-        factory.create(new Engine(), null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutSubscriber() {
-        factory.create(new Engine(), () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(new Engine(), () -> null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/TakeWhileStageFactoryTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/stages/TakeWhileStageFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.streams.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -9,7 +10,7 @@ import java.util.concurrent.Executors;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 
@@ -22,7 +23,7 @@ public class TakeWhileStageFactoryTest extends StageTestBase {
 
     private final TakeWhileStageFactory factory = new TakeWhileStageFactory();
 
-    private ExecutorService executor = Executors.newFixedThreadPool(4);
+    private final ExecutorService executor = Executors.newFixedThreadPool(4);
 
     @After
     public void shutdown() {
@@ -38,14 +39,15 @@ public class TakeWhileStageFactoryTest extends StageTestBase {
         assertThat(list).hasSize(5).containsExactly(1, 2, 3, 4, 5);
     }
 
-    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
+    @Test
     public void createWithoutStage() {
-        factory.create(null, null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void createWithoutPredicate() {
-        factory.create(null, () -> null);
+        assertThrows(NullPointerException.class, () -> factory.create(null, () -> null));
     }
 
 }

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/utils/WrappedSubscriberTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/utils/WrappedSubscriberTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 

--- a/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/utils/WrappedSubscriptionTest.java
+++ b/reactive-streams-operators/src/test/java/io/smallrye/mutiny/streams/utils/WrappedSubscriptionTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
 public class WrappedSubscriptionTest {

--- a/reactor/pom.xml
+++ b/reactor/pom.xml
@@ -27,6 +27,12 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny-test-utils</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/reactor/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
+++ b/reactor/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
@@ -2,7 +2,7 @@ package io.smallrye.mutiny.converters;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.converters.multi.MultiReactorConverters;

--- a/reactor/src/test/java/io/smallrye/mutiny/converters/MultiConvertToTest.java
+++ b/reactor/src/test/java/io/smallrye/mutiny/converters/MultiConvertToTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.converters.multi.MultiReactorConverters;

--- a/reactor/src/test/java/io/smallrye/mutiny/converters/UniConvertFromTest.java
+++ b/reactor/src/test/java/io/smallrye/mutiny/converters/UniConvertFromTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.converters.uni.UniReactorConverters;

--- a/reactor/src/test/java/io/smallrye/mutiny/converters/UniConvertToTest.java
+++ b/reactor/src/test/java/io/smallrye/mutiny/converters/UniConvertToTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.converters.uni.UniReactorConverters;

--- a/rxjava/pom.xml
+++ b/rxjava/pom.xml
@@ -27,6 +27,12 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny-test-utils</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/rxjava/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
+++ b/rxjava/src/test/java/io/smallrye/mutiny/converters/MultiConvertFromTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.reactivex.Completable;
 import io.reactivex.Flowable;

--- a/rxjava/src/test/java/io/smallrye/mutiny/converters/MultiConvertToTest.java
+++ b/rxjava/src/test/java/io/smallrye/mutiny/converters/MultiConvertToTest.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.reactivex.*;
 import io.reactivex.observers.TestObserver;

--- a/rxjava/src/test/java/io/smallrye/mutiny/converters/UniConvertFromTest.java
+++ b/rxjava/src/test/java/io/smallrye/mutiny/converters/UniConvertFromTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.fail;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.reactivex.Completable;
 import io.reactivex.Flowable;

--- a/rxjava/src/test/java/io/smallrye/mutiny/converters/UniConvertToTest.java
+++ b/rxjava/src/test/java/io/smallrye/mutiny/converters/UniConvertToTest.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.reactivex.Completable;
 import io.reactivex.Flowable;

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -26,5 +26,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/test-utils/src/test/java/io/smallrye/mutiny/test/AbstractSubscriberTest.java
+++ b/test-utils/src/test/java/io/smallrye/mutiny/test/AbstractSubscriberTest.java
@@ -12,10 +12,12 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.awaitility.core.ConditionTimeoutException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+@SuppressWarnings("ConstantConditions")
 public class AbstractSubscriberTest {
 
     @Test
@@ -221,7 +223,8 @@ public class AbstractSubscriberTest {
         await().untilTrue(unblocked);
     }
 
-    @Test(timeout = 10)
+    @Test
+    @Timeout(1)
     public void testAwaitWhenAlreadyCompleted() {
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
         subscriber.onComplete();
@@ -233,7 +236,8 @@ public class AbstractSubscriberTest {
 
     }
 
-    @Test(timeout = 10)
+    @Test
+    @Timeout(1)
     public void testAwaitWhenAlreadyFailed() {
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
         subscriber.onError(new IOException("boom"));

--- a/test-utils/src/test/java/io/smallrye/mutiny/test/AssertSubscriberTest.java
+++ b/test-utils/src/test/java/io/smallrye/mutiny/test/AssertSubscriberTest.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
 public class AssertSubscriberTest {

--- a/test-utils/src/test/java/io/smallrye/mutiny/test/MocksTest.java
+++ b/test-utils/src/test/java/io/smallrye/mutiny/test/MocksTest.java
@@ -2,7 +2,7 @@ package io.smallrye.mutiny.test;
 
 import static org.mockito.Mockito.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 


### PR DESCRIPTION
- Provide the Reactive Streams TCK using Junit5 instead of TestNG
- Migrate reactive streams ops test to Junit5
- Migrate context-propagation test from TestNG to Junit5
- Switch main implementation tests to Junit 5
- Switch the TCK implementation to Junit 5
