### PR TITLE
Migrate the context-propagation module to junit 5

### DIFF
--- a/context-propagation/pom.xml
+++ b/context-propagation/pom.xml
@@ -43,14 +43,20 @@
             <scope>test</scope>
         </dependency>
 
-
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>reactive-streams-junit5-tck</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams-tck</artifactId>
             <version>${reactive-streams.version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>
@@ -65,7 +71,8 @@
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <junitArtifactName>none:none</junitArtifactName>
+                            <!-- Disable TestNG -->
+                            <testNGArtifactName>none:none</testNGArtifactName>
                         </configuration>
                     </execution>
                 </executions>

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationMultiTckTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationMultiTckTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.stream.LongStream;
 
 import org.reactivestreams.Publisher;
-import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.context.ContextPropagationMultiInterceptor;

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationSubscriberTckTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationSubscriberTckTest.java
@@ -4,8 +4,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.reactivestreams.tck.SubscriberWhiteboxVerification;
 import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.junit5.SubscriberWhiteboxVerification;
 
 import io.smallrye.mutiny.context.ContextPropagationMultiInterceptor;
 


### PR DESCRIPTION
Missed it during the main migration.

Surefire was configured to ignore junit. 