### PR TITLE
Fix mistake in JavaDocs of ExecutorConfiguration

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/infrastructure/ExecutorConfiguration.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/infrastructure/ExecutorConfiguration.java
@@ -5,7 +5,7 @@ import java.util.concurrent.Executor;
 /**
  * SPI allowing customizing the default executor.
  * Implementors must register their implementation by indicating the fully qualified name of the implementation in the
- * {@code META-INF/services/io.smallrye.reactive.infrastructure.ExecutorConfiguration} file.
+ * {@code META-INF/services/io.smallrye.infrastructure.ExecutorConfiguration} file.
  * <p>
  * The SPI implementation is responsible for creating and terminating the created thread pools.
  */


### PR DESCRIPTION
file name is incorrect. ".reactive" is redundant in file name