### PR TITLE
Improve release process

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -43,4 +43,14 @@ jobs:
 
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "smallrye@googlegroups.com"
+
+          curl -s "https://get.sdkman.io" | bash
+            source ~/.sdkman/bin/sdkman-init.sh && \
+            sdk install jbang
+
+          echo "Waiting for artifacts to be available from Maven Central"
+          jbang .build/WaitForCentral.java \
+            --artifacts=io.smallrye.reactive:mutiny,io.smallrye.reactive:mutiny-context-propagation,io.smallrye.reactive:mutiny-test-utils,io.smallrye.reactive:mutiny-kotlin,io.smallrye.reactive:mutiny-reactor,io.smallrye.reactive:mutiny-rxjava \
+            --expected-version="${REF}"
+
           .build/deploy-site.sh

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -46,3 +46,30 @@ jobs:
         run: |
           source ~/.sdkman/bin/sdkman-init.sh && \
           jbang .build/PostRelease.java --release-version=${REF} --token=${GITHUB_TOKEN}
+      - name: 'Clear compatibility justifications'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
+          REF: ${{ github.event.ref }}
+        run: |
+          source ~/.sdkman/bin/sdkman-init.sh
+
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "smallrye@googlegroups.com"
+
+          echo "Waiting for artifacts to be available from Maven Central, otherwise the build will fail during the compatibility verification"
+          jbang .build/WaitForCentral.java \
+            --artifacts=io.smallrye.reactive:mutiny,io.smallrye.reactive:mutiny-context-propagation,io.smallrye.reactive:mutiny-test-utils,io.smallrye.reactive:mutiny-kotlin,io.smallrye.reactive:mutiny-reactor,io.smallrye.reactive:mutiny-rxjava \
+            --expected-version="${REF}"
+
+          git clone -b master "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/smallrye/smallrye-mutiny.git" new-master
+          cd new-master
+          echo "Clearing difference justifications"
+          jbang .build/CompatibilityUtils.java clear
+          if [[ $(git diff --stat) != '' ]]; then
+            git add -A
+            git status
+            git commit -m "[POST-RELEASE] - Clearing breaking change justifications"
+            git push origin master
+          else
+            echo "No justifications cleared"
+          fi

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -60,30 +60,3 @@ jobs:
 
           sh .build/decrypt-secrets.sh
           .build/cut-release.sh
-      - name: 'Clear compatibility justifications'
-        env:
-          DRY_RUN: ${{ github.event.inputs.dry-run }}
-          BRANCH: ${{ github.event.inputs.branch }}
-        run: |
-          source ~/.sdkman/bin/sdkman-init.sh
-
-          git config --global user.name "${GITHUB_ACTOR}"
-          git config --global user.email "smallrye@googlegroups.com"
-
-          git fetch origin
-          git reset --hard
-          git checkout ${BRANCH}
-          echo "Clearing difference justifications"
-          jbang .build/CompatibilityUtils.java clear
-          if [[ $(git diff --stat) != '' ]]; then
-            git add -A
-            git status
-            git commit -m "[POST-RELEASE] - Clearing breaking change justifications"
-            if [[ ${DRY_RUN} == "true" ]]; then
-              echo "[DRY-RUN] - Skipping push"
-            else
-              git push origin ${BRANCH}
-            fi
-          else
-            echo "No justifications cleared"
-          fi


### PR DESCRIPTION
Fix #446

- The web site build will wait for the artifacts to land in Maven Central
- Prepare release would not push to master
- The justification clearing is postponed to the post-release workflow and is executed after the maven artifacts are made available in Maven Central


