### PR TITLE
Missing upstream cancellation on back pressure failure

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowBufferOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowBufferOp.java
@@ -173,7 +173,12 @@ public class MultiOnOverflowBufferOp<T> extends AbstractMultiOperator<T, T> {
             if (wasDone) {
                 if (failure != null) {
                     queue.clear();
-                    super.onFailure(failure);
+                    if (failure instanceof BackPressureFailure) {
+                        super.cancel();
+                        downstream.onFailure(failure);
+                    } else {
+                        super.onFailure(failure);
+                    }
                     return true;
                 } else if (wasEmpty) {
                     super.onCompletion();


### PR DESCRIPTION
Missing upstream cancellation when the backpressure failure is thrown.﻿
