### PR TITLE
remove subscribeOn and configure revapi properly

### DIFF
--- a/.build/GitBlameDeprecated.java
+++ b/.build/GitBlameDeprecated.java
@@ -1,0 +1,177 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS info.picocli:picocli:4.5.0
+//DEPS org.eclipse.jgit:org.eclipse.jgit:5.10.0.202012080955-r
+//DEPS com.google.guava:guava:30.1-jre
+//DEPS org.slf4j:slf4j-simple:1.7.30
+
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.Callable;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.io.Files;
+import com.google.common.io.MoreFiles;
+
+import org.eclipse.jgit.api.BlameCommand;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.blame.BlameResult;
+import org.eclipse.jgit.errors.NoWorkTreeException;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+
+
+@Command(name = "GitBlameDeprecated", mixinStandardHelpOptions = true, version = "GitBlameDeprecated 0.1",
+        description = "Find the (Java) deprecated methods in a local Git repository. Usage: jbang GitBlameDeprecated path-to-repository")
+class GitBlameDeprecated implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "The root of the git directory", defaultValue = ".")
+	private File directory;
+
+	private Map<File, BlameResult> cache = new HashMap<>();
+
+	public static void main(String... args) {
+        int exitCode = new CommandLine(new GitBlameDeprecated()).execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+	public Integer call() throws Exception {
+		var repository = openRepository();
+
+		List<Deprecation> list = new ArrayList<>();
+		// Collect deprecations
+		var deprecations = getDeprecations();
+
+		// Retrieve the commit related to these deprecations.
+		for (var entry : deprecations.asMap().entrySet()) {
+			for (var d : entry.getValue()) {
+				extractBlame(repository, d);
+				list.add(d);
+			}
+		}
+
+		// Sort deprecation by dates (oldest first)
+		Collections.sort(list);
+
+		// Print report
+		for(Deprecation deprecation : list) {
+			System.out.println(deprecation);
+		}
+
+        return 0;
+	}
+
+
+	private void extractBlame(Repository repository, Deprecation deprecation) throws GitAPIException, NoWorkTreeException, IOException {
+		BlameResult blame = cache.computeIfAbsent(deprecation.file, f -> {
+			BlameCommand blamer = new BlameCommand(repository);
+			blamer.setFilePath(deprecation.file.getAbsolutePath()
+				.substring(directory.getAbsolutePath().length() +1));
+			try {
+				return blamer.call();
+			} catch (GitAPIException e) {
+				// ignore.
+				return null;
+			}
+		});  
+
+		if (blame == null) {
+			deprecation.author = "unknown";
+			deprecation.commit = "commit not found";
+			deprecation.date = Integer.MAX_VALUE;
+			return;
+		}
+
+		RevCommit commit = blame.getSourceCommit(deprecation.line);
+		deprecation.commit = commit.getShortMessage();
+		deprecation.date = commit.getCommitTime();
+		deprecation.author = commit.getAuthorIdent().getName();
+	}
+
+	static class Deprecation implements Comparable<Deprecation> {
+		String signature;
+		int line;
+		File file;
+		String commit;
+		int date;
+		String author;
+
+		@Override
+		public int compareTo(Deprecation o) {
+			return Integer.compare(date, o.date);
+		}
+
+		String getHumanDate() {
+			Long temp = date * 1000L; 
+			Date ms = new Date(temp);
+			SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+			return sdf.format(ms);
+		}
+
+		String getSignature() {
+			return signature
+				.replace("{", "")
+				.replace("public", "")
+				.replace("default", "")
+				.replace("static", "");
+		}
+
+		public String toString() {
+			return getHumanDate() + " - " + getSignature()
+					+ " (" + file.getName() + ":" + line +") [" + commit + ", by " + author + "]";
+		}
+	}
+	
+	public Multimap<File, Deprecation> getDeprecations() throws IOException {
+		Iterable<Path> path = MoreFiles.fileTraverser().breadthFirst(directory.toPath());
+		Multimap<File, Deprecation> map = ArrayListMultimap.create();
+
+		for(Path p : path) {
+			File file = p.toFile();
+			if (file.getName().endsWith(".java")) {
+				List<String> result = Files.readLines(file, Charsets.UTF_8);
+				for (int i = 0; i < result.size(); i++) {
+					if (isDeprecated(result.get(i))) {
+						Deprecation deprecation = new Deprecation();
+						deprecation.line = i;
+						deprecation.signature = result.get(i + 1).trim();
+						deprecation.file = file;
+						map.put(file, deprecation);
+					}
+				}
+			}
+		}
+		return map;
+	}
+
+	private boolean isDeprecated(String l) {
+		return l.trim().equalsIgnoreCase("@Deprecated");
+	}
+
+	public Repository openRepository() throws IOException {
+        FileRepositoryBuilder builder = new FileRepositoryBuilder();
+        Repository repository = builder.setGitDir(new File(directory, ".git"))
+                .readEnvironment() 
+                .findGitDir() 
+				.build();
+        return repository;
+    }
+}

