### PR TITLE
Handle late registration of onTermination callback

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertSubscriber.java
@@ -19,7 +19,7 @@ import org.reactivestreams.Subscription;
  * 
  * @param <T> the type of the items
  */
-@SuppressWarnings({ "ReactiveStreamsSubscriberImplementation"})
+@SuppressWarnings({ "ReactiveStreamsSubscriberImplementation" })
 public class AssertSubscriber<T> implements Subscriber<T> {
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/DefaultUniEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/DefaultUniEmitter.java
@@ -55,14 +55,16 @@ public class DefaultUniEmitter<T> implements UniEmitter<T>, UniSubscription {
     }
 
     @Override
-    public UniEmitter<T> onTermination(Runnable callback) {
-        Runnable actual = nonNull(callback, "callback");
+    public UniEmitter<T> onTermination(Runnable onTermination) {
+        Runnable actual = nonNull(onTermination, "onTermination");
         if (!disposed.get()) {
             this.onTermination.set(actual);
             // Re-check if the termination didn't happen in the meantime
             if (disposed.get()) {
                 terminate();
             }
+        } else {
+            onTermination.run();
         }
         return this;
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/MultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/MultiEmitter.java
@@ -46,6 +46,9 @@ public interface MultiEmitter<T> {
      * or when the emitter has emitted either a {@code completion} or {@code failure} event.
      * <p>
      * This method allows cleanup resources once the emitter can be disposed (has reached a terminal state).
+     * <p>
+     * If the registration of the {@code onTermination} callback is done after the termination, it invokes the callback
+     * immediately.
      *
      * @param onTermination the action to run on termination, must not be {@code null}
      * @return this emitter

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/UniEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/UniEmitter.java
@@ -33,6 +33,9 @@ public interface UniEmitter<T> {
      * or when the emitter has emitted either an {@code item} or {@code failure} event.
      * <p>
      * This method allows cleanup resources once the emitter can be disposed (has reached a terminal state).
+     * <p>
+     * If the registration of the {@code onTermination} callback is done after the termination, it invokes the callback
+     * immediately.
      *
      * @param onTermination the action to run on termination, must not be {@code null}
      * @return this emitter


### PR DESCRIPTION
Fix #417

If the registration is done on a terminated (completed, failed, or canceled) emitter, the callback is invoked immediately.
