### PR TITLE
Optimize MultiFilterOp on the hot path

### DIFF
--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiFilterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiFilterTest.java
@@ -45,6 +45,15 @@ public class MultiFilterTest {
     }
 
     @Test
+    public void cannotRequestZeroItems() {
+        AssertSubscriber<Integer> sub = Multi.createFrom().range(1, 4)
+                .filter(n -> n % 2 == 0)
+                .subscribe().withSubscriber(AssertSubscriber.create());
+        sub.request(0);
+        sub.assertFailedWith(IllegalArgumentException.class, "request must be positive");
+    }
+
+    @Test
     public void testFilteringWithPredicate() {
         Predicate<Integer> test = x -> x % 2 != 0;
         assertThat(Multi.createFrom().range(1, 4)


### PR DESCRIPTION
requestedMax doesn't have to be volatile since the subscription check makes for a memory barrier,
and worst case an upstream subscription will fly and it is fine.

Also avoid calling request upfront if we're on an unbounded subscription.