--- a/implementation/revapi.json
+++ b/implementation/revapi.json
@@ -77,6 +77,16 @@
         "code": "java.method.addedToInterface",
         "new": "method io.smallrye.mutiny.Multi<T> io.smallrye.mutiny.Multi<T>::toHotStream()",
         "justification": "New method to create a _hot_ stream, replace `multi.transform().toHotStream()`. If you are impacted by such a change, we recommend extending `AbstractMulti` instead of implementing `Multi` directly."
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method io.smallrye.mutiny.Multi<T> io.smallrye.mutiny.Multi<T>::subscribeOn(java.util.concurrent.Executor)",
+        "justification": "Remove the deprecated `subscribeOn` method, use `runSubscriptionOn` instead"
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method io.smallrye.mutiny.Uni<T> io.smallrye.mutiny.Uni<T>::subscribeOn(java.util.concurrent.Executor)",
+        "justification": "Remove the deprecated `subscribeOn` method, use `runSubscriptionOn` instead"
       }
     ]
   }

--- a/implementation/revapi.json
+++ b/implementation/revapi.json
@@ -9,7 +9,7 @@
     "filter" : {
       "packages" : {
         "regex" : true,
-        "include" : [ "io\\.smallrye\\.mutiny\\..*" ],
+        "include" : [ "io\\.smallrye\\.mutiny\\..*", "io\\.smallrye\\.mutiny\\.*" ],
         "exclude" : [ "io\\.smallrye\\.mutiny\\.operators\\.*", "io\\.smallrye\\.mutiny\\.operators\\..*" ]
       }
     }
@@ -52,6 +52,31 @@
         "code": "java.class.externalClassExposedInAPI",
         "new": "class io.smallrye.mutiny.groups.MultiCollect<T>",
         "justification": "Addition of the `collect` group"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method io.smallrye.mutiny.groups.MultiCollect<T> io.smallrye.mutiny.Multi<T>::collect()",
+        "justification": "Replace the `collectItems` group. If you are impacted by such a change, we recommend extending `AbstractMulti` instead of implementing `Multi` directly."
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method io.smallrye.mutiny.groups.MultiGroup<T> io.smallrye.mutiny.Multi<T>::group()",
+        "justification": "Replace the `groupItems` group. If you are impacted by such a change, we recommend extending `AbstractMulti` instead of implementing `Multi` directly."
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method io.smallrye.mutiny.groups.MultiSelect<T> io.smallrye.mutiny.Multi<T>::select()",
+        "justification": "New _select_ group, replace `multi.transform().first/test/filter`. If you are impacted by such a change, we recommend extending `AbstractMulti` instead of implementing `Multi` directly."
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method io.smallrye.mutiny.groups.MultiSkip<T> io.smallrye.mutiny.Multi<T>::skip()",
+        "justification": "New _skip_ group, replace `multi.transform().skipX(...)`. If you are impacted by such a change, we recommend extending `AbstractMulti` instead of implementing `Multi` directly."
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method io.smallrye.mutiny.Multi<T> io.smallrye.mutiny.Multi<T>::toHotStream()",
+        "justification": "New method to create a _hot_ stream, replace `multi.transform().toHotStream()`. If you are impacted by such a change, we recommend extending `AbstractMulti` instead of implementing `Multi` directly."
       }
     ]
   }

--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -15,7 +15,7 @@ import org.reactivestreams.Subscription;
 import io.smallrye.mutiny.groups.*;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 
