### PR TITLE
CI update - Use Ubuntu 20.04 and use Zulu build for Java 15

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         java: [

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -16,10 +16,9 @@ jobs:
         java: [
         {'version': '8', 'source': 'releases'},
         {'version': '11', 'source': 'releases'},
-        {'version': '14', 'source': 'releases'},
-        {'version': '15', 'source': 'nightly'}
+        {'version': '14', 'source': 'releases'}
         ]
-    name: Build with Java ${{ matrix.java.version }}
+    name: Build with Java ${{ matrix.java.version }} (OpenJDK)
     steps:
       - uses: actions/cache@v2
         with:
@@ -37,9 +36,30 @@ jobs:
       - name: Build with Maven
         run: mvn -B clean install --file pom.xml
 
+  java15:
+    runs-on: ubuntu-20.04
+    name: Build with Java 15 (Zulu)
+    steps:
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/**/*-SNAPSHOT/*
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - uses: actions/checkout@v2
+      - name: Install JDK 15
+        uses: actions/setup-java@v1.4.2
+        with:
+          java-version: '15-ea'
+          architecture: x64
+      - name: Build with Maven
+        run: mvn -B clean install -Pcoverage --file pom.xml
+
   quality:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/build-pull.yml
+++ b/.github/workflows/build-pull.yml
@@ -11,8 +11,7 @@ jobs:
         java: [
           {'version': '8', 'source': 'releases'},
           {'version': '11', 'source': 'releases'},
-          {'version': '14', 'source': 'releases'},
-          {'version': '15', 'source': 'nightly'}
+          {'version': '14', 'source': 'releases'}
         ]
     name: Build with Java ${{ matrix.java.version }}
     steps:
@@ -34,3 +33,25 @@ jobs:
         run: mvn -B clean install -Pcoverage --file pom.xml
       - name: Codecov
         uses: codecov/codecov-action@v1.0.13
+  java15:
+      runs-on: ubuntu-20.04
+      name: Build with Java 15
+      steps:
+        - uses: actions/cache@v2
+          with:
+            path: |
+              ~/.m2/repository
+              !~/.m2/repository/**/*-SNAPSHOT/*
+            key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+            restore-keys: |
+              ${{ runner.os }}-maven-
+        - uses: actions/checkout@v2
+        - name: Install JDK 15
+          uses: AdoptOpenJDK/install-jdk@v1
+          with:
+            version: 15
+            source: https://cdn.azul.com/zulu/bin/zulu15.0.77-ea-jdk15.0.0-ea.36-linux_x64.tar.gz
+            archiveExtension: .tar
+        - name: Build with Maven
+          run: mvn -B clean install -Pcoverage --file pom.xml
+

--- a/.github/workflows/build-pull.yml
+++ b/.github/workflows/build-pull.yml
@@ -24,7 +24,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: actions/checkout@v2
-      - name: Install JDK ${{ matrix.java.version }}
+      - name: Install JDK ${{ matrix.java.version }} (OpenJDK)
         uses: AdoptOpenJDK/install-jdk@v1
         with:
           version: ${{ matrix.java.version }}
@@ -46,12 +46,11 @@ jobs:
             restore-keys: |
               ${{ runner.os }}-maven-
         - uses: actions/checkout@v2
-        - name: Install JDK 15
-          uses: AdoptOpenJDK/install-jdk@v1
+        - name: Install JDK 15 (Zulu)
+          uses: actions/setup-java@v1.4.2
           with:
-            version: 15
-            source: https://cdn.azul.com/zulu/bin/zulu15.0.77-ea-jdk15.0.0-ea.36-linux_x64.tar.gz
-            archiveExtension: .tar
+            java-version: '15-ea'
+            architecture: x64
         - name: Build with Maven
           run: mvn -B clean install -Pcoverage --file pom.xml
 

--- a/.github/workflows/build-pull.yml
+++ b/.github/workflows/build-pull.yml
@@ -5,7 +5,7 @@ on: pull_request
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         java: [


### PR DESCRIPTION
The Java 15 build from AdopOnJDK was failing with a certificate issue. 