### PR TITLE
Pluggable ThreadContext from the context propagation interceptors

### DIFF
--- a/context-propagation/src/main/java/io/smallrye/mutiny/context/DefaultContextPropagationMultiInterceptor.java
+++ b/context-propagation/src/main/java/io/smallrye/mutiny/context/DefaultContextPropagationMultiInterceptor.java
@@ -1,0 +1,18 @@
+package io.smallrye.mutiny.context;
+
+import org.eclipse.microprofile.context.ThreadContext;
+import org.eclipse.microprofile.context.spi.ContextManagerProvider;
+
+/**
+ * Provides context propagation to Multi types.
+ */
+public class DefaultContextPropagationMultiInterceptor extends ContextPropagationMultiInterceptor {
+
+    static final ThreadContext THREAD_CONTEXT = ContextManagerProvider.instance().getContextManager()
+            .newThreadContextBuilder().build();
+
+    @Override
+    protected ThreadContext getThreadContext() {
+        return THREAD_CONTEXT;
+    }
+}

--- a/context-propagation/src/main/java/io/smallrye/mutiny/context/DefaultContextPropagationUniInterceptor.java
+++ b/context-propagation/src/main/java/io/smallrye/mutiny/context/DefaultContextPropagationUniInterceptor.java
@@ -1,0 +1,18 @@
+package io.smallrye.mutiny.context;
+
+import org.eclipse.microprofile.context.ThreadContext;
+import org.eclipse.microprofile.context.spi.ContextManagerProvider;
+
+/**
+ * Provides context propagation to Uni types.
+ */
+public class DefaultContextPropagationUniInterceptor extends ContextPropagationUniInterceptor {
+
+    static final ThreadContext THREAD_CONTEXT = ContextManagerProvider.instance().getContextManager()
+            .newThreadContextBuilder().build();
+
+    @Override
+    protected ThreadContext getThreadContext() {
+        return THREAD_CONTEXT;
+    }
+}

--- a/context-propagation/src/main/resources/META-INF/services/io.smallrye.mutiny.infrastructure.MultiInterceptor
+++ b/context-propagation/src/main/resources/META-INF/services/io.smallrye.mutiny.infrastructure.MultiInterceptor
@@ -1,1 +1,1 @@
-io.smallrye.mutiny.context.ContextPropagationMultiInterceptor
+io.smallrye.mutiny.context.DefaultContextPropagationMultiInterceptor

--- a/context-propagation/src/main/resources/META-INF/services/io.smallrye.mutiny.infrastructure.UniInterceptor
+++ b/context-propagation/src/main/resources/META-INF/services/io.smallrye.mutiny.infrastructure.UniInterceptor
@@ -1,1 +1,1 @@
-io.smallrye.mutiny.context.ContextPropagationUniInterceptor
+io.smallrye.mutiny.context.DefaultContextPropagationUniInterceptor

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationMultiTckTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationMultiTckTest.java
@@ -9,18 +9,18 @@ import org.reactivestreams.tck.TestEnvironment;
 import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.context.ContextPropagationMultiInterceptor;
+import io.smallrye.mutiny.context.DefaultContextPropagationMultiInterceptor;
 
 /**
  * Reactive Streams TCK for io.smallrye.mutiny.context.ContextPropagationMultiInterceptor.ContextPropagationMulti.
  */
 public class ContextPropagationMultiTckTest extends PublisherVerification<Long> {
 
-    private final ContextPropagationMultiInterceptor interceptor;
+    private final DefaultContextPropagationMultiInterceptor interceptor;
 
     public ContextPropagationMultiTckTest() {
         super(new TestEnvironment(100));
-        interceptor = new ContextPropagationMultiInterceptor();
+        interceptor = new DefaultContextPropagationMultiInterceptor();
     }
 
     @Override

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationSubscriberTckTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/tck/ContextPropagationSubscriberTckTest.java
@@ -7,15 +7,15 @@ import org.reactivestreams.Subscription;
 import org.reactivestreams.tck.TestEnvironment;
 import org.reactivestreams.tck.junit5.SubscriberWhiteboxVerification;
 
-import io.smallrye.mutiny.context.ContextPropagationMultiInterceptor;
+import io.smallrye.mutiny.context.DefaultContextPropagationMultiInterceptor;
 
 public class ContextPropagationSubscriberTckTest extends SubscriberWhiteboxVerification<Long> {
 
-    private final ContextPropagationMultiInterceptor interceptor;
+    private final DefaultContextPropagationMultiInterceptor interceptor;
 
     protected ContextPropagationSubscriberTckTest() {
         super(new TestEnvironment(100));
-        interceptor = new ContextPropagationMultiInterceptor();
+        interceptor = new DefaultContextPropagationMultiInterceptor();
     }
 
     @Override


### PR DESCRIPTION
In a multi-deployment such as WildFly we need to control which ContextManager is used. I've added some hooks to be able to control that, and provided default implementations of those so that Quarkus can work the way it does. (#335 contains a bit more background why this is needed)

If you want me to rename/move anything let me know.

