### PR TITLE
Fix documentation typos

### DIFF
--- a/documentation/src/main/docs/faq.adoc
+++ b/documentation/src/main/docs/faq.adoc
@@ -12,7 +12,7 @@ include::../../../src/test/java/snippets/HowToTransformTest.java[tags=sync]
 
 [NOTE]
 ====
-If your operation throws a _checked exception_, you can use the `io.smallrye.mutiny.unchecked.Unchecked` wrappers to avoid having to catch the exception in the _callback_.
+If your operation throws a _checked exception_, you can use the `io.smallrye.mutiny.unchecked.Unchecked` wrapper to avoid having to catch the exception in the _callback_.
 
 [source,java,indent=0]
 ----
@@ -84,7 +84,7 @@ include::../../../src/test/java/snippets/HowToFilterTest.java[tags=repetition]
 == Where are my map, flatMap and concatMap methods?
 
 If you are a seasoned reactive developer, you may miss the infamous `map`, `flatMap`, `concatMap` methods.
-Mutiny also proposes there methods using the most-used variants of them.
+Mutiny also proposes three methods using the most-used variants of them.
 
 [source,java,indent=0]
 ----
@@ -528,7 +528,7 @@ include::../../../src/test/java/snippets/UniBlockingTest.java[tags=code]
 ----
 
 Create an `Uni` that will supply the item using a blocking call, here the `invokeRemoteServiceUsingBlockingIO` method.
-To avoid blocking the subscriber, use `runSubscriptionOn` which switch the thread and so call `invokeRemoteServiceUsingBlockingIO` on another thread.
+To avoid blocking the subscriber, use `runSubscriptionOn` which switches the thread and so call `invokeRemoteServiceUsingBlockingIO` on another thread.
 Here we pass the default worker thread pool, but you can use your own executor.
 
 Note that `runSubscriptionOn` does not subscribe to the `Uni`.

--- a/documentation/src/main/docs/getting-started.adoc
+++ b/documentation/src/main/docs/getting-started.adoc
@@ -45,7 +45,7 @@ Here, this `Multi` is emitting two _item_ events `hello` and `world`.
 The `onItem` and `onCompletion` lines are processing respectively the _item_ and _completion_ events emitted by the upstream.
 As a result, they also return instances of `Multi` which depending on the events received from upstream would emit events downstream.
 
-In our example, every time the Multi emits an item, we apply a method to transform this item to uppercase, and emits the resulting value.
+In our example, every time the Multi emits an item, we apply a method to transform this item to uppercase, and emit the resulting value.
 Then, when the upstream sends the `completion` event (no more items to emit), we produce a last item: `!` and send it downstream.
 Finally, we _subscribe_ to the resulting stream and for each emitted item, print it on the console.
 

--- a/documentation/src/main/docs/index.adoc
+++ b/documentation/src/main/docs/index.adoc
@@ -19,9 +19,13 @@ ifdef::basebackend-html[toc::[]]
 :sectnumlevels: 4
 
 include::intro.adoc[]
-include::getting-started.adoc[]
-include::philosophy.adoc[]
-//include::sections/converters.adoc[]
-//include::sections/decision-table.adoc[]
-include::faq.adoc[]
 
+include::getting-started.adoc[]
+
+include::philosophy.adoc[]
+
+//include::sections/converters.adoc[]
+
+//include::sections/decision-table.adoc[]
+
+include::faq.adoc[]

--- a/documentation/src/main/docs/intro.adoc
+++ b/documentation/src/main/docs/intro.adoc
@@ -6,7 +6,7 @@ Mutiny is designed after having experienced many issues with other Reactive prog
 Mutiny takes a different approach.
 First, Mutiny does not provide as many operators as the other famous libraries, focusing instead on the most used operators.
 Furthermore, Mutiny provides a more _guided_ API, which avoids having classes with hundreds of methods that cause trouble for even the smartest IDE.
-Finally, Mutiny has built-in converters from and to other reactive programing libraries, so you can always pivot.
+Finally, Mutiny has built-in converters from and to other reactive programming libraries, so you can always pivot.
 
 [TIP]
 .Having questions?

--- a/documentation/src/main/docs/philosophy.adoc
+++ b/documentation/src/main/docs/philosophy.adoc
@@ -26,7 +26,7 @@ An entity that is both a `Publisher` and a `Subscriber` is generally named a `Pr
 
 Four types of events can flow in this direction:
 
-* subscribed - indicate that the upstream has taken into account the subscription
+* subscribed - indicates that the upstream has taken into account the subscription
 * items - events containing some _value_
 * completion - event indicating that no more items will be emitted
 * failure - event indicating that a failure has been encountered, and no more items will be emitted
@@ -45,7 +45,7 @@ In a typical scenario, a subscriber:
 1. A subscriber _subscribes_ to the upstream - the upstream receives the subscription `subscription request`, and when initialized sends the `subscribed` event to the subscriber
 2. The subscriber receives the `subscribed` event with a _subscription_ used to emit the `requests` and `cancellation` events
 3. The subscriber sends a `request` event indicating how many items it can handle at the moment, it can indicate 1, _n_, or infinite.
-4. The publisher receiving the `request` event start emitting at most _n_ item events to the subscriber
+4. The publisher receiving the `request` event starts emitting at most _n_ item events to the subscriber
 5. The subscriber can decide at anytime to request more events, or cancel the subscription
 
 


### PR DESCRIPTION
I noticed a few typos in the doc while reading it.