### PR TITLE
proof of concept for renaming proposal (#273)

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -413,7 +413,11 @@ public interface Uni<T> {
      * @return the new {@link Uni}
      */
     default Uni<T> invoke(Consumer<? super T> callback) {
-        return onItem().invoke(nonNull(callback, "callback"));
+        return onItem().invoke(callback);
+    }
+
+    default Uni<T> invoke(Runnable callback) {
+        return onItem().invoke(callback);
     }
 
     /**
@@ -425,14 +429,18 @@ public interface Uni<T> {
      * {@code Uni} fails, the failure is propagated downstream. If the callback throws an exception, this exception
      * is propagated downstream as failure.
      * <p>
-     * This method is a shortcut on {@link UniOnItem#invokeUni(Function)}
+     * This method is a shortcut on {@link UniOnItem#call(Function)}
      *
      * @param action the function taking the item and returning a {@link Uni}, must not be {@code null}, must not return
      *        {@code null}
      * @return the new {@link Uni}
      */
-    default Uni<T> invokeUni(Function<? super T, Uni<?>> action) {
-        return onItem().invokeUni(nonNull(action, "action"));
+    default Uni<T> call(Function<? super T, Uni<?>> action) {
+        return onItem().call(action);
+    }
+
+    default Uni<T> call(Supplier<Uni<?>> action) {
+        return onItem().call(action);
     }
 
     /**
@@ -482,7 +490,7 @@ public interface Uni<T> {
      * @param <O> the type of item
      * @return a new {@link Uni} that would fire events from the uni produced by the mapper function, possibly
      *         in an asynchronous manner.
-     * @see #then(Supplier)
+     * @see #chain(Supplier)
      */
     default <O> Uni<O> chain(Function<? super T, Uni<? extends O>> mapper) {
         return onItem().transformToUni(nonNull(mapper, "mapper"));
@@ -517,9 +525,9 @@ public interface Uni<T> {
      *         in an asynchronous manner.
      * @see #chain(Function)
      */
-    default <O> Uni<O> then(Supplier<Uni<? extends O>> supplier) {
-        Supplier<Uni<? extends O>> actual = nonNull(supplier, "supplier");
-        return onItem().transformToUni(ignored -> actual.get());
+    default <O> Uni<O> chain(Supplier<Uni<? extends O>> supplier) {
+        nonNull(supplier, "supplier");
+        return onItem().transformToUni(ignored -> supplier.get());
     }
 
     /**
@@ -564,7 +572,7 @@ public interface Uni<T> {
      * }
      * </pre>
      * <p>
-     * This method is a shortcut for {@link UniOnItemOrFailure#invokeUni(BiFunction)}:
+     * This method is a shortcut for {@link UniOnItemOrFailure#call(BiFunction)}:
      * {@code onItemOrFailure().invokeUni((item, err) -> supplier.get())}
      *
      * @param supplier a {@link Uni} supplier, cannot be {@code null} and cannot return {@code null}.
@@ -574,7 +582,7 @@ public interface Uni<T> {
      */
     default <O> Uni<T> eventually(Supplier<Uni<? extends O>> supplier) {
         Supplier<Uni<? extends O>> actual = nonNull(supplier, "supplier");
-        return onItemOrFailure().invokeUni((item, err) -> actual.get());
+        return onItemOrFailure().call((item, err) -> actual.get());
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
@@ -61,6 +61,11 @@ public class UniOnFailure<T> {
                 new UniOnItemConsume<>(upstream, null, nonNull(callback, "callback"), predicate));
     }
 
+    public Uni<T> invoke(Runnable callback) {
+        ParameterValidation.nonNull(callback, "callback");
+        return invoke(i -> callback.run());
+    }
+
     /**
      * Produces a new {@link Uni} invoking the given function when the current {@link Uni} propagates a failure
      * (matching the predicate if set). The function can transform the received failure into another exception that will
@@ -76,7 +81,7 @@ public class UniOnFailure<T> {
      * @param action the callback, must not be {@code null}
      * @return the new {@link Uni}
      */
-    public Uni<T> invokeUni(Function<Throwable, Uni<?>> action) {
+    public Uni<T> call(Function<Throwable, Uni<?>> action) {
         ParameterValidation.nonNull(action, "action");
         return recoverWithUni(failure -> {
             Uni<?> uni = Objects.requireNonNull(action.apply(failure), "The `action` produced a `null` uni");
@@ -85,6 +90,11 @@ public class UniOnFailure<T> {
                     .onItem().failWith(ignored -> failure)
                     .onFailure().apply(subFailure -> new CompositeException(failure, subFailure));
         });
+    }
+
+    public Uni<T> call(Supplier<Uni<?>> action) {
+        ParameterValidation.nonNull(action, "action");
+        return call(i -> action.get());
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNotNull.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnNotNull.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.reactivestreams.Publisher;
 
@@ -36,6 +37,10 @@ public class UniOnNotNull<T> {
         });
     }
 
+    public Uni<T> invoke(Runnable callback) {
+        return invoke(i -> callback.run());
+    }
+
     /**
      * Produces a new {@link Uni} invoking the given @{code action} when the {@code item} event is received. Note that
      * if the received item is {@code null}, the action is not executed, and the item is propagated downstream.
@@ -47,14 +52,18 @@ public class UniOnNotNull<T> {
      * @param action the callback, must not be {@code null}
      * @return the new {@link Uni}
      */
-    public Uni<T> invokeUni(Function<? super T, Uni<?>> action) {
-        return upstream.onItem().invokeUni(item -> {
+    public Uni<T> call(Function<? super T, Uni<?>> action) {
+        return upstream.onItem().call(item -> {
             if (item != null) {
                 return action.apply(item);
             } else {
                 return Uni.createFrom().nullItem();
             }
         });
+    }
+
+    public Uni<T> call(Supplier<Uni<?>> action) {
+        return call(i -> action.get());
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnTerminate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnTerminate.java
@@ -60,21 +60,21 @@ public class UniOnTerminate<T> {
      *        The function must return a non-{@code null} {@link Uni}.
      * @return the new {@link Uni}
      */
-    public Uni<T> invokeUni(Functions.Function3<? super T, Throwable, Boolean, Uni<?>> mapper) {
+    public Uni<T> call(Functions.Function3<? super T, Throwable, Boolean, Uni<?>> mapper) {
         return Infrastructure
                 .onUniCreation(new UniOnTerminationInvokeUni<>(upstream, ParameterValidation.nonNull(mapper, "mapper")));
     }
 
     /**
      * Attaches an action that is executed when the {@link Uni} emits an item or a failure or when the subscriber
-     * cancels the subscription. Unlike {@link #invokeUni(Functions.Function3)} the supplier does not receive the
+     * cancels the subscription. Unlike {@link #call(Functions.Function3)} the supplier does not receive the
      * item, failure or cancellation.
      *
      * @param supplier must return a non-{@code null} {@link Uni}.
      * @return the new {@link Uni}
      */
-    public Uni<T> invokeUni(Supplier<Uni<?>> supplier) {
+    public Uni<T> call(Supplier<Uni<?>> supplier) {
         nonNull(supplier, "supplier");
-        return invokeUni((i, f, c) -> supplier.get());
+        return call((i, f, c) -> supplier.get());
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
@@ -501,7 +501,7 @@ public class UniOnEventTest {
                 .onItem().invoke(Item::set)
                 .onFailure().invoke(failure::set)
                 .onSubscribe().invoke(subscription::set)
-                .onTermination().invokeUni((r, f, c) -> {
+                .onTermination().call((r, f, c) -> {
                     terminate.set(r);
                     return Uni.createFrom().item(r * 100);
                 })
@@ -524,7 +524,7 @@ public class UniOnEventTest {
                 .onItem().invoke(Item::set)
                 .onFailure().invoke(failure::set)
                 .onSubscribe().invoke(subscription::set)
-                .onTermination().invokeUni((r, f, c) -> {
+                .onTermination().call((r, f, c) -> {
                     terminate.set(f);
                     return Uni.createFrom().failure(new IOException("tada"));
                 })
@@ -549,7 +549,7 @@ public class UniOnEventTest {
                 .onItem().invoke(Item::set)
                 .onFailure().invoke(failure::set)
                 .onSubscribe().invoke(subscription::set)
-                .onTermination().invokeUni((r, f, c) -> {
+                .onTermination().call((r, f, c) -> {
                     terminate.set(f);
                     throw new RuntimeException("tada");
                 })
@@ -573,7 +573,7 @@ public class UniOnEventTest {
             // Do not emit anything, just observe the cancellation.
             e.onTermination(() -> upstreamCancelled.set(true));
         })
-                .onTermination().invokeUni((r, f, c) -> {
+                .onTermination().call((r, f, c) -> {
                     terminated.set(c);
                     return Uni.createFrom().item(100);
                 })
@@ -596,7 +596,7 @@ public class UniOnEventTest {
         AtomicBoolean cancelled = new AtomicBoolean();
         AtomicInteger count = new AtomicInteger();
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
-                .onTermination().invokeUni((r, f, c) -> {
+                .onTermination().call((r, f, c) -> {
                     count.incrementAndGet();
                     terminated.set(true);
                     return Uni.createFrom().emitter(e -> {
@@ -630,7 +630,7 @@ public class UniOnEventTest {
             // Do not emit anything, just observe the cancellation.
             e.onTermination(() -> upstreamCancelled.set(true));
         })
-                .onTermination().invokeUni((r, f, c) -> {
+                .onTermination().call((r, f, c) -> {
                     terminated.set(c);
                     return Uni
                             .createFrom().failure(new IOException("boom"))
@@ -658,7 +658,7 @@ public class UniOnEventTest {
         AtomicBoolean cancelled = new AtomicBoolean();
         AtomicInteger count = new AtomicInteger();
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
-                .onTermination().invokeUni(() -> {
+                .onTermination().call(() -> {
                     count.incrementAndGet();
                     terminated.set(true);
                     return Uni.createFrom().emitter(e -> {

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureInvokeTest.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,12 +24,12 @@ public class UniOnFailureInvokeTest {
 
     @Test
     public void testThatConsumeMustNotBeNull() {
-        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onFailure().invoke(null));
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onFailure().invoke((Consumer<Throwable>) null));
     }
 
     @Test
     public void testThatFunctionMustNotBeNull() {
-        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onFailure().invokeUni(null));
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).onFailure().call((Function<Throwable, Uni<?>>) null));
     }
 
     @Test
@@ -59,7 +61,7 @@ public class UniOnFailureInvokeTest {
         AtomicReference<Throwable> container = new AtomicReference<>();
         AtomicInteger called = new AtomicInteger(-1);
         int res = failure
-                .onFailure().invokeUni(t -> {
+                .onFailure().call(t -> {
                     container.set(t);
                     return Uni.createFrom().item(22).onItem().invoke(called::set);
                 })
@@ -76,7 +78,7 @@ public class UniOnFailureInvokeTest {
         AtomicReference<Throwable> container = new AtomicReference<>();
         AtomicInteger called = new AtomicInteger(-1);
         int res = Uni.createFrom().item(3)
-                .onFailure().invokeUni(t -> {
+                .onFailure().call(t -> {
                     container.set(t);
                     return Uni.createFrom().item(22).onItem().invoke(called::set);
                 })
@@ -106,7 +108,7 @@ public class UniOnFailureInvokeTest {
         AtomicReference<Throwable> container = new AtomicReference<>();
         AtomicInteger called = new AtomicInteger(-1);
         int res = Uni.createFrom().nullItem()
-                .onFailure().invokeUni(t -> {
+                .onFailure().call(t -> {
                     container.set(t);
                     return Uni.createFrom().item(22).onItem().invoke(called::set);
                 })
@@ -137,7 +139,7 @@ public class UniOnFailureInvokeTest {
     public void testInvokeUniOnFailureWithExceptionThrownByCallback() {
         AtomicReference<Throwable> container = new AtomicReference<>();
         assertThatThrownBy(() -> failure
-                .onFailure().invokeUni(t -> {
+                .onFailure().call(t -> {
                     container.set(t);
                     throw new IllegalStateException("bad");
                 })
@@ -151,7 +153,7 @@ public class UniOnFailureInvokeTest {
     public void testInvokeUniOnFailureWithCallbackReturningNull() {
         AtomicReference<Throwable> container = new AtomicReference<>();
         assertThatThrownBy(() -> failure
-                .onFailure().invokeUni(t -> {
+                .onFailure().call(t -> {
                     container.set(t);
                     return null;
                 })
@@ -168,7 +170,7 @@ public class UniOnFailureInvokeTest {
 
         AtomicInteger result = new AtomicInteger();
         AtomicReference<Throwable> failed = new AtomicReference<>();
-        Cancellable cancellable = failure.onFailure().invokeUni(i -> uni).subscribe()
+        Cancellable cancellable = failure.onFailure().call(i -> uni).subscribe()
                 .with(result::set, failed::set);
 
         cancellable.cancel();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToUniTest.java
@@ -50,18 +50,18 @@ public class UniOnItemTransformToUniTest {
     @Test
     public void testTransformToUniShortcutThen() {
         UniAssertSubscriber<Integer> test = UniAssertSubscriber.create();
-        Uni.createFrom().item(1).then(() -> Uni.createFrom().item(2)).subscribe().withSubscriber(test);
+        Uni.createFrom().item(1).chain(() -> Uni.createFrom().item(2)).subscribe().withSubscriber(test);
         test.assertCompletedSuccessfully().assertItem(2).assertNoFailure();
     }
 
     @Test
     public void testTransformToUniShortcutThenWithNullSupplier() {
-        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).then((Supplier<Uni<?>>) null));
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).chain((Supplier<Uni<?>>) null));
     }
 
     @Test
     public void testTransformToUniShortcutChainWithNullMapper() {
-        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).chain(null));
+        assertThrows(IllegalArgumentException.class, () -> Uni.createFrom().item(1).chain((Supplier<Uni<?>>) null));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNotNullItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnNotNullItemTest.java
@@ -77,7 +77,7 @@ public class UniOnNotNullItemTest {
         AtomicBoolean invoked = new AtomicBoolean();
         AtomicReference<String> called = new AtomicReference<>();
         assertThat(Uni.createFrom().item("hello")
-                .onItem().ifNotNull().invokeUni(s -> {
+                .onItem().ifNotNull().call(s -> {
                     invoked.set(s.equals("hello"));
                     return Uni.createFrom().item("something").onItem().invoke(called::set);
                 })
@@ -88,7 +88,7 @@ public class UniOnNotNullItemTest {
         invoked.set(false);
         called.set(null);
         assertThat(Uni.createFrom().nullItem()
-                .onItem().ifNotNull().invokeUni(s -> {
+                .onItem().ifNotNull().call(s -> {
                     invoked.set(s.equals("hello"));
                     return Uni.createFrom().item("something").onItem().invoke(called::set);
                 })
@@ -98,7 +98,7 @@ public class UniOnNotNullItemTest {
         assertThat(called).hasValue(null);
 
         assertThatThrownBy(() -> Uni.createFrom().<String> failure(new Exception("boom"))
-                .onItem().ifNotNull().invokeUni(s -> {
+                .onItem().ifNotNull().call(s -> {
                     invoked.set(s.equals("hello"));
                     return Uni.createFrom().item("something").onItem().invoke(called::set);
                 })
@@ -113,7 +113,7 @@ public class UniOnNotNullItemTest {
     public void testInvokeUniProducingNull() {
         assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(() -> Uni.createFrom().item("hello")
-                        .onItem().ifNotNull().invokeUni(s -> null)
+                        .onItem().ifNotNull().call(s -> null)
                         .await().indefinitely());
     }
 
@@ -122,7 +122,7 @@ public class UniOnNotNullItemTest {
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> Uni.createFrom().item("hello")
                         .onItem().ifNotNull()
-                        .invokeUni(s -> Uni.createFrom().failure(new IllegalStateException("boom")))
+                        .call(s -> Uni.createFrom().failure(new IllegalStateException("boom")))
                         .await().indefinitely())
                 .withMessageContaining("boom");
     }
@@ -135,7 +135,7 @@ public class UniOnNotNullItemTest {
 
         Cancellable cancellable = Uni.createFrom().item("hello")
                 .onItem().ifNotNull()
-                .invokeUni(s -> emitter)
+                .call(s -> emitter)
                 .subscribe().with(res::set);
 
         cancellable.cancel();

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedFunctionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedFunctionTest.java
@@ -85,7 +85,7 @@ public class UncheckedFunctionTest {
     public void testWithThen() {
         UniSupplier reader = () -> Uni.createFrom().item(23);
         int res = Uni.createFrom().item(1)
-                .then(supplier(reader::get))
+                .chain(supplier(reader::get))
                 .await().indefinitely();
         assertThat(res).isEqualTo(23);
     }


### PR DESCRIPTION
This is a little proof of concept for what I've proposed in #273

- rename `invokeUni()` to `call()`
- rename `then()` to `chain()`
- add nullary-function overloads for `invoke()` and `call()`