-@SuppressWarnings("PublisherImplementation")
+@SuppressWarnings({ "ReactiveStreamsPublisherImplementation" })
 public interface Multi<T> extends Publisher<T> {
 
     static MultiCreate createFrom() {
@@ -262,20 +262,6 @@ public interface Multi<T> extends Publisher<T> {
      * @return a new {@link Multi}
      */
     Multi<T> emitOn(Executor executor);
-
-    /**
-     * When a subscriber subscribes to this {@link Multi}, execute the subscription to the upstream {@link Multi} on a
-     * thread from the given executor. As a result, the {@link Subscriber#onSubscribe(Subscription)} method will be called
-     * on this thread (except mentioned otherwise)
-     *
-     * @param executor the executor to use, must not be {@code null}
-     * @return a new {@link Multi}
-     * @deprecated Use {@link #runSubscriptionOn(Executor)} instead.
-     */
-    @Deprecated
-    default Multi<T> subscribeOn(Executor executor) {
-        return runSubscriptionOn(executor);
-    }
 
     /**
      * When a subscriber subscribes to this {@link Multi}, execute the subscription to the upstream {@link Multi} on a

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -365,20 +365,6 @@ public interface Uni<T> {
      *
      * @param executor the executor to use, must not be {@code null}
      * @return a new {@link Uni}
-     * @deprecated Use {@link #runSubscriptionOn(Executor)} instead
-     */
-    @Deprecated
-    default Uni<T> subscribeOn(Executor executor) {
-        return runSubscriptionOn(executor);
-    }
-
-    /**
-     * When a subscriber subscribes to this {@link Uni}, executes the subscription to the upstream {@link Uni} on a thread
-     * from the given executor. As a result, the {@link UniSubscriber#onSubscribe(UniSubscription)} method will be called
-     * on this thread (except mentioned otherwise)
-     *
-     * @param executor the executor to use, must not be {@code null}
-     * @return a new {@link Uni}
      */
     Uni<T> runSubscriptionOn(Executor executor);
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiSkip.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiSkip.java
@@ -161,6 +161,7 @@ public class MultiSkip<T> {
      * Unlike {@link MultiSelect#distinct()}, this method can be called on unbounded upstream, as it only keeps a
      * reference on the last item.
      *
+     * @param comparator the comparator, must not be {@code null}
      * @return the resulting {@link Multi}
      * @see MultiSelect#distinct()
      * @see MultiSkip#repetitions()

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiReceiveItemOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiReceiveItemOnTest.java
@@ -49,11 +49,6 @@ public class MultiReceiveItemOnTest {
     }
 
     @Test
-    public void testThatSubscribeOnExecutorCannotBeNull() {
-        assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).subscribeOn(null));
-    }
-
-    @Test
     public void testThatRunSubscriptionOnExecutorCannotBeNull() {
         assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().item(1).runSubscriptionOn(null));
     }
@@ -114,15 +109,6 @@ public class MultiReceiveItemOnTest {
             assertThat(i).isGreaterThan(current);
             current = i;
         }
-    }
-
-    @Test
-    public void testSubscribeOn() {
-        Multi.createFrom().items(1, 2, 3, 4)
-                .subscribeOn(executor)
-                .subscribe().withSubscriber(AssertSubscriber.create(4))
-                .await()
-                .assertItems(1, 2, 3, 4);
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
@@ -29,16 +29,6 @@ public class UniRunSubscriptionOnTest {
     }
 
     @Test
-    public void testRunSubscriptionOnWithSupplierWithDeprecatedMethod() {
-        UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
-        Uni.createFrom().item(() -> 1)
-                .subscribeOn(ForkJoinPool.commonPool())
-                .subscribe().withSubscriber(subscriber);
-        subscriber.await().assertItem(1);
-        assertThat(subscriber.getOnSubscribeThreadName()).isNotEqualTo(Thread.currentThread().getName());
-    }
-
-    @Test
     public void testWithWithImmediateValue() {
         UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 
@@ -109,9 +99,7 @@ public class UniRunSubscriptionOnTest {
     @Test
     public void testCancellation() {
         AtomicBoolean called = new AtomicBoolean();
-        UniAssertSubscriber<Integer> subscriber = Uni.createFrom().<Integer> emitter(e -> {
-            called.set(true);
-        })
+        UniAssertSubscriber<Integer> subscriber = Uni.createFrom().<Integer> emitter(e -> called.set(true))
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor())
                 .subscribe().withSubscriber(new UniAssertSubscriber<>(true));
 
@@ -125,9 +113,7 @@ public class UniRunSubscriptionOnTest {
         ExecutorService pool = Executors.newSingleThreadExecutor();
         pool.shutdown();
         AtomicBoolean called = new AtomicBoolean();
-        UniAssertSubscriber<Integer> subscriber = Uni.createFrom().<Integer> emitter(e -> {
-            called.set(true);
-        })
+        UniAssertSubscriber<Integer> subscriber = Uni.createFrom().<Integer> emitter(e -> called.set(true))
                 .runSubscriptionOn(pool)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         assertThat(called).isFalse();

--- a/reactor/revapi.json
+++ b/reactor/revapi.json
@@ -24,16 +24,7 @@
     "configuration": {
       "criticality": "highlight",
       "differences": [
-        {
-          "code": "java.class.externalClassExposedInAPI",
-          "new": "class io.smallrye.mutiny.groups.MultiSelect<T>",
-          "justification": "Addition of the new `select` group to Multi. If you are impacted by such a change, we recommend extending `AbstractMulti` instead of implementing `Multi` directly."
-        },
-        {
-          "code": "java.class.externalClassExposedInAPI",
-          "new": "class io.smallrye.mutiny.groups.MultiSkip<T>",
-          "justification": "Addition of the new `skip` group to Multi. If you are impacted by such a change, we recommend extending `AbstractMulti` instead of implementing `Multi` directly."
-        }
+
       ]
     }
   },


### PR DESCRIPTION
Remove subscribeOn method - deprecated since April 2020.

Also fix revapi configuration:

* missing root package in the `implementation` module
* limit the scope to the converter package in the `rxjava` and `reactor` modules

The first change requires adding a few justifications due to the addition of the `skip`, `select`, `collect` and `group` methods.

Also add the missing `comparator` parameter in javadoc in `multi.skip().repetition(Comparator)`
