### PR TITLE
Add more tests to handle edges cases  + Fix racy tests

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/tuples/Functions.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/tuples/Functions.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 public final class Functions {
 
     private Functions() {
+        // Avoid direct instantiation.
     }
 
     @FunctionalInterface

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
@@ -22,19 +22,19 @@ public class UniOnEventTest {
 
     @Test
     public void testActionsOnItem() {
-        AtomicInteger Item = new AtomicInteger();
+        AtomicInteger item = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicInteger terminate = new AtomicInteger();
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
-                .onItem().invoke(Item::set)
+                .onItem().invoke(item::set)
                 .onFailure().invoke(failure::set)
                 .onSubscribe().invoke(subscription::set)
                 .onTermination().invoke((r, f, c) -> terminate.set(r))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber.assertItem(1);
-        assertThat(Item).hasValue(1);
+        assertThat(item).hasValue(1);
         assertThat(failure.get()).isNull();
         assertThat(subscription.get()).isNotNull();
         assertThat(terminate).hasValue(1);
@@ -42,19 +42,19 @@ public class UniOnEventTest {
 
     @Test
     public void testActionsUsingOnAndThenGroup() {
-        AtomicInteger Item = new AtomicInteger();
+        AtomicInteger item = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicInteger terminate = new AtomicInteger();
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
-                .on().item().invoke(Item::set)
+                .on().item().invoke(item::set)
                 .on().failure().invoke(failure::set)
                 .on().subscribe().invoke(subscription::set)
                 .on().termination().invoke((r, f, c) -> terminate.set(r))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber.assertItem(1);
-        assertThat(Item).hasValue(1);
+        assertThat(item).hasValue(1);
         assertThat(failure.get()).isNull();
         assertThat(subscription.get()).isNotNull();
         assertThat(terminate).hasValue(1);
@@ -62,19 +62,19 @@ public class UniOnEventTest {
 
     @Test
     public void testActionsOnItem2() {
-        AtomicInteger Item = new AtomicInteger();
+        AtomicInteger item = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicBoolean terminate = new AtomicBoolean();
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
-                .onItem().invoke(Item::set)
+                .onItem().invoke(item::set)
                 .onFailure().invoke(failure::set)
                 .onSubscribe().invoke(subscription::set)
                 .onTermination().invoke(() -> terminate.set(true))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber.assertItem(1);
-        assertThat(Item).hasValue(1);
+        assertThat(item).hasValue(1);
         assertThat(failure.get()).isNull();
         assertThat(subscription.get()).isNotNull();
         assertThat(terminate).isTrue();
@@ -82,19 +82,19 @@ public class UniOnEventTest {
 
     @Test
     public void testActionsOnFailures() {
-        AtomicInteger Item = new AtomicInteger();
+        AtomicInteger item = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicReference<Throwable> terminate = new AtomicReference<>();
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> failure(new IOException("boom"))
-                .onItem().invoke(Item::set)
+                .onItem().invoke(item::set)
                 .onFailure().invoke(failure::set)
                 .onSubscribe().invoke(subscription::set)
                 .onTermination().invoke((r, f, c) -> terminate.set(f))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber.assertCompletedWithFailure().assertFailure(IOException.class, "boom");
-        assertThat(Item).doesNotHaveValue(1);
+        assertThat(item).doesNotHaveValue(1);
         assertThat(failure.get()).isInstanceOf(IOException.class);
         assertThat(subscription.get()).isNotNull();
         assertThat(terminate.get()).isInstanceOf(IOException.class);
@@ -102,19 +102,19 @@ public class UniOnEventTest {
 
     @Test
     public void testActionsOnFailures2() {
-        AtomicInteger Item = new AtomicInteger();
+        AtomicInteger item = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicBoolean terminate = new AtomicBoolean();
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> failure(new IOException("boom"))
-                .onItem().invoke(Item::set)
+                .onItem().invoke(item::set)
                 .onFailure().invoke(failure::set)
                 .onSubscribe().invoke(subscription::set)
                 .onTermination().invoke(() -> terminate.set(true))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber.assertCompletedWithFailure().assertFailure(IOException.class, "boom");
-        assertThat(Item).doesNotHaveValue(1);
+        assertThat(item).doesNotHaveValue(1);
         assertThat(failure.get()).isInstanceOf(IOException.class);
         assertThat(subscription.get()).isNotNull();
         assertThat(terminate).isTrue();
@@ -122,7 +122,7 @@ public class UniOnEventTest {
 
     @Test
     public void testWhenOnItemThrowsAnException() {
-        AtomicInteger Item = new AtomicInteger();
+        AtomicInteger item = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicInteger ItemFromTerminate = new AtomicInteger();
@@ -142,7 +142,7 @@ public class UniOnEventTest {
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber.assertCompletedWithFailure().assertFailure(IllegalStateException.class, "boom");
-        assertThat(Item).doesNotHaveValue(1);
+        assertThat(item).doesNotHaveValue(1);
         assertThat(failure.get()).isInstanceOf(IllegalStateException.class);
         assertThat(subscription.get()).isNotNull();
         assertThat(ItemFromTerminate).doesNotHaveValue(1);
@@ -151,7 +151,7 @@ public class UniOnEventTest {
 
     @Test
     public void testWhenOnItemThrowsAnException2() {
-        AtomicInteger Item = new AtomicInteger();
+        AtomicInteger item = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicBoolean terminated = new AtomicBoolean();
@@ -165,7 +165,7 @@ public class UniOnEventTest {
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber.assertCompletedWithFailure().assertFailure(IllegalStateException.class, "boom");
-        assertThat(Item).doesNotHaveValue(1);
+        assertThat(item).doesNotHaveValue(1);
         assertThat(failure.get()).isInstanceOf(IllegalStateException.class);
         assertThat(subscription.get()).isNotNull();
         assertThat(terminated).isTrue();
@@ -173,12 +173,12 @@ public class UniOnEventTest {
 
     @Test
     public void testWhenOnFailureThrowsAnException() {
-        AtomicInteger Item = new AtomicInteger();
+        AtomicInteger item = new AtomicInteger();
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicInteger ItemFromTerminate = new AtomicInteger();
         AtomicReference<Throwable> failureFromTerminate = new AtomicReference<>();
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> failure(new IOException("kaboom"))
-                .onItem().invoke(Item::set)
+                .onItem().invoke(item::set)
                 .onFailure().invoke(e -> {
                     throw new IllegalStateException("boom");
                 })
@@ -194,7 +194,7 @@ public class UniOnEventTest {
         subscriber.assertCompletedWithFailure()
                 .assertFailure(CompositeException.class, "boom")
                 .assertFailure(CompositeException.class, "kaboom");
-        assertThat(Item).doesNotHaveValue(1);
+        assertThat(item).doesNotHaveValue(1);
         assertThat(subscription.get()).isNotNull();
         assertThat(ItemFromTerminate).doesNotHaveValue(1);
         assertThat(failureFromTerminate.get()).isInstanceOf(CompositeException.class);
@@ -202,11 +202,11 @@ public class UniOnEventTest {
 
     @Test
     public void testWhenOnFailureThrowsAnException2() {
-        AtomicInteger Item = new AtomicInteger();
+        AtomicInteger item = new AtomicInteger();
         AtomicReference<Subscription> subscription = new AtomicReference<>();
         AtomicBoolean terminated = new AtomicBoolean();
         UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> failure(new IOException("kaboom"))
-                .onItem().invoke(Item::set)
+                .onItem().invoke(item::set)
                 .onFailure().invoke(e -> {
                     throw new IllegalStateException("boom");
                 })
@@ -217,7 +217,7 @@ public class UniOnEventTest {
         subscriber.assertCompletedWithFailure()
                 .assertFailure(CompositeException.class, "boom")
                 .assertFailure(CompositeException.class, "kaboom");
-        assertThat(Item).doesNotHaveValue(1);
+        assertThat(item).doesNotHaveValue(1);
         assertThat(subscription.get()).isNotNull();
         assertThat(terminated).isTrue();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnTerminationTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnTerminationTest.java
@@ -1,0 +1,149 @@
+package io.smallrye.mutiny.operators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.CompositeException;
+import io.smallrye.mutiny.TestException;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+@SuppressWarnings("ConstantConditions")
+public class UniOnTerminationTest {
+
+    @Test
+    public void testTerminationAfterImmediateItem() {
+        AtomicInteger terminate = new AtomicInteger();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
+                .onTermination().invoke((r, f, c) -> terminate.set(r))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertItem(1);
+        assertThat(terminate).hasValue(1);
+    }
+
+    @Test
+    public void testTerminationAfterDelayedItem() {
+        AtomicInteger terminate = new AtomicInteger();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .onTermination().invoke((r, f, c) -> terminate.set(r))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber
+                .await()
+                .assertItem(1);
+        assertThat(terminate).hasValue(1);
+    }
+
+    @Test
+    public void testTerminationWithoutParamsAfterImmediateItem() {
+        AtomicBoolean terminate = new AtomicBoolean();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
+                .onTermination().invoke(() -> terminate.set(true))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertItem(1);
+        assertThat(terminate).isTrue();
+    }
+
+    @Test
+    public void testTerminationWithoutParamsAfterDelayedItem() {
+        AtomicBoolean terminate = new AtomicBoolean();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .onTermination().invoke(() -> terminate.set(true))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.await().assertItem(1);
+        assertThat(terminate).isTrue();
+    }
+
+    @Test
+    public void testTerminationAfterImmediateFailure() {
+        AtomicReference<Throwable> terminate = new AtomicReference<>();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> failure(new TestException("boom"))
+                .onTermination().invoke((r, f, c) -> terminate.set(f))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertFailure(TestException.class, "boom");
+        assertThat(terminate.get()).hasMessageContaining("boom").isInstanceOf(TestException.class);
+    }
+
+    @Test
+    public void testTerminationAfterDelayedFailure() {
+        AtomicReference<Throwable> terminate = new AtomicReference<>();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> failure(new TestException("boom"))
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .onTermination().invoke((r, f, c) -> terminate.set(f))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.await().assertFailure(TestException.class, "boom");
+        assertThat(terminate.get()).hasMessageContaining("boom").isInstanceOf(TestException.class);
+    }
+
+    @Test
+    public void testTerminationWithoutParameterAfterImmediateFailure() {
+        AtomicBoolean terminate = new AtomicBoolean();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> failure(new TestException("boom"))
+                .onTermination().invoke(() -> terminate.set(true))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertFailure(TestException.class, "boom");
+        assertThat(terminate).isTrue();
+    }
+
+    @Test
+    public void testTerminationWithoutParameterAfterDelayedFailure() {
+        AtomicBoolean terminate = new AtomicBoolean();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> failure(new TestException("boom"))
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .onTermination().invoke(() -> terminate.set(true))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.await().assertFailure(TestException.class, "boom");
+        assertThat(terminate).isTrue();
+    }
+
+    @Test
+    public void testTerminationAfterCancellation() {
+        AtomicBoolean terminate = new AtomicBoolean();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> emitter(e -> {
+        })
+                .onTermination().invoke((r, f, c) -> terminate.set(c))
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertSubscribed()
+                .cancel();
+        assertThat(terminate).isTrue();
+    }
+
+    @Test
+    public void testTerminationWithImmediateCancellation() {
+        AtomicBoolean terminate = new AtomicBoolean();
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> emitter(e -> {
+        })
+                .onTermination().invoke((r, f, c) -> terminate.set(c))
+                .subscribe().withSubscriber(new UniAssertSubscriber<>(true));
+        subscriber.assertSubscribed();
+        assertThat(terminate).isTrue();
+    }
+
+    @Test
+    public void testTerminationThrowingExceptionOnItem() {
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().item(1)
+                .onTermination().invoke((r, f, c) -> {
+                    throw new TestException("boom");
+                })
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertFailure(TestException.class, "boom");
+    }
+
+    @Test
+    public void testTerminationThrowingExceptionOnFailure() {
+        UniAssertSubscriber<? super Integer> subscriber = Uni.createFrom().<Integer> failure(new IOException("I/O"))
+                .onTermination().invoke((r, f, c) -> {
+                    throw new TestException("boom");
+                })
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertFailure(CompositeException.class, "boom");
+        subscriber.assertFailure(CompositeException.class, "I/O");
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
@@ -27,6 +27,16 @@ public class UniRunSubscriptionOnTest {
     }
 
     @Test
+    public void testRunSubscriptionOnWithSupplierWithDeprecatedMethod() {
+        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
+        Uni.createFrom().item(() -> 1)
+                .subscribeOn(ForkJoinPool.commonPool())
+                .subscribe().withSubscriber(subscriber);
+        subscriber.await().assertItem(1);
+        assertThat(subscriber.getOnSubscribeThreadName()).isNotEqualTo(Thread.currentThread().getName());
+    }
+
+    @Test
     public void testWithWithImmediateValue() {
         UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/multicast/MultiReferenceCountSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/multicast/MultiReferenceCountSubscriberTest.java
@@ -1,0 +1,109 @@
+package io.smallrye.mutiny.operators.multi.multicast;
+
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+import io.smallrye.mutiny.test.AssertSubscriber;
+
+class MultiReferenceCountSubscriberTest {
+
+    @Test
+    public void testCancellationWithASingleSubscriber() {
+        Multi<Integer> multi = Multi.createFrom().items(1, 2, 3, 4, 5)
+                .broadcast().withCancellationAfterLastSubscriberDeparture().toAllSubscribers();
+
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(1));
+
+        subscriber.request(2).cancel();
+        subscriber.assertReceived(1, 2, 3);
+    }
+
+    @Test
+    public void testCancellationWithATwoSubscribers() {
+        Multi<Integer> multi = Multi.createFrom().items(1, 2, 3, 4, 5)
+                .broadcast().withCancellationAfterLastSubscriberDeparture().toAllSubscribers();
+
+        AssertSubscriber<Integer> subscriber1 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(0));
+        AssertSubscriber<Integer> subscriber2 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(0));
+
+        subscriber2.request(3);
+        subscriber1.request(3).cancel();
+        subscriber1.assertReceived(1, 2, 3);
+        subscriber2.request(20);
+        subscriber2.assertReceived(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void testFailureWithASingleSubscriber() {
+        Multi<Integer> multi = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items(1, 2, 3, 4, 5),
+                Multi.createFrom().failure(new IOException("boom")))
+                .broadcast()
+                .withCancellationAfterLastSubscriberDeparture().toAllSubscribers();
+
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+
+        subscriber
+                .assertHasFailedWith(IOException.class, "boom");
+
+    }
+
+    @Test
+    public void testFailureWithATwoSubscribers() {
+        Multi<Integer> multi = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items(1, 2, 3, 4, 5),
+                Multi.createFrom().failure(new IOException("boom")))
+                .broadcast()
+                .withCancellationAfterLastSubscriberDeparture().toAllSubscribers();
+
+        AssertSubscriber<Integer> subscriber1 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        AssertSubscriber<Integer> subscriber2 = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+
+        subscriber1
+                .assertHasFailedWith(IOException.class, "boom");
+
+        subscriber2
+                .assertHasFailedWith(IOException.class, "boom");
+    }
+
+    @Test
+    public void testFailureWithRogueUpstream() {
+        Multi<Integer> multi = new AbstractMulti<Integer>() {
+            @Override
+            public void subscribe(MultiSubscriber<? super Integer> subscriber) {
+                subscriber.onSubscribe(mock(Subscription.class));
+                subscriber.onItem(1);
+                subscriber.onItem(2);
+                subscriber.onItem(3);
+                subscriber.onFailure(new IOException("boom"));
+                subscriber.onItem(4);
+                subscriber.onItem(5);
+                subscriber.onComplete();
+                subscriber.onItem(6);
+            }
+        }
+                .broadcast()
+                .withCancellationAfterLastSubscriberDeparture().toAllSubscribers();
+
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+
+        subscriber
+                .assertHasFailedWith(IOException.class, "boom");
+
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/stack/StackTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/stack/StackTest.java
@@ -2,7 +2,6 @@ package io.smallrye.mutiny.stack;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
@@ -59,15 +58,15 @@ public class StackTest {
         List<Integer> list = new ArrayList<>();
 
         AtomicInteger index = new AtomicInteger();
-        Uni.createFrom().<Byte> emitter(e -> {
-            if (index.get() > bytes.length) {
-                e.complete(null);
+        Uni.createFrom().<Integer> emitter(e -> {
+            if (index.get() > bytes.length - 1) {
+                e.complete(Integer.MIN_VALUE);
             } else {
                 int i = index.getAndIncrement();
-                e.complete(bytes[i]);
+                e.complete(new Byte(bytes[i]).intValue());
             }
-        }).repeat().until(Objects::isNull)
-                .subscribe().with(i -> list.add(i.intValue()));
+        }).repeat().until(b -> b == Integer.MIN_VALUE)
+                .subscribe().with(list::add);
 
         for (int i = 0; i < length; i++) {
             Assertions.assertThat(bytes[i]).isEqualTo(list.get(i).byteValue());


### PR DESCRIPTION
Cover multiple areas with tests.
These tests verify edges case like failure management, cancellation... 

It also fixes a few racy tests.

- Verify the behavior of the MultiReferenceCountSubscriber when receiving failures, cancellation and illegal events.
- Add a test using the deprecated Uni.subscribeOn just to verify it's still working
- Fix the UnicastProcessorTest
- Fix test ending with an ArrayOutOfBoundException.
- Verify the behavior of Uni.onTermination when the callback throws exceptions
- Verify Uni Timeout management
