### PR TITLE
A couple of additional tests and fixes

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -432,7 +432,7 @@ public interface Multi<T> extends Publisher<T> {
      */
     @Deprecated
     default Multi<T> invokeUni(Function<? super T, Uni<?>> action) {
-        return onItem().invokeUni(nonNull(action, "action"));
+        return onItem().call(nonNull(action, "action"));
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDistinctUntilChangedOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDistinctUntilChangedOp.java
@@ -35,6 +35,8 @@ public final class MultiDistinctUntilChangedOp<T> extends AbstractMultiOperator<
             if (last == null || !last.equals(t)) {
                 last = t;
                 downstream.onItem(t);
+            } else {
+                // Request the next one, as that item is dropped.
                 request(1);
             }
         }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnItemCallTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnItemCallTest.java
@@ -1,0 +1,334 @@
+package io.smallrye.mutiny.operators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.TestException;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.test.AssertSubscriber;
+
+@SuppressWarnings("ConstantConditions")
+public class MultiOnItemCallTest {
+
+    @Test
+    public void testOnItemWithSupplier() {
+        AtomicInteger counter = new AtomicInteger();
+        Multi.createFrom().items(1, 2, 3, 4)
+                .onItem().call(() -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().item(5);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2, 3, 4).assertCompletedSuccessfully();
+        assertThat(counter).hasValue(4);
+    }
+
+    @Test
+    public void testOnItemWithSupplierShortcut() {
+        AtomicInteger counter = new AtomicInteger();
+        Multi.createFrom().items(1, 2, 3, 4)
+                .call(() -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().item(5);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2, 3, 4).assertCompletedSuccessfully();
+        assertThat(counter).hasValue(4);
+    }
+
+    @Test
+    public void testOnItemWithFunction() {
+        AtomicInteger counter = new AtomicInteger();
+        Multi.createFrom().items(1, 2, 3, 4)
+                .onItem().call(i -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().item(i);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2, 3, 4).assertCompletedSuccessfully();
+        assertThat(counter).hasValue(4);
+    }
+
+    @Test
+    public void testOnItemWithFunctionShortcut() {
+        AtomicInteger counter = new AtomicInteger();
+        Multi.createFrom().items(1, 2, 3, 4)
+                .call(i -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().item(i);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2, 3, 4).assertCompletedSuccessfully();
+        assertThat(counter).hasValue(4);
+    }
+
+    @Test
+    public void testOnItemWithFunctionDeprecatedShortcut() {
+        AtomicInteger counter = new AtomicInteger();
+        Multi.createFrom().items(1, 2, 3, 4)
+                .invokeUni(i -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().item(i);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2, 3, 4).assertCompletedSuccessfully();
+        assertThat(counter).hasValue(4);
+    }
+
+    @Test
+    public void testOnItemWithFunctionDeprecated() {
+        AtomicInteger counter = new AtomicInteger();
+        Multi.createFrom().items(1, 2, 3, 4)
+                .onItem().invokeUni(i -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().item(i);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2, 3, 4).assertCompletedSuccessfully();
+        assertThat(counter).hasValue(4);
+    }
+
+    @Test
+    public void testOnFailureWithSupplier() {
+        AtomicInteger counter = new AtomicInteger();
+        Multi.createFrom().items(1, 2, 3, 4).onCompletion().fail()
+                .onItem().call(() -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().item(5);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2, 3, 4).assertHasFailedWith(NoSuchElementException.class, null);
+        assertThat(counter).hasValue(4);
+    }
+
+    @Test
+    public void testOnFailureWithFunction() {
+        AtomicInteger counter = new AtomicInteger();
+        Multi.createFrom().items(1, 2, 3, 4).onCompletion().fail()
+                .onItem().call(i -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().item(5);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2, 3, 4).assertHasFailedWith(NoSuchElementException.class, null);
+        assertThat(counter).hasValue(4);
+    }
+
+    @Test
+    public void testOnCompletionWithSupplier() {
+        AtomicInteger counter = new AtomicInteger();
+        Multi.createFrom().empty()
+                .onItem().call(() -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().item(5);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertHasNotReceivedAnyItem().assertCompletedSuccessfully();
+        assertThat(counter).hasValue(0);
+    }
+
+    @Test
+    public void testOnCompletionWithFunction() {
+        AtomicInteger counter = new AtomicInteger();
+        Multi.createFrom().empty()
+                .onItem().call(i -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().item(5);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertHasNotReceivedAnyItem().assertCompletedSuccessfully();
+        assertThat(counter).hasValue(0);
+    }
+
+    @Test
+    public void testCancellationWithSupplier() {
+        AtomicInteger counter = new AtomicInteger();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        Multi.createFrom().nothing()
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .onItem().call(() -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().item(5);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .cancel()
+                .assertHasNotReceivedAnyItem().assertNotTerminated();
+        assertThat(counter).hasValue(0);
+        assertThat(cancelled).isTrue();
+    }
+
+    @Test
+    public void testCancellationWithFunction() {
+        AtomicInteger counter = new AtomicInteger();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        Multi.createFrom().nothing()
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .onItem().call(i -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().item(5);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .cancel()
+                .assertHasNotReceivedAnyItem().assertNotTerminated();
+        assertThat(counter).hasValue(0);
+        assertThat(cancelled).isTrue();
+    }
+
+    @Test
+    public void testCancellationWithSupplierAndPendingUni() {
+        AtomicInteger counter = new AtomicInteger();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        Multi.createFrom().items(1)
+                .onItem().call(() -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().emitter(e -> e.onTermination(() -> cancelled.set(true)));
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .cancel()
+                .assertHasNotReceivedAnyItem().assertNotTerminated();
+        assertThat(counter).hasValue(1);
+        assertThat(cancelled).isTrue();
+    }
+
+    @Test
+    public void testCancellationWithFunctionAndPendingUni() {
+        AtomicInteger counter = new AtomicInteger();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        Multi.createFrom().items(1)
+                .onItem().call(i -> {
+                    counter.incrementAndGet();
+                    return Uni.createFrom().emitter(e -> e.onTermination(() -> cancelled.set(true)));
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .cancel()
+                .assertHasNotReceivedAnyItem().assertNotTerminated();
+        assertThat(counter).hasValue(1);
+        assertThat(cancelled).isTrue();
+    }
+
+    @Test
+    public void testNullSupplierOrFunction() {
+        assertThatThrownBy(() -> Multi.createFrom().items(1)
+                .onItem().call((Function<? super Integer, Uni<?>>) null)).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> Multi.createFrom().items(1)
+                .onItem().call((Supplier<Uni<?>>) null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testMapperThrowingExceptionOnItemWithSupplier() {
+        AtomicInteger counter = new AtomicInteger();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        Multi.createFrom().items(1, 2, 3, 4)
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .onItem().call(() -> {
+                    if (counter.incrementAndGet() == 3) {
+                        throw new TestException("boom");
+                    }
+                    return Uni.createFrom().item(0);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2).assertHasFailedWith(TestException.class, "boom");
+        assertThat(counter).hasValue(3);
+        assertThat(cancelled).isTrue();
+    }
+
+    @Test
+    public void testMapperThrowingExceptionOnItemWithFunction() {
+        AtomicInteger counter = new AtomicInteger();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        Multi.createFrom().items(1, 2, 3, 4)
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .onItem().call(i -> {
+                    if (counter.incrementAndGet() == 3) {
+                        throw new TestException("boom");
+                    }
+                    return Uni.createFrom().item(i);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2).assertHasFailedWith(TestException.class, "boom");
+        assertThat(counter).hasValue(3);
+        assertThat(cancelled).isTrue();
+    }
+
+    @Test
+    public void testMapperReturningNullWithSupplier() {
+        AtomicInteger counter = new AtomicInteger();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        Multi.createFrom().items(1, 2, 3, 4)
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .onItem().call(() -> {
+                    if (counter.incrementAndGet() == 3) {
+                        return null;
+                    }
+                    return Uni.createFrom().item(0);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2).assertHasFailedWith(NullPointerException.class, "");
+        assertThat(counter).hasValue(3);
+        assertThat(cancelled).isTrue();
+    }
+
+    @Test
+    public void testMapperReturningNullWithFunction() {
+        AtomicInteger counter = new AtomicInteger();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        Multi.createFrom().items(1, 2, 3, 4)
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .onItem().call(i -> {
+                    if (counter.incrementAndGet() == 3) {
+                        return null;
+                    }
+                    return Uni.createFrom().item(0);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2).assertHasFailedWith(NullPointerException.class, "");
+        assertThat(counter).hasValue(3);
+        assertThat(cancelled).isTrue();
+    }
+
+    @Test
+    public void testMapperProducingFailureWithSupplier() {
+        AtomicInteger counter = new AtomicInteger();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        Multi.createFrom().items(1, 2, 3, 4)
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .onItem().call(() -> {
+                    if (counter.incrementAndGet() == 3) {
+                        return Uni.createFrom().failure(new TestException("boom"));
+                    }
+                    return Uni.createFrom().item(0);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2).assertHasFailedWith(TestException.class, "boom");
+        assertThat(counter).hasValue(3);
+        assertThat(cancelled).isTrue();
+    }
+
+    @Test
+    public void testMapperProducingFailureWithFunction() {
+        AtomicInteger counter = new AtomicInteger();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        Multi.createFrom().items(1, 2, 3, 4)
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .onItem().call(i -> {
+                    if (counter.incrementAndGet() == 3) {
+                        return Uni.createFrom().failure(new TestException("boom"));
+                    }
+                    return Uni.createFrom().item(0);
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertReceived(1, 2).assertHasFailedWith(TestException.class, "boom");
+        assertThat(counter).hasValue(3);
+        assertThat(cancelled).isTrue();
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
@@ -322,7 +322,7 @@ public class MultiFromIterableTest {
             }
         };
 
-        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(10);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
         Multi.createFrom().iterable(it).subscribe(subscriber);
 
@@ -369,7 +369,7 @@ public class MultiFromIterableTest {
             }
         };
 
-        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(1);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
         Multi.createFrom().iterable(it).subscribe(subscriber);
 

--- a/implementation/src/test/java/tck/AbstractPublisherTck.java
+++ b/implementation/src/test/java/tck/AbstractPublisherTck.java
@@ -22,6 +22,14 @@ public abstract class AbstractPublisherTck<T> extends PublisherVerification<T> {
         super(new TestEnvironment(timeout));
     }
 
+    public Multi<Long> upstream(long elements) {
+        return Multi.createFrom().deferred(() -> Multi.createFrom().iterable(iterate(elements)));
+    }
+
+    public Multi<Long> failedUpstream() {
+        return Multi.createFrom().failure(() -> new RuntimeException("failed"));
+    }
+
     @Override
     public Publisher<T> createFailedPublisher() {
         return Multi.createFrom().failure(new TestException());
@@ -30,7 +38,7 @@ public abstract class AbstractPublisherTck<T> extends PublisherVerification<T> {
     /**
      * Creates an Iterable with the specified number of elements or an infinite one if
      * elements > Integer.MAX_VALUE.
-     * 
+     *
      * @param elements the number of elements to return, Integer.MAX_VALUE means an infinite sequence
      * @return the Iterable
      */
@@ -43,17 +51,13 @@ public abstract class AbstractPublisherTck<T> extends PublisherVerification<T> {
     }
 
     /**
-     * Create an array of Long values, ranging from 0L to elements - 1L.
-     * 
-     * @param elements the number of elements to return
-     * @return the array
+     * An infinite stream of integers starting from one.
      */
-    protected Long[] array(long elements) {
-        Long[] a = new Long[(int) elements];
-        for (int i = 0; i < elements; i++) {
-            a[i] = (long) i;
-        }
-        return a;
+    Multi<Integer> infiniteStream() {
+        return Multi.createFrom().iterable(() -> {
+            AtomicInteger value = new AtomicInteger();
+            return IntStream.generate(value::incrementAndGet).boxed().iterator();
+        });
     }
 
     static final class FiniteRange implements Iterable<Long> {
@@ -122,15 +126,5 @@ public abstract class AbstractPublisherTck<T> extends PublisherVerification<T> {
                 throw new UnsupportedOperationException();
             }
         }
-    }
-
-    /**
-     * An infinite stream of integers starting from one.
-     */
-    Multi<Integer> infiniteStream() {
-        return Multi.createFrom().iterable(() -> {
-            AtomicInteger value = new AtomicInteger();
-            return IntStream.generate(value::incrementAndGet).boxed().iterator();
-        });
     }
 }

--- a/implementation/src/test/java/tck/MultiDisjointTckTest.java
+++ b/implementation/src/test/java/tck/MultiDisjointTckTest.java
@@ -10,7 +10,13 @@ public class MultiDisjointTckTest extends AbstractPublisherTck<Long> {
     @Override
     public Publisher<Long> createPublisher(long elements) {
         Long[] list = LongStream.rangeClosed(1, elements).boxed().toArray(Long[]::new);
-        return Multi.createFrom().item(list)
+        return Multi.createFrom().item(() -> list)
+                .onItem().disjoint();
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        return failedUpstream()
                 .onItem().disjoint();
     }
 

--- a/implementation/src/test/java/tck/MultiDistinctTckTest.java
+++ b/implementation/src/test/java/tck/MultiDistinctTckTest.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
@@ -17,7 +16,7 @@ import org.reactivestreams.Publisher;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.Subscriptions;
 
-public class MultiDistinctTckTest extends AbstractPublisherTck<Integer> {
+public class MultiDistinctTckTest extends AbstractPublisherTck<Long> {
     @Test
     public void distinctStageShouldReturnDistinctElements() {
         assertEquals(await(
@@ -38,10 +37,11 @@ public class MultiDistinctTckTest extends AbstractPublisherTck<Integer> {
 
     @Test
     public void distinctStageShouldPropagateUpstreamExceptions() {
-        assertThrows(QuietRuntimeException.class, () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
-                .transform().byDroppingDuplicates()
-                .collectItems().asList()
-                .subscribeAsCompletionStage()));
+        assertThrows(QuietRuntimeException.class,
+                () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
+                        .transform().byDroppingDuplicates()
+                        .collectItems().asList()
+                        .subscribeAsCompletionStage()));
     }
 
     @Test
@@ -79,14 +79,14 @@ public class MultiDistinctTckTest extends AbstractPublisherTck<Integer> {
     }
 
     @Override
-    public Publisher<Integer> createPublisher(long elements) {
-        return Multi.createFrom().items(IntStream.rangeClosed(1, (int) elements).boxed())
+    public Publisher<Long> createPublisher(long elements) {
+        return upstream(elements)
                 .transform().byDroppingDuplicates();
     }
 
     @Override
-    public Publisher<Integer> createFailedPublisher() {
-        return Multi.createFrom().<Integer> failure(new RuntimeException("failed"))
+    public Publisher<Long> createFailedPublisher() {
+        return failedUpstream()
                 .transform().byDroppingDuplicates();
     }
 

--- a/implementation/src/test/java/tck/MultiDistinctUntilChangedTckTest.java
+++ b/implementation/src/test/java/tck/MultiDistinctUntilChangedTckTest.java
@@ -1,0 +1,21 @@
+package tck;
+
+import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
+
+public class MultiDistinctUntilChangedTckTest extends AbstractPublisherTck<Long> {
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        return Multi.createFrom().iterable(iterate(elements))
+                .transform().byDroppingRepetitions();
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+                .transform().byDroppingRepetitions();
+    }
+
+}

--- a/implementation/src/test/java/tck/MultiDistinctUntilChangedTckTest.java
+++ b/implementation/src/test/java/tck/MultiDistinctUntilChangedTckTest.java
@@ -2,19 +2,17 @@ package tck;
 
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
-
 public class MultiDistinctUntilChangedTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().iterable(iterate(elements))
+        return upstream(elements)
                 .transform().byDroppingRepetitions();
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .transform().byDroppingRepetitions();
     }
 

--- a/implementation/src/test/java/tck/MultiEmitOnTckTest.java
+++ b/implementation/src/test/java/tck/MultiEmitOnTckTest.java
@@ -7,8 +7,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
-
 public class MultiEmitOnTckTest extends AbstractPublisherTck<Long> {
 
     private ExecutorService executor;
@@ -25,13 +23,13 @@ public class MultiEmitOnTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().iterable(iterate(elements))
+        return upstream(elements)
                 .emitOn(executor);
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new IllegalStateException("failed"))
+        return failedUpstream()
                 .emitOn(executor);
     }
 }

--- a/implementation/src/test/java/tck/MultiFirstTckTest.java
+++ b/implementation/src/test/java/tck/MultiFirstTckTest.java
@@ -44,8 +44,9 @@ public class MultiFirstTckTest extends AbstractTck {
 
     @Test
     public void findFirstStageShouldPropagateErrors() {
-        assertThrows(QuietRuntimeException.class, () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
-                .collectItems().first().subscribeAsCompletionStage()));
+        assertThrows(QuietRuntimeException.class,
+                () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
+                        .collectItems().first().subscribeAsCompletionStage()));
     }
 
     @Test

--- a/implementation/src/test/java/tck/MultiFlatMapCompletionStageTckTest.java
+++ b/implementation/src/test/java/tck/MultiFlatMapCompletionStageTckTest.java
@@ -35,7 +35,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Lon
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().iterable(iterate(elements))
+        return upstream(elements)
                 // Use supplyAsync on purpose to check the concurrency.
                 .onItem().transformToUni(i -> Uni.createFrom().completionStage(CompletableFuture.supplyAsync(() -> i)))
                 .merge();
@@ -43,7 +43,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Lon
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 // Use supplyAsync on purpose to check the concurrency.
                 .onItem().transformToUni(i -> Uni.createFrom().completionStage(CompletableFuture.supplyAsync(() -> i)))
                 .merge();

--- a/implementation/src/test/java/tck/MultiFlatMapTckTest.java
+++ b/implementation/src/test/java/tck/MultiFlatMapTckTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.stream.LongStream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -76,10 +75,11 @@ public class MultiFlatMapTckTest extends AbstractPublisherTck<Long> {
 
     @Test
     public void flatMapStageShouldPropagateUpstreamExceptions() {
-        assertThrows(QuietRuntimeException.class, () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
-                .flatMap(x -> Multi.createFrom().item(x))
-                .collectItems().asList()
-                .subscribeAsCompletionStage()));
+        assertThrows(QuietRuntimeException.class,
+                () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
+                        .flatMap(x -> Multi.createFrom().item(x))
+                        .collectItems().asList()
+                        .subscribeAsCompletionStage()));
     }
 
     @Test
@@ -127,13 +127,13 @@ public class MultiFlatMapTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .flatMap(x -> Multi.createFrom().item(x));
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .flatMap(x -> Multi.createFrom().item(x));
     }
 }

--- a/implementation/src/test/java/tck/MultiFromCollectionTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromCollectionTckTest.java
@@ -14,7 +14,7 @@ public class MultiFromCollectionTckTest extends AbstractPublisherTck<Long> {
         for (int i = 0; i < elements; i++) {
             list.add((long) i);
         }
-        return Multi.createFrom().items(list.toArray(new Long[0]));
+        return Multi.createFrom().deferred(() -> Multi.createFrom().items(list.toArray(new Long[0])));
     }
 
     @Override

--- a/implementation/src/test/java/tck/MultiFromItemsTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromItemsTckTest.java
@@ -10,7 +10,7 @@ public class MultiFromItemsTckTest extends AbstractPublisherTck<Long> {
     @Override
     public Publisher<Long> createPublisher(long elements) {
         Long[] list = LongStream.rangeClosed(1, elements).boxed().toArray(Long[]::new);
-        return Multi.createFrom().items(list);
+        return Multi.createFrom().deferred(() -> Multi.createFrom().items(list));
     }
 
     @Override

--- a/implementation/src/test/java/tck/MultiFromIterableTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromIterableTckTest.java
@@ -12,7 +12,7 @@ public class MultiFromIterableTckTest extends AbstractPublisherTck<Long> {
     @Override
     public Publisher<Long> createPublisher(long elements) {
         List<Long> list = LongStream.rangeClosed(1, elements).boxed().collect(Collectors.toList());
-        return Multi.createFrom().iterable(list);
+        return Multi.createFrom().deferred(() -> Multi.createFrom().iterable(list));
     }
 
     @Override

--- a/implementation/src/test/java/tck/MultiFromResourceTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromResourceTckTest.java
@@ -10,16 +10,11 @@ public class MultiFromResourceTckTest extends AbstractPublisherTck<Long> {
     public Publisher<Long> createPublisher(long elements) {
         return Multi.createFrom().resource(() -> elements, max -> {
             int bound = max.intValue();
-            return Multi.createFrom().range(0, bound);
+            return upstream(bound);
         }).withFinalizer(x -> {
             return Uni.createFrom().item(() -> null);
         })
-                .onItem().transform(i -> (long) i);
-    }
-
-    @Override
-    public long maxElementsFromPublisher() {
-        return 1024;
+                .onItem().transform(i -> i);
     }
 
 }

--- a/implementation/src/test/java/tck/MultiFromStreamTckTest.java
+++ b/implementation/src/test/java/tck/MultiFromStreamTckTest.java
@@ -1,7 +1,6 @@
 package tck;
 
 import java.util.stream.LongStream;
-import java.util.stream.Stream;
 
 import org.reactivestreams.Publisher;
 
@@ -10,12 +9,6 @@ import io.smallrye.mutiny.Multi;
 public class MultiFromStreamTckTest extends AbstractPublisherTck<Long> {
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        Stream<Long> list = LongStream.rangeClosed(1, elements).boxed();
-        return Multi.createFrom().items(list);
-    }
-
-    @Override
-    public long maxElementsFromPublisher() {
-        return 1024;
+        return Multi.createFrom().items(() -> LongStream.rangeClosed(1, elements).boxed());
     }
 }

--- a/implementation/src/test/java/tck/MultiOnCancellationCallTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnCancellationCallTckTest.java
@@ -1,23 +1,20 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 public class MultiOnCancellationCallTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .onCancellation().call(() -> Uni.createFrom().nullItem());
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onCancellation().call(() -> Uni.createFrom().nullItem());
     }
 }

--- a/implementation/src/test/java/tck/MultiOnCancellationInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnCancellationInvokeTckTest.java
@@ -1,16 +1,12 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
-
-import io.smallrye.mutiny.Multi;
 
 public class MultiOnCancellationInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .onCancellation().invoke(() -> {
                     // Do nothing
                 });
@@ -18,7 +14,7 @@ public class MultiOnCancellationInvokeTckTest extends AbstractPublisherTck<Long>
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onCancellation().invoke(() -> {
                     // noop
                 });

--- a/implementation/src/test/java/tck/MultiOnCompletionCallTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnCompletionCallTckTest.java
@@ -2,20 +2,19 @@ package tck;
 
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 public class MultiOnCompletionCallTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().iterable(iterate(elements))
+        return upstream(elements)
                 .onCompletion().call(() -> Uni.createFrom().nullItem());
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onCompletion().call(() -> Uni.createFrom().nullItem());
     }
 }

--- a/implementation/src/test/java/tck/MultiOnCompletionInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnCompletionInvokeTckTest.java
@@ -2,13 +2,11 @@ package tck;
 
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
-
 public class MultiOnCompletionInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().iterable(iterate(elements))
+        return upstream(elements)
                 .onCompletion().invoke(() -> {
                     // Do nothing
                 });
@@ -16,7 +14,7 @@ public class MultiOnCompletionInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onCompletion().invoke(() -> {
                     // noop
                 });

--- a/implementation/src/test/java/tck/MultiOnFailureCallTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureCallTckTest.java
@@ -2,20 +2,19 @@ package tck;
 
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 public class MultiOnFailureCallTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().iterable(iterate(elements))
+        return upstream(elements)
                 .onFailure().call(x -> Uni.createFrom().nullItem());
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onFailure().call(x -> Uni.createFrom().nullItem());
     }
 }

--- a/implementation/src/test/java/tck/MultiOnFailureInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureInvokeTckTest.java
@@ -1,16 +1,12 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
-
-import io.smallrye.mutiny.Multi;
 
 public class MultiOnFailureInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .onFailure().invoke(x -> {
                     // noop
                 });
@@ -18,7 +14,7 @@ public class MultiOnFailureInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onFailure().invoke(x -> {
                     // noop
                 });

--- a/implementation/src/test/java/tck/MultiOnFailureRecoverWithFailureTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureRecoverWithFailureTckTest.java
@@ -4,13 +4,11 @@ import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
-
 public class MultiOnFailureRecoverWithFailureTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().iterable(iterate(elements))
+        return upstream(elements)
                 .onFailure().recoverWithMulti(t -> {
                     if (t instanceof RuntimeException) {
                         throw (RuntimeException) t;
@@ -22,7 +20,7 @@ public class MultiOnFailureRecoverWithFailureTckTest extends AbstractPublisherTc
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onFailure().recoverWithItem(t -> {
                     // Re-throw the exception.
                     if (t instanceof RuntimeException) {

--- a/implementation/src/test/java/tck/MultiOnFailureRecoverWithItemTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureRecoverWithItemTckTest.java
@@ -10,13 +10,13 @@ public class MultiOnFailureRecoverWithItemTckTest extends AbstractPublisherTck<L
 
     @Override
     public Publisher<Long> createPublisher(long l) {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onFailure().recoverWithMulti(t -> Multi.createFrom().items(LongStream.rangeClosed(1, l).boxed()));
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onFailure().recoverWithItem(t -> {
                     // Re-throw the exception.
                     if (t instanceof RuntimeException) {

--- a/implementation/src/test/java/tck/MultiOnFailureRecoverWithMultiTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureRecoverWithMultiTckTest.java
@@ -10,13 +10,13 @@ public class MultiOnFailureRecoverWithMultiTckTest extends AbstractPublisherTck<
 
     @Override
     public Publisher<Long> createPublisher(long l) {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onFailure().recoverWithMulti(t -> Multi.createFrom().items(LongStream.rangeClosed(1, l).boxed()));
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onFailure().recoverWithMulti(t -> {
                     // Re-throw the exception.
                     if (t instanceof RuntimeException) {

--- a/implementation/src/test/java/tck/MultiOnFailureResumeTest.java
+++ b/implementation/src/test/java/tck/MultiOnFailureResumeTest.java
@@ -83,22 +83,24 @@ public class MultiOnFailureResumeTest {
 
     @Test
     public void onErrorResumeStageShouldPropagateRuntimeExceptions() {
-        assertThrows(RuntimeException.class, () -> await(Multi.createFrom().<String> failure(new Exception("source-failure"))
-                .onFailure().recoverWithMulti(t -> {
-                    throw new QuietRuntimeException("failed");
-                })
-                .collectItems().asList()
-                .subscribeAsCompletionStage()));
+        assertThrows(RuntimeException.class,
+                () -> await(Multi.createFrom().<String> failure(new Exception("source-failure"))
+                        .onFailure().recoverWithMulti(t -> {
+                            throw new QuietRuntimeException("failed");
+                        })
+                        .collectItems().asList()
+                        .subscribeAsCompletionStage()));
     }
 
     @Test
     public void onErrorResumeWithStageShouldPropagateRuntimeExceptions() {
-        assertThrows(RuntimeException.class, () -> await(Multi.createFrom().<String> failure(new Exception("source-failure"))
-                .onFailure().recoverWithItem(t -> {
-                    throw new QuietRuntimeException("failed");
-                })
-                .collectItems().asList()
-                .subscribeAsCompletionStage()));
+        assertThrows(RuntimeException.class,
+                () -> await(Multi.createFrom().<String> failure(new Exception("source-failure"))
+                        .onFailure().recoverWithItem(t -> {
+                            throw new QuietRuntimeException("failed");
+                        })
+                        .collectItems().asList()
+                        .subscribeAsCompletionStage()));
     }
 
     @Test

--- a/implementation/src/test/java/tck/MultiOnITemTransformToMultiAndConcatenateTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnITemTransformToMultiAndConcatenateTckTest.java
@@ -11,7 +11,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
-import java.util.stream.LongStream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,10 +76,11 @@ public class MultiOnITemTransformToMultiAndConcatenateTckTest extends AbstractPu
 
     @Test
     public void flatMapStageShouldPropagateUpstreamExceptions() {
-        assertThrows(QuietRuntimeException.class, () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
-                .onItem().transformToMultiAndConcatenate(x -> Multi.createFrom().item(x))
-                .collectItems().asList()
-                .subscribeAsCompletionStage()));
+        assertThrows(QuietRuntimeException.class,
+                () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
+                        .onItem().transformToMultiAndConcatenate(x -> Multi.createFrom().item(x))
+                        .collectItems().asList()
+                        .subscribeAsCompletionStage()));
     }
 
     @Test
@@ -118,13 +118,13 @@ public class MultiOnITemTransformToMultiAndConcatenateTckTest extends AbstractPu
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .onItem().transformToMultiAndConcatenate(x -> Multi.createFrom().item(x));
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onItem().transformToMultiAndConcatenate(x -> Multi.createFrom().item(x));
     }
 }

--- a/implementation/src/test/java/tck/MultiOnITemTransformToMultiAndMergeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnITemTransformToMultiAndMergeTckTest.java
@@ -11,7 +11,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
-import java.util.stream.LongStream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,10 +76,11 @@ public class MultiOnITemTransformToMultiAndMergeTckTest extends AbstractPublishe
 
     @Test
     public void flatMapStageShouldPropagateUpstreamExceptions() {
-        assertThrows(QuietRuntimeException.class, () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
-                .onItem().transformToMultiAndMerge(x -> Multi.createFrom().item(x))
-                .collectItems().asList()
-                .subscribeAsCompletionStage()));
+        assertThrows(QuietRuntimeException.class,
+                () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
+                        .onItem().transformToMultiAndMerge(x -> Multi.createFrom().item(x))
+                        .collectItems().asList()
+                        .subscribeAsCompletionStage()));
     }
 
     @Test
@@ -116,13 +116,13 @@ public class MultiOnITemTransformToMultiAndMergeTckTest extends AbstractPublishe
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .onItem().transformToMultiAndMerge(x -> Multi.createFrom().item(x));
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onItem().transformToMultiAndMerge(x -> Multi.createFrom().item(x));
     }
 }

--- a/implementation/src/test/java/tck/MultiOnItemCallTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnItemCallTckTest.java
@@ -1,23 +1,20 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 public class MultiOnItemCallTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .onItem().call(x -> Uni.createFrom().nullItem());
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onItem().call(x -> Uni.createFrom().nullItem());
     }
 }

--- a/implementation/src/test/java/tck/MultiOnItemInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnItemInvokeTckTest.java
@@ -1,16 +1,12 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
-
-import io.smallrye.mutiny.Multi;
 
 public class MultiOnItemInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .onItem().invoke(x -> {
                     // noop
                 });
@@ -18,7 +14,7 @@ public class MultiOnItemInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onItem().invoke(x -> {
                     // noop
                 });

--- a/implementation/src/test/java/tck/MultiOnItemTransformTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnItemTransformTckTest.java
@@ -9,14 +9,13 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
-import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 
-public class MultiOnItemTransformTckTest extends AbstractPublisherTck<Integer> {
+public class MultiOnItemTransformTckTest extends AbstractPublisherTck<Long> {
 
     @Test
     public void mapStageShouldMapElements() {
@@ -44,10 +43,11 @@ public class MultiOnItemTransformTckTest extends AbstractPublisherTck<Integer> {
 
     @Test
     public void mapStageShouldPropagateUpstreamExceptions() {
-        assertThrows(QuietRuntimeException.class, () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
-                .map(Function.identity())
-                .collectItems().asList()
-                .subscribeAsCompletionStage()));
+        assertThrows(QuietRuntimeException.class,
+                () -> await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
+                        .map(Function.identity())
+                        .collectItems().asList()
+                        .subscribeAsCompletionStage()));
     }
 
     @Test
@@ -64,14 +64,14 @@ public class MultiOnItemTransformTckTest extends AbstractPublisherTck<Integer> {
     }
 
     @Override
-    public Publisher<Integer> createPublisher(long elements) {
-        return Multi.createFrom().items(IntStream.rangeClosed(1, (int) elements).boxed())
+    public Publisher<Long> createPublisher(long elements) {
+        return upstream(elements)
                 .map(Function.identity());
     }
 
     @Override
-    public Publisher<Integer> createFailedPublisher() {
-        return Multi.createFrom().<Integer> failure(new RuntimeException("failed"))
+    public Publisher<Long> createFailedPublisher() {
+        return failedUpstream()
                 .map(Function.identity());
     }
 

--- a/implementation/src/test/java/tck/MultiOnItemTransformToUniAndConcatenateTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnItemTransformToUniAndConcatenateTckTest.java
@@ -1,23 +1,20 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 public class MultiOnItemTransformToUniAndConcatenateTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .onItem().transformToUniAndConcatenate(x -> Uni.createFrom().item(x));
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onItem().transformToUniAndConcatenate(x -> Uni.createFrom().item(x));
     }
 }

--- a/implementation/src/test/java/tck/MultiOnItemTransformToUniAndMergeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnItemTransformToUniAndMergeTckTest.java
@@ -1,23 +1,20 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 public class MultiOnItemTransformToUniAndMergeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .onItem().transformToUniAndMerge(x -> Uni.createFrom().item(x));
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onItem().transformToUniAndMerge(x -> Uni.createFrom().item(x));
     }
 }

--- a/implementation/src/test/java/tck/MultiOnRequestCallTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnRequestCallTckTest.java
@@ -2,25 +2,19 @@ package tck;
 
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 public class MultiOnRequestCallTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().iterable(iterate(elements))
+        return upstream(elements)
                 .onRequest().call((count) -> Uni.createFrom().nullItem());
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onRequest().call((count) -> Uni.createFrom().nullItem());
-    }
-
-    @Override
-    public long maxElementsFromPublisher() {
-        return 1024;
     }
 }

--- a/implementation/src/test/java/tck/MultiOnRequestInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnRequestInvokeTckTest.java
@@ -2,13 +2,11 @@ package tck;
 
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
-
 public class MultiOnRequestInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().iterable(iterate(elements))
+        return upstream(elements)
                 .onRequest().invoke((count) -> {
                     // Do nothing
                 });
@@ -16,15 +14,10 @@ public class MultiOnRequestInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onRequest().invoke((count) -> {
                     // noop
                 });
-    }
-
-    @Override
-    public long maxElementsFromPublisher() {
-        return 1024;
     }
 
 }

--- a/implementation/src/test/java/tck/MultiOnSubscribeCallTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnSubscribeCallTckTest.java
@@ -2,20 +2,19 @@ package tck;
 
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 public class MultiOnSubscribeCallTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().iterable(iterate(elements))
+        return upstream(elements)
                 .onSubscribe().call(x -> Uni.createFrom().nullItem());
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onSubscribe().call(x -> Uni.createFrom().nullItem());
     }
 }

--- a/implementation/src/test/java/tck/MultiOnSubscribeInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnSubscribeInvokeTckTest.java
@@ -2,13 +2,11 @@ package tck;
 
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
-
 public class MultiOnSubscribeInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().iterable(iterate(elements))
+        return upstream(elements)
                 .onSubscribe().invoke(x -> {
                     // noop
                 });
@@ -16,7 +14,7 @@ public class MultiOnSubscribeInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onSubscribe().invoke(x -> {
                     // noop
                 });

--- a/implementation/src/test/java/tck/MultiOnTerminationCallTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnTerminationCallTckTest.java
@@ -1,23 +1,20 @@
 package tck;
 
-import java.util.stream.LongStream;
-
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 public class MultiOnTerminationCallTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .onTermination().call((t, c) -> Uni.createFrom().nullItem());
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onTermination().call((t, c) -> Uni.createFrom().nullItem());
     }
 }

--- a/implementation/src/test/java/tck/MultiOnTerminationInvokeTckTest.java
+++ b/implementation/src/test/java/tck/MultiOnTerminationInvokeTckTest.java
@@ -2,13 +2,11 @@ package tck;
 
 import org.reactivestreams.Publisher;
 
-import io.smallrye.mutiny.Multi;
-
 public class MultiOnTerminationInvokeTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().iterable(iterate(elements))
+        return upstream(elements)
                 .onTermination().invoke(() -> {
                     // Do nothing
                 });
@@ -16,7 +14,7 @@ public class MultiOnTerminationInvokeTckTest extends AbstractPublisherTck<Long> 
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .onTermination().invoke(() -> {
                     // noop
                 });

--- a/implementation/src/test/java/tck/MultiRunSubscriptionOnTckTest.java
+++ b/implementation/src/test/java/tck/MultiRunSubscriptionOnTckTest.java
@@ -2,13 +2,10 @@ package tck;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.stream.LongStream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.reactivestreams.Publisher;
-
-import io.smallrye.mutiny.Multi;
 
 public class MultiRunSubscriptionOnTckTest extends AbstractPublisherTck<Long> {
 
@@ -26,13 +23,13 @@ public class MultiRunSubscriptionOnTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .runSubscriptionOn(executor);
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .runSubscriptionOn(executor);
     }
 }

--- a/implementation/src/test/java/tck/MultiSkipItemsWhileTckTest.java
+++ b/implementation/src/test/java/tck/MultiSkipItemsWhileTckTest.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.LongStream;
 
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
@@ -101,13 +100,13 @@ public class MultiSkipItemsWhileTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .transform().bySkippingItemsWhile(i -> false);
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .transform().bySkippingItemsWhile(i -> false);
     }
 }

--- a/implementation/src/test/java/tck/MultiTakeFirstItemsTckTest.java
+++ b/implementation/src/test/java/tck/MultiTakeFirstItemsTckTest.java
@@ -6,7 +6,6 @@ import static tck.Await.await;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.LongStream;
 
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
@@ -95,13 +94,13 @@ public class MultiTakeFirstItemsTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .transform().byTakingFirstItems(Long.MAX_VALUE);
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .transform().byTakingFirstItems(Long.MAX_VALUE);
     }
 }

--- a/implementation/src/test/java/tck/MultiTakeItemsWhileTckTest.java
+++ b/implementation/src/test/java/tck/MultiTakeItemsWhileTckTest.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.LongStream;
 
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
@@ -80,13 +79,13 @@ public class MultiTakeItemsWhileTckTest extends AbstractPublisherTck<Long> {
 
     @Override
     public Publisher<Long> createPublisher(long elements) {
-        return Multi.createFrom().items(LongStream.rangeClosed(1, elements).boxed())
+        return upstream(elements)
                 .transform().byTakingItemsWhile(x -> true);
     }
 
     @Override
     public Publisher<Long> createFailedPublisher() {
-        return Multi.createFrom().<Long> failure(new RuntimeException("failed"))
+        return failedUpstream()
                 .transform().byTakingItemsWhile(x -> true);
     }
 }

--- a/implementation/src/test/java/tck/UniTransformToMultiTckTest.java
+++ b/implementation/src/test/java/tck/UniTransformToMultiTckTest.java
@@ -10,7 +10,7 @@ public class UniTransformToMultiTckTest extends AbstractPublisherTck<Long> {
     @Override
     public Publisher<Long> createPublisher(long elements) {
         return Uni.createFrom().item(elements)
-                .onItem().transformToMulti(max -> Multi.createFrom().iterable(iterate(elements)));
+                .onItem().transformToMulti(max -> upstream(elements));
     }
 
     @Override

--- a/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/IdentityProcessorVerification.java
+++ b/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/IdentityProcessorVerification.java
@@ -464,6 +464,7 @@ public abstract class IdentityProcessorVerification<T>
 
     @Override
     public void notVerified(String message) {
-        System.err.println("[Not Verified] " + message);
+        StackTraceElement element = Thread.currentThread().getStackTrace()[3];
+        System.err.println("[Not Verified - " + element.getMethodName() + "] " + message);
     }
 }

--- a/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/PublisherVerification.java
+++ b/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/PublisherVerification.java
@@ -282,7 +282,7 @@ public abstract class PublisherVerification<T> extends org.reactivestreams.tck.P
 
     @Override
     public void notVerified(String message) {
-        System.err.println("[Not Verified] " + message);
+        StackTraceElement element = Thread.currentThread().getStackTrace()[3];
+        System.err.println("[Not Verified - " + element.getMethodName() + "] " + message);
     }
-
 }

--- a/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/SubscriberWhiteboxVerification.java
+++ b/reactive-streams-junit5-tck/src/test/java/org/reactivestreams/tck/junit5/SubscriberWhiteboxVerification.java
@@ -226,6 +226,7 @@ public abstract class SubscriberWhiteboxVerification<T>
 
     @Override
     public void notVerified(String message) {
-        System.err.println("[Not Verified] " + message);
+        StackTraceElement element = Thread.currentThread().getStackTrace()[3];
+        System.err.println("[Not Verified - " + element.getMethodName() + "] " + message);
     }
 }


### PR DESCRIPTION
- Fast path tests were not using Long.MAX requests - so were not fast path
- More tests around the new Multi.call methods
