### PR TITLE
Caching the ThreadContext breaks in multi-deployment environments

### DIFF
--- a/context-propagation/src/main/java/io/smallrye/mutiny/context/ContextPropagationMultiInterceptor.java
+++ b/context-propagation/src/main/java/io/smallrye/mutiny/context/ContextPropagationMultiInterceptor.java
@@ -20,19 +20,21 @@ import io.smallrye.mutiny.subscription.MultiSubscriber;
  */
 public class ContextPropagationMultiInterceptor implements MultiInterceptor {
 
-    static final ThreadContext THREAD_CONTEXT = ContextManagerProvider.instance().getContextManager()
-            .newThreadContextBuilder().build();
-
     @Override
     public <T> Subscriber<? super T> onSubscription(Publisher<? extends T> instance, Subscriber<? super T> subscriber) {
-        Executor executor = THREAD_CONTEXT.currentContextExecutor();
+        Executor executor = threadContext().currentContextExecutor();
         return new ContextPropagationSubscriber<>(executor, subscriber);
     }
 
     @Override
     public <T> Multi<T> onMultiCreation(Multi<T> multi) {
-        Executor executor = THREAD_CONTEXT.currentContextExecutor();
+        Executor executor = threadContext().currentContextExecutor();
         return new ContextPropagationMulti<>(executor, multi);
+    }
+
+    private static ThreadContext threadContext() {
+        return ContextManagerProvider.instance().getContextManager()
+                .newThreadContextBuilder().build();
     }
 
     private static class ContextPropagationMulti<T> extends AbstractMulti<T> {

--- a/context-propagation/src/main/java/io/smallrye/mutiny/context/ContextPropagationUniInterceptor.java
+++ b/context-propagation/src/main/java/io/smallrye/mutiny/context/ContextPropagationUniInterceptor.java
@@ -17,12 +17,9 @@ import io.smallrye.mutiny.subscription.UniSubscription;
  */
 public class ContextPropagationUniInterceptor implements UniInterceptor {
 
-    static final ThreadContext THREAD_CONTEXT = ContextManagerProvider.instance().getContextManager()
-            .newThreadContextBuilder().build();
-
     @Override
     public <T> UniSubscriber<? super T> onSubscription(Uni<T> instance, UniSubscriber<? super T> subscriber) {
-        Executor executor = THREAD_CONTEXT.currentContextExecutor();
+        Executor executor = threadContext().currentContextExecutor();
         return new UniSubscriber<T>() {
 
             @Override
@@ -44,7 +41,7 @@ public class ContextPropagationUniInterceptor implements UniInterceptor {
 
     @Override
     public <T> Uni<T> onUniCreation(Uni<T> uni) {
-        Executor executor = THREAD_CONTEXT.currentContextExecutor();
+        Executor executor = threadContext().currentContextExecutor();
         return new AbstractUni<T>() {
             @Override
             protected void subscribing(UniSerializedSubscriber<? super T> subscriber) {
@@ -52,4 +49,10 @@ public class ContextPropagationUniInterceptor implements UniInterceptor {
             }
         };
     }
+
+    private static ThreadContext threadContext() {
+        return ContextManagerProvider.instance().getContextManager()
+                .newThreadContextBuilder().build();
+    }
+
 }


### PR DESCRIPTION
My use-case is that I first deploy application A in WildFly, then undeploy application A, and then deploy application B.

Before this fix application B will still use the ThreadContext and underlying ContextManager from application A. This breaks the optimisation @stuartwdouglas added to [cache the TransactionManager in the JtaThreadContextProvider](https://github.com/smallrye/smallrye-context-propagation/commit/eb454a70ca03b1aa6ddc8fa8a862db954d68a527#diff-6719340760b3e74dbd9230d39c1f683af6390f27307ee70d4660b917031f2f90) as it tries to read data from the bean manager from deployment A which has been cleared. Also, I believe we cannot cache in case deployments supply their own ThreadContext implementations.

Creating the ThreadContext on demand as I am doing here fixes the problem. 

