### PR TITLE
Fix a race condition between onSubscribe / cancel / on{Item,Failure}

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/UniSerializedSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/UniSerializedSubscriber.java
@@ -89,7 +89,6 @@ public class UniSerializedSubscriber<T> implements UniSubscriber<T>, UniSubscrip
                 throw e; // Rethrow in case of synchronous emission
             }
         }
-        dispose();
     }
 
     @Override
@@ -102,16 +101,10 @@ public class UniSerializedSubscriber<T> implements UniSubscriber<T>, UniSubscrip
             } catch (Throwable e) {
                 Infrastructure.handleDroppedException(new CompositeException(throwable, e));
                 throw e; // Rethrow in case of synchronous emission
-            } finally {
-                dispose();
             }
         } else {
             Infrastructure.handleDroppedException(throwable);
         }
-    }
-
-    private void dispose() {
-        subscription = null;
     }
 
     @Override
@@ -122,12 +115,10 @@ public class UniSerializedSubscriber<T> implements UniSubscriber<T>, UniSubscrip
             }
             if (subscription != null) { // May have been cancelled already by another thread.
                 subscription.cancel();
-                dispose();
             }
         } else {
             state.set(DONE);
         }
-
     }
 
     public synchronized boolean isCancelledOrDone() {


### PR DESCRIPTION
There is a possibility for cancel to have the subscription become null because an item or a failure is emitted.

This removes the dispose() method whose sole purpose was to set the subscription to null. Since the subscription value being null does not have any value there is no point keeping it around.