### PR TITLE
Fix repetition when the first emitted item is `null`

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniRepeat.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniRepeat.java
@@ -32,7 +32,7 @@ public class UniRepeat<T> {
      * <p>
      * The produced {@link Multi} contains the items emitted by the upstream {@link Uni}. After every emission,
      * another subscription is performed on the {@link Uni}, and the item is then propagated. If the {@link Uni}
-     * fires a failure, the failure is propagated. If the {@link Uni} fires an empty items, it resubscribes.
+     * fires a failure, the failure is propagated. If the {@link Uni} emits `null` as item, it resubscribes.
      *
      * @return the {@link Multi} containing the items from the upstream {@link Uni}, resubscribed indefinitely.
      */
@@ -52,7 +52,7 @@ public class UniRepeat<T> {
      * <p>
      * The produced {@link Multi} contains the items emitted by the upstream {@link Uni}. After every emission,
      * another subscription is performed on the {@link Uni}, and the item is then propagated. If the {@link Uni}
-     * fires a failure, the failure is propagated. If the {@link Uni} fires an empty items, it resubscribes.
+     * fires a failure, the failure is propagated. If the {@link Uni} emits `null` as item, it resubscribes.
      * <p>
      * This method is named {@code atMost} because the repeating re-subscription can be stopped if the subscriber
      * cancels its subscription to the produced {@link Multi}.

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRepeatUntilOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRepeatUntilOp.java
@@ -90,7 +90,7 @@ public class MultiRepeatUntilOp<T> extends AbstractMultiOperator<T, T> implement
          * Access does not need to be synchronized as it is only accessed in onItem and onCompletion which cannot be
          * called concurrently.
          */
-        private boolean passed;
+        private boolean passed = true;
 
         public RepeatUntilProcessor(Multi<? extends T> upstream, MultiSubscriber<? super T> downstream,
                 long times, Predicate<T> predicate) {


### PR DESCRIPTION
Fix #447
﻿
