### PR TITLE
Uni signals tracking and ordering assertion in UniAssertSubscriber

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/OnCancellationUniSignal.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/OnCancellationUniSignal.java
@@ -1,0 +1,17 @@
+package io.smallrye.mutiny.helpers.test;
+
+/**
+ * A cancellation signal.
+ */
+public final class OnCancellationUniSignal implements UniSignal {
+
+    @Override
+    public Void value() {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "OnCancellationSignal{}";
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/OnFailureUniSignal.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/OnFailureUniSignal.java
@@ -1,0 +1,24 @@
+package io.smallrye.mutiny.helpers.test;
+
+/**
+ * A onFailure signal.
+ */
+public final class OnFailureUniSignal implements UniSignal {
+    private final Throwable failure;
+
+    public OnFailureUniSignal(Throwable failure) {
+        this.failure = failure;
+    }
+
+    @Override
+    public Throwable value() {
+        return failure;
+    }
+
+    @Override
+    public String toString() {
+        return "OnFailureSignal{" +
+                "failure=" + failure +
+                '}';
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/OnItemUniSignal.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/OnItemUniSignal.java
@@ -1,0 +1,24 @@
+package io.smallrye.mutiny.helpers.test;
+
+/**
+ * A onItem signal.
+ */
+public final class OnItemUniSignal<T> implements UniSignal {
+    private final T item;
+
+    public OnItemUniSignal(T item) {
+        this.item = item;
+    }
+
+    @Override
+    public T value() {
+        return item;
+    }
+
+    @Override
+    public String toString() {
+        return "OnItemSignal{" +
+                "item=" + item +
+                '}';
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/OnSubscribeUniSignal.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/OnSubscribeUniSignal.java
@@ -1,0 +1,26 @@
+package io.smallrye.mutiny.helpers.test;
+
+import io.smallrye.mutiny.subscription.UniSubscription;
+
+/**
+ * A onSubscribe signal.
+ */
+public final class OnSubscribeUniSignal implements UniSignal {
+    private final UniSubscription subscription;
+
+    public OnSubscribeUniSignal(UniSubscription subscription) {
+        this.subscription = subscription;
+    }
+
+    @Override
+    public UniSubscription value() {
+        return subscription;
+    }
+
+    @Override
+    public String toString() {
+        return "OnSubscribeSignal{" +
+                "subscription=" + subscription +
+                '}';
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/UniSignal.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/UniSignal.java
@@ -1,0 +1,14 @@
+package io.smallrye.mutiny.helpers.test;
+
+/**
+ * A signal: onSubscribe, onItem, onFailure or cancel.
+ */
+public interface UniSignal {
+
+    /**
+     * Get the signal associated value, if any.
+     *
+     * @return the value
+     */
+    Object value();
+}


### PR DESCRIPTION
This is useful to check if a `Uni` has received signals in correct order.