### PR TITLE
Uni.replaceWithVoid

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -806,6 +806,20 @@ public interface Uni<T> {
     }
 
     /**
+     * Ignore the item emitted by this {@link Uni} and replace it with {@code null} and type {@link Void}.
+     * <p>
+     * This method is in effect similar to {@link Uni#replaceWithNull()}, except that it returns a {@code Uni<Void>}
+     * instead of a {@code Uni<T>}.
+     * <p>
+     * This is a shortcut for {@code uni.onItem().transform(ignored -> null)}.
+     * 
+     * @return the new {@link Uni}
+     */
+    default Uni<Void> replaceWithVoid() {
+        return onItem().transform(ignored -> null);
+    }
+
+    /**
      * Log events (onSubscribe, onItem, ...) as they come from the upstream or the subscriber.
      *
      * Events will be logged as long as the {@link Uni} hasn't been cancelled or terminated.

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniReplaceWithTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniReplaceWithTest.java
@@ -51,4 +51,15 @@ class UniReplaceWithTest {
 
         subscriber.assertCompleted().assertItem(null);
     }
+
+    @Test
+    @DisplayName("Replace with void")
+    void replaceWithVoid() {
+        UniAssertSubscriber<Void> subscriber = Uni.createFrom()
+                .item(69)
+                .replaceWithVoid()
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertCompleted().assertItem(null);
+    }
 }


### PR DESCRIPTION
Uni.replaceWithNull is useful, but sometimes we need the return type to be switched to Void.

Fixes #486