### PR TITLE
Enhance testing utilities

### DIFF
--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/MultiContextPropagationTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/MultiContextPropagationTest.java
@@ -252,7 +252,7 @@ public class MultiContextPropagationTest {
                 })
                 .subscribe().withSubscriber(AssertSubscriber.create(20));
 
-        subscriber.await()
+        subscriber.awaitCompletion()
                 .assertItems(0L, 1L, 2L, 3L, 4L);
 
     }
@@ -270,7 +270,7 @@ public class MultiContextPropagationTest {
                 })
                 .subscribe().withSubscriber(AssertSubscriber.create(20));
 
-        subscriber.await()
+        subscriber.awaitCompletion()
                 .assertItems(0L, 2L, 4L);
 
     }
@@ -289,8 +289,7 @@ public class MultiContextPropagationTest {
                 .select().first(10)
                 .subscribe().withSubscriber(AssertSubscriber.create(10));
 
-        subscriber.await()
-                .assertCompleted()
+        subscriber.awaitCompletion()
                 .assertItems(0, 1, 3, 6, 10, 15, 21, 28, 36, 45);
 
     }

--- a/documentation/src/test/java/guides/operators/BroadcastProcessorTest.java
+++ b/documentation/src/test/java/guides/operators/BroadcastProcessorTest.java
@@ -30,7 +30,6 @@ public class BroadcastProcessorTest {
         // end::code[]
         AssertSubscriber<String> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
         multi.subscribe().withSubscriber(subscriber)
-                .await()
-                .assertCompleted();
+                .awaitCompletion();
     }
 }

--- a/documentation/src/test/java/guides/operators/UnicastProcessorTest.java
+++ b/documentation/src/test/java/guides/operators/UnicastProcessorTest.java
@@ -28,7 +28,7 @@ public class UnicastProcessorTest {
         // end::code[]
         AssertSubscriber<String> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
         multi.subscribe().withSubscriber(subscriber)
-                .await()
+                .awaitCompletion()
                 .run(() -> assertThat(subscriber.getItems()).hasSize(1000));
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
@@ -121,7 +121,13 @@ public class UniOnFailure<T> {
             //noinspection unchecked
             return (Uni<T>) uni
                     .onItem().failWith(ignored -> failure)
-                    .onFailure().apply(subFailure -> new CompositeException(failure, subFailure));
+                    .onFailure().transform(subFailure -> {
+                        if (subFailure != failure) {
+                            return new CompositeException(failure, subFailure);
+                        } else {
+                            return subFailure;
+                        }
+                    });
         });
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/spies/MultiOnCancellationSpy.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/spies/MultiOnCancellationSpy.java
@@ -23,4 +23,16 @@ public class MultiOnCancellationSpy<T> extends MultiSpyBase<T> {
     public String toString() {
         return "MultiOnCancellationSpy{} " + super.toString();
     }
+
+    public void assertCancelled() {
+        if (!isCancelled()) {
+            throw new AssertionError("Expected downstream cancellation, but it did not happen");
+        }
+    }
+
+    public void assertNotCancelled() {
+        if (isCancelled()) {
+            throw new AssertionError("Did not expect to receive a downstream cancellation");
+        }
+    }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertSubscriber.java
@@ -226,7 +226,7 @@ public class AssertSubscriber<T> implements Subscriber<T> {
     }
 
     /**
-     * @return get the last received item, potentially {@code null} is no items have been received.
+     * @return get the last received item, potentially {@code null} if no items have been received.
      */
     public T getLastItem() {
         if (items.isEmpty()) {

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertionHelper.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertionHelper.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.*;
+import java.util.concurrent.CancellationException;
 import java.util.stream.Collectors;
 
 public class AssertionHelper {
@@ -76,6 +77,15 @@ public class AssertionHelper {
         if (completed) {
             fail("%nExpected no terminal event, but received a completion event.");
         } else if (failure != null) {
+            fail("%nExpected no terminal event, but received a failure event: <%s>:%n<%s>",
+                    failure, getStackTrace(failure));
+        }
+    }
+
+    static void shouldNotBeTerminatedUni(boolean completed, Throwable failure) {
+        if (completed) {
+            fail("%nExpected no terminal event, but received a completion event.");
+        } else if (failure != null && !(failure instanceof CancellationException)) {
             fail("%nExpected no terminal event, but received a failure event: <%s>:%n<%s>",
                     failure, getStackTrace(failure));
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertionHelper.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertionHelper.java
@@ -37,9 +37,17 @@ public class AssertionHelper {
                     failure, expectedFailureType, getStackTrace(failure));
         }
 
-        if (expectedMessage != null && !failure.getMessage().contains(expectedMessage)) {
-            fail("%nReceived a failure event, but expecting:%n  <%s>%nto contain:%n  <%s>%nbut was:%n  <%s>",
-                    failure.getMessage(), expectedMessage, getStackTrace(failure));
+        if (expectedMessage != null) {
+            final String msg = failure.getMessage();
+            if (msg == null) {
+                fail("%nReceived a failure event, but expecting:%n  <%s>%nto contain:%n  <%s>%nbut was:%n  <%s>",
+                        msg, expectedMessage, getStackTrace(failure));
+            } else {
+                if (!msg.contains(expectedMessage)) {
+                    fail("%nReceived a failure event, but expecting:%n  <%s>%nto contain:%n  <%s>%nbut was:%n  <%s>",
+                            msg, expectedMessage, getStackTrace(failure));
+                }
+            }
         }
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiBroadcastTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiBroadcastTest.java
@@ -298,9 +298,9 @@ public class MultiBroadcastTest {
 
         subscriber2.request(1000);
 
-        subscriber1.await().assertCompleted();
+        subscriber1.awaitCompletion();
         assertThat(subscriber1.getItems()).hasSize(1000);
-        subscriber2.await().assertCompleted();
+        subscriber2.awaitCompletion();
         assertThat(subscriber2.getItems()).hasSize(1000);
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiDisjointTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiDisjointTest.java
@@ -1,7 +1,6 @@
 package io.smallrye.mutiny.groups;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -159,16 +158,16 @@ public class MultiDisjointTest {
                 .subscribe().withSubscriber(AssertSubscriber.create(0));
 
         subscriber
-                .assertSubscribed()
+                .awaitSubscription()
                 .assertHasNotReceivedAnyItem()
                 .request(1);
 
-        await().until(() -> subscriber.getItems().contains("A"));
-
-        subscriber.request(2);
-        await().until(() -> subscriber.getItems().contains("B") && subscriber.getItems().contains("C"));
+        subscriber.awaitNextItem()
+                .request(2)
+                .awaitNextItems(2)
+                .assertItems("A", "B", "C");
 
         subscriber.request(100);
-        subscriber.await().assertCompleted();
+        subscriber.awaitCompletion();
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/UniMemoizeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/UniMemoizeTest.java
@@ -461,9 +461,9 @@ class UniMemoizeTest {
     public void testDrainBlockedByAwait() {
         Uni<Integer> uni = Uni.createFrom().item(() -> 1)
                 .memoize().indefinitely();
-        uni
+        assertThat(uni
                 .onItem().transform(x -> uni.await().indefinitely())
-                .subscribe().withSubscriber(UniAssertSubscriber.create()).await();
+                .subscribe().withSubscriber(UniAssertSubscriber.create()).awaitItem().getItem()).isEqualTo(1);
 
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/test/AssertSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/test/AssertSubscriberTest.java
@@ -8,11 +8,26 @@ import static org.mockito.Mockito.verify;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.TestException;
+import io.smallrye.mutiny.TimeoutException;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
 public class AssertSubscriberTest {
+
+    private final Duration SMALL = Duration.ofMillis(100);
+    private final Duration MEDIUM = Duration.ofMillis(1000);
+
+    private final Uni<Void> smallDelay = Uni.createFrom().voidItem()
+            .onItem().delayIt().by(SMALL);
+    private final Uni<Void> mediumDelay = Uni.createFrom().voidItem()
+            .onItem().delayIt().by(MEDIUM);
 
     @Test
     public void testItemsAndCompletion() {
@@ -144,8 +159,7 @@ public class AssertSubscriberTest {
             subscriber.onComplete();
         }).start();
 
-        subscriber.await();
-        subscriber.assertCompleted();
+        subscriber.awaitCompletion();
     }
 
     @Test
@@ -162,8 +176,7 @@ public class AssertSubscriberTest {
             subscriber.onComplete();
         }).start();
 
-        subscriber.await(Duration.ofMillis(100));
-        subscriber.assertCompleted();
+        subscriber.awaitCompletion();
     }
 
     @Test
@@ -180,7 +193,7 @@ public class AssertSubscriberTest {
             subscriber.onError(new Exception("boom"));
         }).start();
 
-        subscriber.await();
+        subscriber.awaitFailure();
         subscriber.assertFailedWith(Exception.class, "boom");
 
         assertThatThrownBy(() -> subscriber.assertFailedWith(IllegalStateException.class, ""))
@@ -201,8 +214,7 @@ public class AssertSubscriberTest {
         subscriber.request(2);
         subscriber.onComplete();
 
-        subscriber.await();
-        subscriber.assertCompleted();
+        subscriber.awaitCompletion();
     }
 
     @Test
@@ -214,7 +226,7 @@ public class AssertSubscriberTest {
         subscriber.request(2);
         subscriber.onError(new Exception("boom"));
 
-        subscriber.await();
+        subscriber.awaitFailure();
         subscriber.assertFailedWith(Exception.class, "boom");
     }
 
@@ -301,4 +313,229 @@ public class AssertSubscriberTest {
         subscriber.assertTerminated();
     }
 
+    @Test
+    public void testAwaitSubscription() {
+        // already subscribed
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1)
+                .subscribe().withSubscriber(AssertSubscriber.create(0));
+        assertThat(subscriber.awaitSubscription()).isSameAs(subscriber);
+
+        // Delay
+        subscriber = Multi.createFrom().items(1)
+                .onSubscribe().call(x -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(0));
+        assertThat(subscriber.awaitSubscription()).isSameAs(subscriber);
+
+        subscriber = Multi.createFrom().items(1)
+                .onSubscribe().call(x -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(0));
+        assertThat(subscriber.awaitSubscription(MEDIUM)).isSameAs(subscriber);
+
+        // timeout
+        subscriber = Multi.createFrom().items(1)
+                .onSubscribe().call(x -> mediumDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(0));
+        AssertSubscriber<Integer> tmp = subscriber;
+        assertThatThrownBy(() -> tmp.awaitSubscription(SMALL)).isInstanceOf(AssertionError.class)
+                .hasMessageContaining("subscription").hasMessageContaining(SMALL.toMillis() + " ms");
+    }
+
+    @Test
+    public void testAwaitCompletion() {
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1)
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
+        assertThat(subscriber.awaitCompletion()).isSameAs(subscriber);
+
+        // Delay
+        subscriber = Multi.createFrom().items(1)
+                .onCompletion().call(() -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
+        assertThat(subscriber.awaitCompletion()).isSameAs(subscriber);
+
+        subscriber = Multi.createFrom().items(1)
+                .onCompletion().call(() -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
+        assertThat(subscriber.awaitCompletion(MEDIUM)).isSameAs(subscriber);
+
+        // timeout
+        subscriber = Multi.createFrom().items(1)
+                .onCompletion().call(() -> Uni.createFrom().voidItem()
+                        .onItem().delayIt().by(MEDIUM))
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
+        AssertSubscriber<Integer> tmp = subscriber;
+        assertThatThrownBy(() -> tmp.awaitCompletion(SMALL))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("completion").hasMessageContaining(SMALL.toMillis() + " ms");
+    }
+
+    @Test
+    public void testAwaitFailure() {
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> failure(new TestException())
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
+        assertThat(subscriber.awaitFailure()).isSameAs(subscriber);
+
+        assertThat(
+                subscriber.awaitFailure(t -> assertThat(t).isInstanceOf(TestException.class))).isSameAs(subscriber);
+
+        AssertSubscriber<Integer> tmp = subscriber;
+        Consumer<Throwable> failedValidation = t -> assertThat(t).isInstanceOf(IOException.class);
+        Consumer<Throwable> passedValidation = t -> assertThat(t).isInstanceOf(TestException.class);
+
+        assertThatThrownBy(() -> tmp.awaitFailure(failedValidation))
+                .isInstanceOf(AssertionError.class).hasMessageContaining("validation");
+
+        // Delay
+        subscriber = Multi.createFrom().<Integer> failure(new TestException())
+                .onFailure().call(() -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
+        assertThat(subscriber.awaitFailure()).isSameAs(subscriber);
+
+        subscriber = Multi.createFrom().<Integer> failure(new TestException())
+                .onFailure().call(() -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
+        assertThat(subscriber.awaitFailure(passedValidation)).isSameAs(subscriber);
+
+        subscriber = Multi.createFrom().<Integer> failure(new TestException())
+                .onFailure().call(() -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
+        assertThat(subscriber.awaitFailure(MEDIUM)).isSameAs(subscriber);
+
+        // timeout
+        subscriber = Multi.createFrom().<Integer> failure(new TestException())
+                .onFailure().call(() -> mediumDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
+        AssertSubscriber<Integer> tmp2 = subscriber;
+        assertThatThrownBy(() -> tmp2.awaitFailure(SMALL)).isInstanceOf(AssertionError.class)
+                .hasMessageContaining("failure").hasMessageContaining(SMALL.toMillis() + " ms");
+    }
+
+    @Test
+    public void testFailureWithNoMessage() {
+        Multi.createFrom().failure(new TimeoutException())
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitFailure()
+                .assertFailedWith(TimeoutException.class);
+    }
+
+    @Test
+    public void testAwaitItem() {
+        // Already completed
+        assertThatThrownBy(() -> Multi.createFrom().empty()
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItem()).isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("completion").hasMessageContaining("event");
+
+        // Already failed
+        assertThatThrownBy(() -> Multi.createFrom().failure(new TestException())
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItem()).isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("failure").hasMessageContaining("event")
+                        .hasMessageContaining(TestException.class.getName());
+
+        // Completion instead of item
+        assertThatThrownBy(() -> Multi.createFrom().empty()
+                .onCompletion().call(() -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItem(SMALL.multipliedBy(2))).isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("completion").hasMessageContaining("item")
+                        .hasMessageContaining(SMALL.multipliedBy(2).toMillis() + " ms");
+
+        // Failure instead of item
+        assertThatThrownBy(() -> Multi.createFrom().failure(new TestException())
+                .onFailure().call(() -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItem(SMALL.multipliedBy(2))).isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("failure").hasMessageContaining("item")
+                        .hasMessageContaining(SMALL.multipliedBy(2).toMillis() + " ms");
+
+        // Item
+        Multi.createFrom().items(1)
+                .onItem().call(() -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItem(MEDIUM)
+                .assertItems(1);
+
+        // Item group
+        Multi.createFrom().items(1, 2, 3)
+                .onItem().call(() -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItem(MEDIUM);
+
+        // Timeout
+        assertThatThrownBy(() -> Multi.createFrom().item(1)
+                .onItem().call(() -> mediumDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItem(SMALL)).isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("item")
+                        .hasMessageContaining(SMALL.toMillis() + " ms");
+    }
+
+    @Test
+    public void testAwaitItems() {
+        // Already completed
+        assertThatThrownBy(() -> Multi.createFrom().empty()
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItems(2)).isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("completion").hasMessageContaining("event");
+
+        // Already failed
+        assertThatThrownBy(() -> Multi.createFrom().failure(new TestException())
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItems(2)).isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("failure").hasMessageContaining("event")
+                        .hasMessageContaining(TestException.class.getName());
+
+        // Completion instead of item
+        assertThatThrownBy(() -> Multi.createFrom().emitter(e -> e.emit(1).complete())
+                .onCompletion().call(() -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItems(2, SMALL.multipliedBy(2))).isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("completion").hasMessageContaining("item")
+                        .hasMessageContaining(SMALL.multipliedBy(2).toMillis() + " ms");
+
+        // Failure instead of item
+        assertThatThrownBy(() -> Multi.createFrom().emitter(e -> e.emit(1).fail(new TestException()))
+                .onFailure().call(() -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItems(2, SMALL.multipliedBy(2))).isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("failure").hasMessageContaining("item")
+                        .hasMessageContaining(SMALL.multipliedBy(2).toMillis() + " ms");
+
+        // Item
+        Multi.createFrom().items(1, 2, 3)
+                .onItem().call(() -> smallDelay)
+                .subscribe().withSubscriber(AssertSubscriber.create(3))
+                .awaitNextItems(3, MEDIUM)
+                .assertItems(1, 2, 3)
+                .assertLastItem(3);
+
+        // Timeout
+        assertThatThrownBy(() -> Multi.createFrom().emitter(e -> {
+            e.emit(1).emit(2);
+            try {
+                Thread.sleep(MEDIUM.toMillis());
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+            e.emit(3);
+        })
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .subscribe().withSubscriber(AssertSubscriber.create(3))
+                .awaitNextItems(3, SMALL)).isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("item")
+                        .hasMessageContaining(SMALL.toMillis() + " ms");
+    }
+
+    @Test
+    public void testAssertLast() {
+        assertThatThrownBy(
+                () -> Multi.createFrom().empty().subscribe().withSubscriber(AssertSubscriber.create(1)).assertLastItem(1))
+                        .isInstanceOf(AssertionError.class);
+
+        Multi.createFrom().items(1, 2, 3, 4)
+                .subscribe().withSubscriber(AssertSubscriber.create(2))
+                .assertLastItem(2)
+                .request(2)
+                .assertLastItem(4);
+    }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCollectTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCollectTest.java
@@ -39,13 +39,13 @@ public class MultiCollectTest {
         items
                 .collect().first()
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await()
+                .awaitItem()
                 .assertItem(1);
 
         items
                 .collect().last()
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await()
+                .awaitItem()
                 .assertItem(3);
     }
 
@@ -56,13 +56,13 @@ public class MultiCollectTest {
         items
                 .collectItems().first()
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await()
+                .awaitItem()
                 .assertItem(1);
 
         items
                 .collectItems().last()
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await()
+                .awaitItem()
                 .assertItem(3);
     }
 
@@ -72,13 +72,13 @@ public class MultiCollectTest {
         items
                 .collect().first()
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await()
+                .awaitItem()
                 .assertItem(null);
 
         items
                 .collect().last()
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await()
+                .awaitItem()
                 .assertItem(null);
     }
 
@@ -88,13 +88,13 @@ public class MultiCollectTest {
         failing
                 .collect().first()
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IOException.class, "boom");
 
         failing
                 .collect().last()
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IOException.class, "boom");
     }
 
@@ -103,7 +103,7 @@ public class MultiCollectTest {
         UniAssertSubscriber<List<Integer>> subscriber = Multi.createFrom().items(1, 2, 3)
                 .collect().asList()
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await();
+                .awaitItem();
 
         assertThat(subscriber.getItem()).containsExactly(1, 2, 3);
     }
@@ -113,7 +113,7 @@ public class MultiCollectTest {
         UniAssertSubscriber<LinkedList<Integer>> subscriber = Multi.createFrom().range(1, 10)
                 .collect().in(LinkedList<Integer>::new, LinkedList::add)
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await();
+                .awaitItem();
 
         assertThat(subscriber.getItem()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9).isInstanceOf(LinkedList.class);
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromCompletionStageTest.java
@@ -41,7 +41,7 @@ public class MultiCreateFromCompletionStageTest {
         AssertSubscriber<String> subscriber = Multi.createFrom()
                 .completionStage(CompletableFuture.supplyAsync(() -> "hello")).subscribe()
                 .withSubscriber(AssertSubscriber.create(1));
-        subscriber.await().assertCompleted().assertItems("hello");
+        subscriber.awaitCompletion().assertItems("hello");
     }
 
     @Test
@@ -58,7 +58,7 @@ public class MultiCreateFromCompletionStageTest {
         AssertSubscriber<Void> subscriber = Multi.createFrom()
                 .completionStage(CompletableFuture.runAsync(() -> called.set(true))).subscribe()
                 .withSubscriber(AssertSubscriber.create(1));
-        subscriber.await().assertCompleted().assertHasNotReceivedAnyItem();
+        subscriber.awaitCompletion().assertHasNotReceivedAnyItem();
         assertThat(called).isTrue();
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
@@ -1,7 +1,6 @@
 package io.smallrye.mutiny.operators;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
 import java.util.List;
@@ -37,8 +36,8 @@ public class MultiCreateFromTimePeriodTest {
                 .onItem().transform(l -> System.currentTimeMillis())
                 .subscribe().withSubscriber(subscriber);
 
-        await().until(() -> subscriber.getItems().size() >= 10);
-        subscriber.cancel();
+        subscriber.awaitNextItems(10)
+                .cancel();
 
         subscriber.assertNotTerminated();
 
@@ -64,8 +63,8 @@ public class MultiCreateFromTimePeriodTest {
                 .onItem().transform(l -> System.currentTimeMillis())
                 .subscribe().withSubscriber(subscriber);
 
-        await().until(() -> subscriber.getItems().size() >= 10);
-        subscriber.cancel();
+        subscriber.awaitNextItems(10)
+                .cancel();
 
         subscriber.assertNotTerminated();
 
@@ -90,8 +89,11 @@ public class MultiCreateFromTimePeriodTest {
 
         subscriber
                 .request(2) // request only 2
-                .await() // wait until failure
-                .assertFailedWith(BackPressureFailure.class, "lack of requests");
+                .awaitFailure(t -> { // wait until failure, and validate
+                    assertThat(t)
+                            .isInstanceOf(BackPressureFailure.class)
+                            .hasMessageContaining("lack of requests");
+                });
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmitOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmitOnTest.java
@@ -1,5 +1,6 @@
 package io.smallrye.mutiny.operators;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 
@@ -37,12 +38,12 @@ public class MultiEmitOnTest {
                 .emitOn(executor)
                 .subscribe().withSubscriber(AssertSubscriber.create());
 
-        subscriber.request(2);
-        await().until(() -> subscriber.getItems().size() == 2);
-        subscriber.assertItems(1, 2);
-        subscriber.request(20);
-        await().until(() -> subscriber.getItems().size() == 10);
-        subscriber.assertItems(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        subscriber.request(2)
+                .awaitNextItems(2)
+                .assertItems(1, 2)
+                .request(20)
+                .awaitNextItems(8)
+                .assertItems(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
 
     @Test
@@ -52,8 +53,9 @@ public class MultiEmitOnTest {
                 .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(0);
-        subscriber.await()
-                .assertFailedWith(IllegalArgumentException.class, "request");
+        subscriber.awaitFailure(t -> assertThat(t)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("request"));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -869,7 +870,7 @@ public class MultiGroupTest {
         assertThat(subscriber.assertNotTerminated().isCancelled()).isTrue();
     }
 
-    @Test
+    @RepeatedTest(10)
     public void testGroupByWithUpstreamFailure() {
         AtomicReference<MultiEmitter<? super Long>> emitter = new AtomicReference<>();
 
@@ -882,7 +883,7 @@ public class MultiGroupTest {
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
         subscriber.assertSubscribed();
-        subscriber.awaitNextItems(2);
+        await().until(() -> subscriber.getItems().size() == 2);
         AssertSubscriber<Long> s1 = subscriber.getItems().get(0).subscribe()
                 .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
         s1.assertSubscribed();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryTest.java
@@ -141,7 +141,7 @@ public class MultiOnFailureRetryTest {
                 .retry()
                 .withBackOff(Duration.ofMillis(10)).atMost(3)
                 .subscribe().withSubscriber(AssertSubscriber.create(10))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(RuntimeException.class, "boom")
                 .assertItems(1, 2, 3);
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnOverflowTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnOverflowTest.java
@@ -83,7 +83,7 @@ public class MultiOnOverflowTest {
         Multi.createFrom().range(1, 10)
                 .onOverflow().drop()
                 .subscribe(sub);
-        sub.await().assertCompleted().assertHasNotReceivedAnyItem();
+        sub.awaitCompletion().assertHasNotReceivedAnyItem();
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnSubscribeTest.java
@@ -228,9 +228,10 @@ public class MultiOnSubscribeTest {
 
         subscriber.assertNotSubscribed();
         latch.countDown();
-        subscriber.await()
-                .assertSubscribed()
-                .assertCompleted().assertItems(1, 2, 3);
+        subscriber
+                .awaitSubscription()
+                .awaitCompletion()
+                .assertItems(1, 2, 3);
     }
 
     @Test
@@ -246,9 +247,10 @@ public class MultiOnSubscribeTest {
         await().until(() -> emitter.get() != null);
         emitter.get().complete(12345);
 
-        subscriber.await()
-                .assertSubscribed()
-                .assertCompleted().assertItems(1, 2, 3);
+        subscriber
+                .awaitSubscription()
+                .awaitCompletion()
+                .assertItems(1, 2, 3);
 
     }
 
@@ -266,9 +268,10 @@ public class MultiOnSubscribeTest {
         await().until(() -> emitter.get() != null);
         emitter.get().complete(12345);
 
-        subscriber.await()
-                .assertSubscribed()
-                .assertCompleted().assertItems(1, 2, 3);
+        subscriber
+                .awaitSubscription()
+                .awaitCompletion()
+                .assertItems(1, 2, 3);
 
     }
 
@@ -280,9 +283,8 @@ public class MultiOnSubscribeTest {
 
         subscriber
                 .request(1)
-                .await()
-                .assertItems(1, 2, 3)
-                .assertCompleted();
+                .awaitCompletion()
+                .assertItems(1, 2, 3);
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiReceiveItemOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiReceiveItemOnTest.java
@@ -62,8 +62,7 @@ public class MultiReceiveItemOnTest {
                 .onItem().invoke(i -> itemThread.add(Thread.currentThread().getName()))
                 .onCompletion().invoke(() -> completionThread.add(Thread.currentThread().getName()))
                 .subscribe().withSubscriber(AssertSubscriber.create(4))
-                .await()
-                .assertCompleted();
+                .awaitCompletion();
 
         await().until(() -> subscriber.getItems().size() == 4);
         assertThat(itemThread).allSatisfy(s -> assertThat(s).startsWith("test-"));
@@ -79,7 +78,7 @@ public class MultiReceiveItemOnTest {
                 .onItem().invoke(i -> itemThread.add(Thread.currentThread().getName()))
                 .onFailure().invoke(f -> failureThread.add(Thread.currentThread().getName()))
                 .subscribe().withSubscriber(AssertSubscriber.create(4))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IOException.class, "boom");
 
         assertThat(itemThread).isEmpty();
@@ -91,7 +90,7 @@ public class MultiReceiveItemOnTest {
         Multi.createFrom().items(1, 2, 3, 4)
                 .emitOn(Runnable::run)
                 .subscribe().withSubscriber(AssertSubscriber.create(4))
-                .await()
+                .awaitCompletion()
                 .assertItems(1, 2, 3, 4);
     }
 
@@ -100,8 +99,7 @@ public class MultiReceiveItemOnTest {
         AssertSubscriber<Integer> subscriber = Multi.createFrom().range(0, 100_000)
                 .emitOn(executor)
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
-                .await()
-                .assertCompleted();
+                .awaitCompletion();
 
         assertThat(subscriber.getItems()).hasSize(100_000);
         int current = -1;
@@ -116,7 +114,7 @@ public class MultiReceiveItemOnTest {
         Multi.createFrom().items(1, 2, 3, 4)
                 .runSubscriptionOn(executor)
                 .subscribe().withSubscriber(AssertSubscriber.create(4))
-                .await()
+                .awaitCompletion()
                 .assertItems(1, 2, 3, 4);
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSelectFirstOrLast.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSelectFirstOrLast.java
@@ -249,8 +249,7 @@ public class MultiSelectFirstOrLast {
         Multi.createFrom().ticks().every(Duration.ofMillis(2))
                 .select().first(5)
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
-                .await()
-                .assertCompleted()
+                .awaitCompletion()
                 .assertItems(0L, 1L, 2L, 3L, 4L);
     }
 
@@ -265,8 +264,7 @@ public class MultiSelectFirstOrLast {
         AssertSubscriber<Integer> subscriber = Multi.createFrom().range(1, 100)
                 .select().first(Duration.ofMillis(1000))
                 .subscribe().withSubscriber(AssertSubscriber.create(10))
-                .await()
-                .assertCompleted();
+                .awaitCompletion();
 
         assertThat(subscriber.getItems()).hasSize(10);
     }
@@ -280,7 +278,7 @@ public class MultiSelectFirstOrLast {
         AssertSubscriber<Integer> subscriber = multi
                 .select().first(Duration.ofMillis(1000))
                 .subscribe().withSubscriber(AssertSubscriber.create(100))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(TestException.class, "boom");
 
         assertThat(subscriber.getItems()).hasSize(4);
@@ -330,8 +328,7 @@ public class MultiSelectFirstOrLast {
         AssertSubscriber<Integer> subscriber = rogue
                 .select().first(Duration.ofMillis(1000))
                 .subscribe().withSubscriber(AssertSubscriber.create(100))
-                .await()
-                .assertCompleted();
+                .awaitCompletion();
 
         assertThat(subscriber.getItems()).hasSize(2);
     }
@@ -351,7 +348,7 @@ public class MultiSelectFirstOrLast {
         AssertSubscriber<Integer> subscriber = rogue
                 .select().first(Duration.ofMillis(1000))
                 .subscribe().withSubscriber(AssertSubscriber.create(100))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IOException.class, "boom");
 
         assertThat(subscriber.getItems()).hasSize(2);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipTest.java
@@ -342,8 +342,7 @@ public class MultiSkipTest {
                 .onItem().transform(n -> n * 10)
                 .subscribe().withSubscriber(AssertSubscriber.create(100))
 
-                .await()
-                .assertCompleted()
+                .awaitCompletion()
                 .assertItems(40, 60, 80);
 
         assertThat(called).isFalse();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTakeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTakeTest.java
@@ -18,6 +18,7 @@ import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 
+@SuppressWarnings("deprecation")
 public class MultiTakeTest {
 
     @Test
@@ -207,8 +208,7 @@ public class MultiTakeTest {
         Multi.createFrom().ticks().every(Duration.ofMillis(2))
                 .transform().byTakingFirstItems(5)
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
-                .await()
-                .assertCompleted()
+                .awaitCompletion()
                 .assertItems(0L, 1L, 2L, 3L, 4L);
     }
 
@@ -217,8 +217,7 @@ public class MultiTakeTest {
         AssertSubscriber<Integer> subscriber = Multi.createFrom().range(1, 100).transform()
                 .byTakingItemsFor(Duration.ofMillis(1000))
                 .subscribe().withSubscriber(AssertSubscriber.create(10))
-                .await()
-                .assertCompleted();
+                .awaitCompletion();
 
         assertThat(subscriber.getItems()).hasSize(10);
     }
@@ -232,7 +231,7 @@ public class MultiTakeTest {
         AssertSubscriber<Integer> subscriber = multi
                 .transform().byTakingItemsFor(Duration.ofMillis(1000))
                 .subscribe().withSubscriber(AssertSubscriber.create(100))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(TestException.class, "boom");
 
         assertThat(subscriber.getItems()).hasSize(4);
@@ -282,8 +281,7 @@ public class MultiTakeTest {
         AssertSubscriber<Integer> subscriber = rogue
                 .transform().byTakingItemsFor(Duration.ofMillis(1000))
                 .subscribe().withSubscriber(AssertSubscriber.create(100))
-                .await()
-                .assertCompleted();
+                .awaitCompletion();
 
         assertThat(subscriber.getItems()).hasSize(2);
     }
@@ -303,7 +301,7 @@ public class MultiTakeTest {
         AssertSubscriber<Integer> subscriber = rogue
                 .transform().byTakingItemsFor(Duration.ofMillis(1000))
                 .subscribe().withSubscriber(AssertSubscriber.create(100))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IOException.class, "boom");
 
         assertThat(subscriber.getItems()).hasSize(2);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiToUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiToUniTest.java
@@ -114,12 +114,12 @@ public class MultiToUniTest {
                 .completionStage(() -> CompletableFuture.supplyAsync(count::incrementAndGet));
 
         multi.toUni().subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await()
+                .awaitItem()
                 .assertItem(1)
                 .assertCompleted();
 
         Uni.createFrom().multi(multi).subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await()
+                .awaitItem()
                 .assertItem(2)
                 .assertCompleted();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformByMergingTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformByMergingTest.java
@@ -68,7 +68,7 @@ public class MultiTransformByMergingTest {
         AssertSubscriber<Integer> subscriber = merged.subscribe()
                 .withSubscriber(AssertSubscriber.create(1000));
 
-        subscriber.await();
+        subscriber.awaitCompletion();
         List<Integer> items = subscriber.getItems();
         assertThat(Collections.singleton(items)).noneSatisfy(list -> assertThat(list).isSorted());
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToMultiTest.java
@@ -241,8 +241,7 @@ public class MultiTransformToMultiTest {
                 .subscribe(subscriber);
 
         subscriber
-                .await()
-                .assertCompleted();
+                .awaitCompletion();
         assertThat(subscriber.getItems()).containsExactlyInAnyOrder(1, 1, 2, 2, 3, 3);
     }
 
@@ -259,8 +258,7 @@ public class MultiTransformToMultiTest {
                 .subscribe(subscriber);
 
         subscriber
-                .await()
-                .assertCompleted();
+                .awaitCompletion();
         assertThat(subscriber.getItems()).containsExactly(1, 1, 2, 2, 3, 3);
     }
 
@@ -276,9 +274,7 @@ public class MultiTransformToMultiTest {
                 })
                 .subscribe(subscriber);
 
-        subscriber
-                .await()
-                .assertCompleted();
+        subscriber.awaitCompletion();
         assertThat(subscriber.getItems()).containsExactlyInAnyOrder(1, 1, 2, 2, 3, 3);
     }
 
@@ -295,8 +291,7 @@ public class MultiTransformToMultiTest {
                 .subscribe(subscriber);
 
         subscriber
-                .await()
-                .assertCompleted();
+                .awaitCompletion();
         assertThat(subscriber.getItems()).containsExactlyInAnyOrder(1, 1, 2, 2, 3, 3);
     }
 
@@ -309,8 +304,8 @@ public class MultiTransformToMultiTest {
                 .subscribe(subscriber);
 
         subscriber
-                .await()
-                .assertItems(1, 1, 2, 2, 3, 3).assertCompleted();
+                .awaitCompletion()
+                .assertItems(1, 1, 2, 2, 3, 3);
     }
 
     @Test
@@ -451,7 +446,7 @@ public class MultiTransformToMultiTest {
                 .merge(25)
                 .subscribe(subscriber);
 
-        subscriber.await().assertCompleted();
+        subscriber.awaitCompletion();
         assertThat(subscriber.getItems()).hasSize(10000);
     }
 
@@ -881,8 +876,7 @@ public class MultiTransformToMultiTest {
         AssertSubscriber<Object> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
         multi.subscribe().withSubscriber(subscriber);
 
-        subscriber.await()
-                .assertCompleted();
+        subscriber.awaitCompletion();
 
         List<Integer> expected = new ArrayList<>();
         for (int i = 0; i <= 99; i++) {
@@ -939,8 +933,7 @@ public class MultiTransformToMultiTest {
                 .merge(8)
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
-        subscriber.await()
-                .assertCompleted();
+        subscriber.awaitCompletion();
 
         assertThat(subscriber.getItems()).containsExactlyInAnyOrderElementsOf(expected);
     }
@@ -956,8 +949,7 @@ public class MultiTransformToMultiTest {
                 .concatenate()
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
-        subscriber.await()
-                .assertCompleted();
+        subscriber.awaitCompletion();
 
         assertThat(subscriber.getItems()).containsExactlyElementsOf(expected);
     }
@@ -967,8 +959,7 @@ public class MultiTransformToMultiTest {
         AssertSubscriber<Integer> subscriber = Multi.createFrom().range(1, 1001)
                 .flatMap(i -> Multi.createFrom().item(i).runSubscriptionOn(Infrastructure.getDefaultExecutor()))
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
-        subscriber.await()
-                .assertCompleted();
+        subscriber.awaitCompletion();
         assertThat(subscriber.getItems()).hasSize(1000);
     }
 
@@ -978,8 +969,7 @@ public class MultiTransformToMultiTest {
                 .flatMap(i -> Multi.createFrom().items(i + 1, i + 2))
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
-        subscriber.await()
-                .assertCompleted();
+        subscriber.awaitCompletion();
         assertThat(subscriber.getItems()).hasSize(4);
     }
 
@@ -995,8 +985,7 @@ public class MultiTransformToMultiTest {
                 })
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
-        subscriber.await()
-                .assertCompleted();
+        subscriber.awaitCompletion();
         assertThat(subscriber.getItems()).hasSize(512);
     }
 
@@ -1012,8 +1001,7 @@ public class MultiTransformToMultiTest {
                 })
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
-        subscriber.await()
-                .assertCompleted();
+        subscriber.awaitCompletion();
         assertThat(subscriber.getItems()).hasSize(512);
     }
 
@@ -1029,8 +1017,7 @@ public class MultiTransformToMultiTest {
                 })
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
-        subscriber.await()
-                .assertCompleted();
+        subscriber.awaitCompletion();
         assertThat(subscriber.getItems()).hasSize(512);
     }
 
@@ -1049,8 +1036,7 @@ public class MultiTransformToMultiTest {
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor())
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
-        subscriber.await(Duration.ofSeconds(5))
-                .assertCompleted();
+        subscriber.awaitCompletion(Duration.ofSeconds(5));
         assertThat(subscriber.getItems()).hasSize(max / 2);
     }
 
@@ -1067,7 +1053,8 @@ public class MultiTransformToMultiTest {
                 })
                 .subscribe().withSubscriber(AssertSubscriber.create(10));
 
-        subscriber.await()
+        subscriber
+                .awaitFailure()
                 .assertFailedWith(IllegalArgumentException.class, "boom");
         assertThat(cancelled).hasValue(1);
     }
@@ -1087,7 +1074,8 @@ public class MultiTransformToMultiTest {
                 .merge()
                 .subscribe().withSubscriber(AssertSubscriber.create(10));
 
-        subscriber.await()
+        subscriber
+                .awaitFailure()
                 .assertFailedWith(CompositeException.class, "boom");
         assertThat(cancelled).hasValue(0);
     }
@@ -1106,7 +1094,8 @@ public class MultiTransformToMultiTest {
                 .merge()
                 .subscribe().withSubscriber(AssertSubscriber.create(10));
 
-        subscriber.await()
+        subscriber
+                .awaitFailure()
                 .assertFailedWith(IllegalArgumentException.class, "boom");
         assertThat(cancelled).hasValue(1);
     }
@@ -1126,7 +1115,8 @@ public class MultiTransformToMultiTest {
                 .concatenate()
                 .subscribe().withSubscriber(AssertSubscriber.create(10));
 
-        subscriber.await()
+        subscriber
+                .awaitFailure()
                 .assertFailedWith(CompositeException.class, "boom");
         assertThat(cancelled).hasValue(0);
     }
@@ -1145,7 +1135,8 @@ public class MultiTransformToMultiTest {
                 .concatenate()
                 .subscribe().withSubscriber(AssertSubscriber.create(10));
 
-        subscriber.await()
+        subscriber
+                .awaitFailure()
                 .assertFailedWith(IllegalArgumentException.class, "boom");
         assertThat(cancelled).hasValue(1);
     }
@@ -1283,7 +1274,7 @@ public class MultiTransformToMultiTest {
                 }).merge(1)
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
-        subscriber.await().assertCompleted();
+        subscriber.awaitCompletion();
         assertThat(subscriber.getItems()).hasSize(20);
         assertThat(subscriber.getItems())
                 .containsExactlyInAnyOrder(0, 1, 2, 3, 4, -5, 6, 7, 8, 9, -10, 11, 12, 13, 14, -15, 16, 17, 18, 19);
@@ -1299,7 +1290,7 @@ public class MultiTransformToMultiTest {
                 }).merge(5)
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
-        subscriber.await().assertCompleted();
+        subscriber.awaitCompletion();
         assertThat(subscriber.getItems()).hasSize(20);
         assertThat(subscriber.getItems())
                 .containsExactlyInAnyOrder(0, 1, 2, 3, 4, -5, 6, 7, 8, 9, -10, 11, 12, 13, 14, -15, 16, 17, 18, 19);
@@ -1318,7 +1309,7 @@ public class MultiTransformToMultiTest {
                 }).concatenate()
                 .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
-        subscriber.await().assertCompleted();
+        subscriber.awaitCompletion();
         assertThat(subscriber.getItems()).hasSize(20);
         assertThat(subscriber.getItems())
                 .containsExactly(0, 1, 2, 3, 4, -5, 6, 7, 8, 9, -10, 11, 12, 13, 14, -15, 16, 17, 18, 19);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAndTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAndTest.java
@@ -75,7 +75,7 @@ public class UniAndTest {
         UniAssertSubscriber<Integer> subscriber = Uni.combine().all().unis(uni1, uni2, uni3)
                 .combinedWith((i1, i2, i3) -> i1 + i2 + i3)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        subscriber.await().assertItem(6);
+        subscriber.awaitItem().assertItem(6);
     }
 
     @Test
@@ -142,7 +142,7 @@ public class UniAndTest {
         UniAssertSubscriber<Integer> subscriber = uni1.and().unis(uni2, uni3)
                 .combinedWith((i1, i2, i3) -> i1 + i2 + i3)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        subscriber.await().assertItem(6);
+        subscriber.awaitItem().assertItem(6);
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromFutureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromFutureTest.java
@@ -26,7 +26,7 @@ public class UniCreateFromFutureTest {
         Uni.createFrom().future(cs).subscribe().withSubscriber(subscriber);
         cs.complete(null);
         subscriber
-                .await()
+                .awaitItem()
                 .assertCompleted().assertItem(null);
     }
 
@@ -47,8 +47,9 @@ public class UniCreateFromFutureTest {
         CompletableFuture<String> cs = new CompletableFuture<>();
         cs.cancel(false);
         Uni.createFrom().future(cs).subscribe().withSubscriber(subscriber);
-        // No await - immediate failure
+
         subscriber
+                .awaitFailure()
                 .assertFailedWith(CancellationException.class, null);
     }
 
@@ -59,7 +60,7 @@ public class UniCreateFromFutureTest {
         Uni.createFrom().future(cs).subscribe().withSubscriber(subscriber);
         cs.complete("1");
         subscriber
-                .await()
+                .awaitItem()
                 .assertCompleted().assertItem("1");
     }
 
@@ -70,7 +71,7 @@ public class UniCreateFromFutureTest {
         Uni.createFrom().future(cs).subscribe().withSubscriber(subscriber);
         cs.completeExceptionally(new IOException("boom"));
         subscriber
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IOException.class, "boom");
     }
 
@@ -96,7 +97,7 @@ public class UniCreateFromFutureTest {
                 })).subscribe().withSubscriber(subscriber);
         cs.complete("bonjour");
         subscriber
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IllegalStateException.class, "boom");
     }
 
@@ -115,7 +116,7 @@ public class UniCreateFromFutureTest {
         Uni.createFrom().future(() -> cs).subscribe().withSubscriber(subscriber);
         cs.complete("1");
         subscriber
-                .await()
+                .awaitItem()
                 .assertCompleted().assertItem("1");
     }
 
@@ -126,7 +127,7 @@ public class UniCreateFromFutureTest {
         Uni.createFrom().future(() -> cs).subscribe().withSubscriber(subscriber);
         cs.completeExceptionally(new IOException("boom"));
         subscriber
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IOException.class, "boom");
     }
 
@@ -244,7 +245,7 @@ public class UniCreateFromFutureTest {
 
         uni.subscribe().withSubscriber(subscriber);
         cs.complete(1);
-        subscriber.await();
+        subscriber.awaitItem();
         subscriber.cancel();
         assertThat(called).isTrue();
         subscriber.assertItem(1);
@@ -259,7 +260,7 @@ public class UniCreateFromFutureTest {
         uni.subscribe().withSubscriber(subscriber);
         cs.complete(1);
         subscriber
-                .await()
+                .awaitItem()
                 .cancel();
 
         subscriber.assertItem(1);
@@ -292,7 +293,7 @@ public class UniCreateFromFutureTest {
         Uni.createFrom().future(cs).subscribe().withSubscriber(subscriber);
         cs.cancel(true);
         subscriber
-                .await()
+                .awaitFailure()
                 .assertFailedWith(CancellationException.class, null);
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
@@ -27,7 +27,7 @@ public class UniIfNoItemTest {
                 .ifNoItem().after(Duration.ofMillis(10)).recoverWithUni(Uni.createFrom().nothing())
                 .subscribe().withSubscriber(subscriber);
 
-        subscriber.await().assertCompleted().assertItem(1);
+        assertThat(subscriber.awaitItem().getItem()).isEqualTo(1);
     }
 
     @Test
@@ -39,7 +39,7 @@ public class UniIfNoItemTest {
                 .ifNoItem().after(Duration.ofMillis(1)).fail()
                 .subscribe().withSubscriber(subscriber);
 
-        subscriber.await().assertFailed();
+        subscriber.awaitFailure();
         assertThat(subscriber.getFailure()).isInstanceOf(TimeoutException.class);
     }
 
@@ -58,7 +58,7 @@ public class UniIfNoItemTest {
                 .ifNoItem().after(Duration.ofMillis(1)).fail()
                 .subscribe().withSubscriber(subscriber);
 
-        subscriber.await().assertFailed();
+        subscriber.awaitFailure();
         assertThat(subscriber.getFailure()).isInstanceOf(TimeoutException.class);
     }
 
@@ -78,7 +78,7 @@ public class UniIfNoItemTest {
                 .ifNoItem().after(Duration.ofMillis(10000)).fail()
                 .subscribe().withSubscriber(subscriber);
 
-        subscriber.await().assertFailed();
+        subscriber.awaitFailure();
         assertThat(subscriber.getFailure()).isInstanceOf(TestException.class);
     }
 
@@ -87,7 +87,7 @@ public class UniIfNoItemTest {
         UniAssertSubscriber<Integer> subscriber = Uni.createFrom().<Integer> nothing()
                 .ifNoItem().after(Duration.ofMillis(10)).recoverWithItem(5)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        subscriber.await().assertItem(5);
+        subscriber.awaitItem().assertItem(5);
     }
 
     @Test
@@ -95,7 +95,7 @@ public class UniIfNoItemTest {
         UniAssertSubscriber<Integer> subscriber = Uni.createFrom().<Integer> nothing()
                 .ifNoItem().after(Duration.ofMillis(10)).recoverWithItem(() -> 23)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        subscriber.await().assertItem(23);
+        subscriber.awaitItem().assertItem(23);
     }
 
     @Test
@@ -103,7 +103,7 @@ public class UniIfNoItemTest {
         UniAssertSubscriber<Integer> subscriber = Uni.createFrom().<Integer> nothing()
                 .ifNoItem().after(Duration.ofMillis(10)).recoverWithUni(() -> Uni.createFrom().item(15))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        subscriber.await().assertItem(15);
+        subscriber.awaitItem().assertItem(15);
     }
 
     @Test
@@ -111,7 +111,7 @@ public class UniIfNoItemTest {
         UniAssertSubscriber<Integer> subscriber = Uni.createFrom().<Integer> nothing()
                 .ifNoItem().after(Duration.ofMillis(10)).failWith(new IOException("boom"))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        subscriber.await().assertFailedWith(IOException.class, "boom");
+        subscriber.awaitFailure().assertFailedWith(IOException.class, "boom");
     }
 
     @Test
@@ -140,8 +140,7 @@ public class UniIfNoItemTest {
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber
-                .await()
-                .assertFailed()
+                .awaitFailure()
                 .assertFailedWith(RejectedExecutionException.class, "");
     }
 
@@ -184,7 +183,7 @@ public class UniIfNoItemTest {
                 })
                 .subscribe().withSubscriber(subscriber);
 
-        subscriber.await().assertFailed();
+        subscriber.awaitFailure();
         assertThat(subscriber.getFailure()).isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureTransformTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureTransformTest.java
@@ -101,7 +101,7 @@ public class UniOnFailureTransformTest {
                     })
                     .subscribe().withSubscriber(subscriber);
 
-            subscriber.await().assertFailedWith(BoomException.class, "BoomException");
+            subscriber.awaitFailure().assertFailedWith(BoomException.class, "BoomException");
             assertThat(threadName).isNotNull().doesNotHaveValue("main");
             assertThat(subscriber.getOnFailureThreadName()).isEqualTo(threadName.get());
         } finally {

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayTest.java
@@ -51,7 +51,7 @@ public class UniOnItemDelayTest {
                 .onItem().delayIt()
                 .by(Duration.ofMillis(100)).subscribe().withSubscriber(subscriber);
 
-        subscriber.await();
+        subscriber.awaitItem();
         long end = System.currentTimeMillis();
         assertThat(end - begin).isGreaterThanOrEqualTo(100);
         subscriber.assertCompleted().assertItem(null);
@@ -77,7 +77,7 @@ public class UniOnItemDelayTest {
         long begin = System.currentTimeMillis();
         UniAssertSubscriber<Void> subscriber = UniAssertSubscriber.create();
         delayed.subscribe().withSubscriber(subscriber);
-        subscriber.await();
+        subscriber.awaitItem();
         long end = System.currentTimeMillis();
         assertThat(end - begin).isGreaterThanOrEqualTo(100);
         subscriber.assertCompleted().assertItem(null);
@@ -91,10 +91,10 @@ public class UniOnItemDelayTest {
         Uni.createFrom().<Void> failure(new Exception("boom")).onItem().delayIt()
                 .onExecutor(executor)
                 .by(Duration.ofMillis(100)).subscribe().withSubscriber(subscriber);
-        subscriber.await();
+        subscriber.awaitFailure();
         long end = System.currentTimeMillis();
         assertThat(end - begin).isLessThan(100);
-        subscriber.assertFailed().assertFailedWith(Exception.class, "boom");
+        subscriber.assertFailedWith(Exception.class, "boom");
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayUntilTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayUntilTest.java
@@ -92,7 +92,7 @@ public class UniOnItemDelayUntilTest {
         await().until(() -> reference.get() != null);
         subscriber.assertNotTerminated();
         reference.get().complete(null);
-        subscriber.await().assertItem(1);
+        subscriber.awaitItem().assertItem(1);
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureFlatMapTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureFlatMapTest.java
@@ -72,7 +72,7 @@ public class UniOnItemOrFailureFlatMapTest {
             return Uni.createFrom().item(2);
         }).subscribe().withSubscriber(test);
 
-        test.await().assertCompleted().assertItem(2);
+        assertThat(test.awaitItem().getItem()).isEqualTo(2);
         assertThat(count).hasValue(1);
     }
 
@@ -114,7 +114,7 @@ public class UniOnItemOrFailureFlatMapTest {
             return Uni.createFrom().item(2);
         }).subscribe().withSubscriber(test);
 
-        test.await().assertCompleted().assertItem(2);
+        assertThat(test.awaitItem().getItem()).isEqualTo(2);
         assertThat(count).hasValue(1);
     }
 
@@ -154,7 +154,7 @@ public class UniOnItemOrFailureFlatMapTest {
             throw new IllegalStateException("kaboom");
         }).subscribe().withSubscriber(test);
 
-        test.await().assertFailedWith(IllegalStateException.class, "kaboom");
+        test.awaitFailure().assertFailedWith(IllegalStateException.class, "kaboom");
         assertThat(count).hasValue(1);
     }
 
@@ -168,7 +168,7 @@ public class UniOnItemOrFailureFlatMapTest {
             throw new IllegalStateException("kaboom");
         }).subscribe().withSubscriber(test);
 
-        test.await().assertFailedWith(IllegalStateException.class, "kaboom");
+        test.awaitFailure().assertFailedWith(IllegalStateException.class, "kaboom");
         assertThat(count).hasValue(1);
     }
 
@@ -183,8 +183,8 @@ public class UniOnItemOrFailureFlatMapTest {
             throw new IllegalStateException("kaboom");
         }).subscribe().withSubscriber(test);
 
-        test.await().assertFailedWith(CompositeException.class, "kaboom");
-        test.await().assertFailedWith(CompositeException.class, "boom");
+        test.awaitFailure().assertFailedWith(CompositeException.class, "kaboom");
+        test.awaitFailure().assertFailedWith(CompositeException.class, "boom");
         assertThat(count).hasValue(1);
     }
 
@@ -197,7 +197,7 @@ public class UniOnItemOrFailureFlatMapTest {
                     called.set(true);
                     return null;
                 }).subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(NullPointerException.class, "");
+        test.awaitFailure().assertFailedWith(NullPointerException.class, "");
         assertThat(called).isTrue();
     }
 
@@ -211,7 +211,7 @@ public class UniOnItemOrFailureFlatMapTest {
                     called.set(true);
                     return null;
                 }).subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(NullPointerException.class, "");
+        test.awaitFailure().assertFailedWith(NullPointerException.class, "");
         assertThat(called).isTrue();
     }
 
@@ -244,7 +244,7 @@ public class UniOnItemOrFailureFlatMapTest {
             e.complete(2);
         }).subscribe().withSubscriber(test);
 
-        test.await().assertItem(2).assertCompleted();
+        test.awaitItem().assertItem(2).assertCompleted();
     }
 
     @Test
@@ -257,7 +257,7 @@ public class UniOnItemOrFailureFlatMapTest {
             e.complete(2);
         }).subscribe().withSubscriber(test);
 
-        test.await().assertItem(2).assertCompleted();
+        test.awaitItem().assertItem(2).assertCompleted();
     }
 
     @Test
@@ -269,7 +269,7 @@ public class UniOnItemOrFailureFlatMapTest {
             e.complete(2);
         }).subscribe().withSubscriber(test);
 
-        test.await().assertItem(2).assertCompleted();
+        test.awaitItem().assertItem(2).assertCompleted();
     }
 
     @Test
@@ -281,7 +281,7 @@ public class UniOnItemOrFailureFlatMapTest {
             e.complete(2);
         }).subscribe().withSubscriber(test);
 
-        test.await().assertItem(2).assertCompleted();
+        test.awaitItem().assertItem(2).assertCompleted();
     }
 
     @Test
@@ -293,7 +293,7 @@ public class UniOnItemOrFailureFlatMapTest {
             throw new IllegalStateException("bing");
         }).subscribe().withSubscriber(test);
 
-        test.await().assertFailedWith(IllegalStateException.class, "bing");
+        test.awaitFailure().assertFailedWith(IllegalStateException.class, "bing");
     }
 
     @Test
@@ -303,8 +303,8 @@ public class UniOnItemOrFailureFlatMapTest {
             throw new IllegalStateException("bing");
         }).subscribe().withSubscriber(test);
 
-        test.await().assertFailedWith(CompositeException.class, "bing");
-        test.await().assertFailedWith(CompositeException.class, "boom");
+        test.awaitFailure().assertFailedWith(CompositeException.class, "bing");
+        test.awaitFailure().assertFailedWith(CompositeException.class, "boom");
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureInvokeTest.java
@@ -178,7 +178,7 @@ public class UniOnItemOrFailureInvokeTest {
                     .onItemOrFailure().invoke((i, f) -> threadName.set(Thread.currentThread().getName()))
                     .subscribe().withSubscriber(subscriber);
 
-            subscriber.await().assertCompleted().assertItem(1);
+            assertThat(subscriber.awaitItem().getItem()).isEqualTo(1);
             assertThat(threadName).isNotNull().doesNotHaveValue("main");
             assertThat(subscriber.getOnItemThreadName()).isEqualTo(threadName.get());
         } finally {
@@ -202,7 +202,7 @@ public class UniOnItemOrFailureInvokeTest {
                     .onFailure().recoverWithItem(1)
                     .subscribe().withSubscriber(subscriber);
 
-            subscriber.await().assertCompleted().assertItem(1);
+            assertThat(subscriber.awaitItem().getItem()).isEqualTo(1);
             assertThat(threadName).isNotNull().doesNotHaveValue("main");
             assertThat(subscriber.getOnItemThreadName()).isEqualTo(threadName.get());
         } finally {

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureMapTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureMapTest.java
@@ -167,7 +167,7 @@ public class UniOnItemOrFailureMapTest {
                     })
                     .subscribe().withSubscriber(subscriber);
 
-            subscriber.await().assertCompleted().assertItem(2);
+            assertThat(subscriber.awaitItem().getItem()).isEqualTo(2);
             assertThat(threadName).isNotNull().doesNotHaveValue("main");
             assertThat(subscriber.getOnItemThreadName()).isEqualTo(threadName.get());
         } finally {
@@ -191,7 +191,7 @@ public class UniOnItemOrFailureMapTest {
                     })
                     .subscribe().withSubscriber(subscriber);
 
-            subscriber.await().assertCompleted().assertItem(1);
+            assertThat(subscriber.awaitItem().getItem()).isEqualTo(1);
             assertThat(threadName).isNotNull().doesNotHaveValue("main");
             assertThat(subscriber.getOnItemThreadName()).isEqualTo(threadName.get());
         } finally {

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemProduceCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemProduceCompletionStageTest.java
@@ -40,7 +40,7 @@ public class UniOnItemProduceCompletionStageTest {
         Uni<Integer> uni = Uni.createFrom().item(1).onItem()
                 .produceCompletionStage(v -> CompletableFuture.supplyAsync(() -> 42));
         uni.subscribe().withSubscriber(test);
-        test.await().assertCompleted().assertItem(42);
+        assertThat(test.awaitItem().getItem()).isEqualTo(42);
     }
 
     @Test
@@ -51,7 +51,7 @@ public class UniOnItemProduceCompletionStageTest {
                     throw new IllegalStateException("boom");
                 }));
         uni.subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(IllegalStateException.class, "boom");
+        test.awaitFailure().assertFailedWith(IllegalStateException.class, "boom");
     }
 
     @Test
@@ -62,7 +62,7 @@ public class UniOnItemProduceCompletionStageTest {
             called.set(true);
             return CompletableFuture.completedFuture(2);
         }).subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(Exception.class, "boom");
+        test.awaitFailure().assertFailedWith(Exception.class, "boom");
         assertThat(called).isFalse();
     }
 
@@ -76,7 +76,7 @@ public class UniOnItemProduceCompletionStageTest {
                     throw new IllegalStateException("boom");
                 })
                 .subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(IllegalStateException.class, "boom");
+        test.awaitFailure().assertFailedWith(IllegalStateException.class, "boom");
         assertThat(called).isTrue();
     }
 
@@ -89,7 +89,7 @@ public class UniOnItemProduceCompletionStageTest {
                     called.set(true);
                     return null;
                 }).subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(NullPointerException.class, "");
+        test.awaitFailure().assertFailedWith(NullPointerException.class, "");
         assertThat(called).isTrue();
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformTest.java
@@ -110,7 +110,7 @@ public class UniOnItemTransformTest {
                     })
                     .subscribe().withSubscriber(subscriber);
 
-            subscriber.await().assertCompleted().assertItem(2);
+            assertThat(subscriber.awaitItem().getItem()).isEqualTo(2);
             assertThat(threadName).isNotNull().doesNotHaveValue("main");
             assertThat(subscriber.getOnItemThreadName()).isEqualTo(threadName.get());
         } finally {

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToMultiTest.java
@@ -28,8 +28,7 @@ public class UniOnItemTransformToMultiTest {
         Uni.createFrom().item(1)
                 .onItem().transformToMulti(i -> Multi.createFrom().range(i, 5))
                 .subscribe().withSubscriber(AssertSubscriber.create(10))
-                .await()
-                .assertCompleted()
+                .awaitCompletion()
                 .assertItems(1, 2, 3, 4);
     }
 
@@ -39,8 +38,7 @@ public class UniOnItemTransformToMultiTest {
         Uni.createFrom().item(1)
                 .onItem().produceMulti(i -> Multi.createFrom().range(i, 5))
                 .subscribe().withSubscriber(AssertSubscriber.create(10))
-                .await()
-                .assertCompleted()
+                .awaitCompletion()
                 .assertItems(1, 2, 3, 4);
     }
 
@@ -49,8 +47,7 @@ public class UniOnItemTransformToMultiTest {
         Uni.createFrom().voidItem()
                 .onItem().transformToMulti(x -> Multi.createFrom().range(1, 5))
                 .subscribe().withSubscriber(AssertSubscriber.create(10))
-                .await()
-                .assertCompleted()
+                .awaitCompletion()
                 .assertItems(1, 2, 3, 4);
     }
 
@@ -59,7 +56,7 @@ public class UniOnItemTransformToMultiTest {
         Uni.createFrom().<Integer> failure(new IOException("boom"))
                 .onItem().transformToMulti(x -> Multi.createFrom().range(1, 5))
                 .subscribe().withSubscriber(AssertSubscriber.create(10))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IOException.class, "boom")
                 .assertHasNotReceivedAnyItem();
     }
@@ -71,7 +68,7 @@ public class UniOnItemTransformToMultiTest {
                     throw new IllegalStateException("boom");
                 })
                 .subscribe().withSubscriber(AssertSubscriber.create(10))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IllegalStateException.class, "boom")
                 .assertHasNotReceivedAnyItem();
     }
@@ -81,7 +78,7 @@ public class UniOnItemTransformToMultiTest {
         Uni.createFrom().item(1)
                 .onItem().transformToMulti(x -> null)
                 .subscribe().withSubscriber(AssertSubscriber.create(10))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(NullPointerException.class, "")
                 .assertHasNotReceivedAnyItem();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToUniTest.java
@@ -98,7 +98,8 @@ public class UniOnItemTransformToUniTest {
                 .transformToUni(
                         v -> Uni.createFrom().emitter(emitter -> new Thread(() -> emitter.complete(42)).start()));
         uni.subscribe().withSubscriber(test);
-        test.await().assertCompleted().assertItem(42);
+        assertThat(test.awaitItem().getItem()).isEqualTo(42);
+
     }
 
     @Test
@@ -107,7 +108,7 @@ public class UniOnItemTransformToUniTest {
         Uni<Integer> uni = Uni.createFrom().item(1).onItem().transformToUni(v -> Uni.createFrom()
                 .emitter(emitter -> new Thread(() -> emitter.fail(new IOException("boom"))).start()));
         uni.subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(IOException.class, "boom");
+        test.awaitFailure().assertFailedWith(IOException.class, "boom");
     }
 
     @Test
@@ -118,7 +119,7 @@ public class UniOnItemTransformToUniTest {
             called.set(true);
             return Uni.createFrom().item(2);
         }).subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(Exception.class, "boom");
+        test.awaitFailure().assertFailedWith(Exception.class, "boom");
         assertThat(called).isFalse();
     }
 
@@ -132,7 +133,7 @@ public class UniOnItemTransformToUniTest {
                     throw new IllegalStateException("boom");
                 })
                 .subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(IllegalStateException.class, "boom");
+        test.awaitFailure().assertFailedWith(IllegalStateException.class, "boom");
         assertThat(called).isTrue();
     }
 
@@ -145,7 +146,7 @@ public class UniOnItemTransformToUniTest {
                     called.set(true);
                     return null;
                 }).subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(NullPointerException.class, "");
+        test.awaitFailure().assertFailedWith(NullPointerException.class, "");
         assertThat(called).isTrue();
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToUniWithEmitterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemTransformToUniWithEmitterTest.java
@@ -58,10 +58,8 @@ public class UniOnItemTransformToUniWithEmitterTest {
                 .transformToUni((v, e) -> new Thread(() -> e.complete(count.incrementAndGet())).start());
         uni.subscribe().withSubscriber(test1);
         uni.subscribe().withSubscriber(test2);
-        test1.await().assertCompleted();
-        test2.await().assertCompleted();
-        assertThat(test1.getItem()).isBetween(3, 4);
-        assertThat(test2.getItem()).isBetween(3, 4);
+        assertThat(test1.awaitItem().getItem()).isBetween(3, 4);
+        assertThat(test2.awaitItem().getItem()).isBetween(3, 4);
     }
 
     @Test
@@ -70,7 +68,7 @@ public class UniOnItemTransformToUniWithEmitterTest {
         Uni<Integer> uni = Uni.createFrom().item(1).onItem()
                 .transformToUni((v, e) -> new Thread(() -> e.fail(new IOException("boom"))).start());
         uni.subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(IOException.class, "boom");
+        test.awaitFailure().assertFailedWith(IOException.class, "boom");
     }
 
     @Test
@@ -81,7 +79,7 @@ public class UniOnItemTransformToUniWithEmitterTest {
             called.set(true);
             e.complete(2);
         }).subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(Exception.class, "boom");
+        test.awaitFailure().assertFailedWith(Exception.class, "boom");
         assertThat(called).isFalse();
     }
 
@@ -93,7 +91,7 @@ public class UniOnItemTransformToUniWithEmitterTest {
             called.set(true);
             throw new IllegalStateException("boom");
         }).subscribe().withSubscriber(test);
-        test.await().assertFailed().assertFailedWith(IllegalStateException.class, "boom");
+        test.awaitFailure().assertFailedWith(IllegalStateException.class, "boom");
         assertThat(called).isTrue();
     }
 
@@ -106,7 +104,7 @@ public class UniOnItemTransformToUniWithEmitterTest {
             e.complete(2);
             throw new IllegalStateException("boom");
         }).subscribe().withSubscriber(test);
-        test.await().assertCompleted().assertItem(2);
+        assertThat(test.awaitItem().getItem()).isEqualTo(2);
         assertThat(called).isTrue();
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnSubscribeTest.java
@@ -315,8 +315,8 @@ public class UniOnSubscribeTest {
 
         subscriber.assertNotSubscribed();
         latch.countDown();
-        subscriber.await()
-                .assertSubscribed()
+        subscriber.awaitSubscription()
+                .awaitItem()
                 .assertCompleted().assertItem(1);
     }
 
@@ -333,8 +333,8 @@ public class UniOnSubscribeTest {
         await().until(() -> emitter.get() != null);
         emitter.get().complete(12345);
 
-        subscriber.await()
-                .assertSubscribed()
+        subscriber.awaitSubscription()
+                .awaitItem()
                 .assertCompleted().assertItem(1);
 
     }
@@ -353,8 +353,8 @@ public class UniOnSubscribeTest {
         await().until(() -> emitter.get() != null);
         emitter.get().complete(12345);
 
-        subscriber.await()
-                .assertSubscribed()
+        subscriber.awaitSubscription()
+                .awaitItem()
                 .assertCompleted().assertItem(1);
 
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnTerminationTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnTerminationTest.java
@@ -36,7 +36,8 @@ public class UniOnTerminationTest {
                 .onTermination().invoke((r, f, c) -> terminate.set(r))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber
-                .await()
+                .awaitSubscription()
+                .awaitItem()
                 .assertItem(1);
         assertThat(terminate).hasValue(1);
     }
@@ -58,7 +59,7 @@ public class UniOnTerminationTest {
                 .emitOn(Infrastructure.getDefaultExecutor())
                 .onTermination().invoke(() -> terminate.set(true))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        subscriber.await().assertItem(1);
+        subscriber.awaitItem().assertItem(1);
         assertThat(terminate).isTrue();
     }
 
@@ -79,7 +80,7 @@ public class UniOnTerminationTest {
                 .emitOn(Infrastructure.getDefaultExecutor())
                 .onTermination().invoke((r, f, c) -> terminate.set(f))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        subscriber.await().assertFailedWith(TestException.class, "boom");
+        subscriber.awaitFailure().assertFailedWith(TestException.class, "boom");
         assertThat(terminate.get()).hasMessageContaining("boom").isInstanceOf(TestException.class);
     }
 
@@ -100,7 +101,7 @@ public class UniOnTerminationTest {
                 .emitOn(Infrastructure.getDefaultExecutor())
                 .onTermination().invoke(() -> terminate.set(true))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        subscriber.await().assertFailedWith(TestException.class, "boom");
+        subscriber.awaitFailure().assertFailedWith(TestException.class, "boom");
         assertThat(terminate).isTrue();
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOrTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOrTest.java
@@ -106,7 +106,7 @@ public class UniOrTest {
                 .of(Uni.createFrom().item("foo").onItem().delayIt().onExecutor(executor).by(Duration.ofMillis(10)),
                         Uni.createFrom().item("bar").onItem().delayIt().onExecutor(executor).by(Duration.ofMillis(100)))
                 .subscribe().withSubscriber(subscriber2);
-        subscriber2.await().assertCompleted().assertItem("foo");
+        assertThat(subscriber2.awaitItem().getItem()).isEqualTo("foo");
     }
 
     @RepeatedTest(100)
@@ -172,6 +172,7 @@ public class UniOrTest {
         assertThat(c3.await().indefinitely()).isEqualTo("foo");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testUniOrWithDelayedUniAndDeprecatedApis() {
         Uni<String> first = Uni.createFrom().item("foo").onItem().delayIt().onExecutor(executor)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRepeatTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRepeatTest.java
@@ -435,7 +435,7 @@ public class UniRepeatTest {
                 .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
-                .await()
+                .awaitFailure()
                 .assertItems(1, 2)
                 .assertFailedWith(IllegalStateException.class, "boom");
         assertThat(subscriber.getItems()).hasSize(2);
@@ -455,7 +455,7 @@ public class UniRepeatTest {
                 .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
-                .await()
+                .awaitFailure()
                 .assertItems(1, 2)
                 .assertFailedWith(IllegalStateException.class, "boom");
         assertThat(subscriber.getItems()).hasSize(2);
@@ -475,7 +475,7 @@ public class UniRepeatTest {
                 .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
-                .await()
+                .awaitFailure()
                 .assertItems(1, 2)
                 .assertFailedWith(IllegalStateException.class, "boom");
         assertThat(subscriber.getItems()).hasSize(2);
@@ -495,9 +495,8 @@ public class UniRepeatTest {
                 .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(10)
-                .await()
-                .assertItems(1, 2)
-                .assertCompleted();
+                .awaitCompletion()
+                .assertItems(1, 2);
         assertThat(subscriber.getItems()).hasSize(2);
     }
 
@@ -515,9 +514,8 @@ public class UniRepeatTest {
                 .subscribe().withSubscriber(AssertSubscriber.create());
 
         subscriber.request(100)
-                .await()
-                .assertItems(1, 2, 4, 5, 7, 8, 10)
-                .assertCompleted();
+                .awaitCompletion()
+                .assertItems(1, 2, 4, 5, 7, 8, 10);
         assertThat(count).hasValue(10);
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
@@ -24,7 +24,7 @@ public class UniRunSubscriptionOnTest {
         Uni.createFrom().item(() -> 1)
                 .runSubscriptionOn(ForkJoinPool.commonPool())
                 .subscribe().withSubscriber(subscriber);
-        subscriber.await().assertItem(1);
+        subscriber.awaitItem().assertItem(1);
         assertThat(subscriber.getOnSubscribeThreadName()).isNotEqualTo(Thread.currentThread().getName());
     }
 
@@ -36,7 +36,7 @@ public class UniRunSubscriptionOnTest {
                 .runSubscriptionOn(ForkJoinPool.commonPool())
                 .subscribe().withSubscriber(subscriber);
 
-        subscriber.await().assertItem(1);
+        subscriber.awaitItem().assertItem(1);
         assertThat(subscriber.getOnSubscribeThreadName()).isNotEqualTo(Thread.currentThread().getName());
     }
 
@@ -58,7 +58,7 @@ public class UniRunSubscriptionOnTest {
                 .runSubscriptionOn(executorService)
                 .subscribe().withSubscriber(subscriber);
 
-        subscriber.await().assertItem(1);
+        subscriber.awaitItem().assertItem(1);
 
         executorService.shutdownNow();
     }
@@ -71,7 +71,7 @@ public class UniRunSubscriptionOnTest {
                 .runSubscriptionOn(ForkJoinPool.commonPool());
 
         assertThat(count).hasValue(0);
-        uni.subscribe().withSubscriber(UniAssertSubscriber.create()).await();
+        uni.subscribe().withSubscriber(UniAssertSubscriber.create()).awaitItem();
         assertThat(count).hasValue(1);
     }
 
@@ -80,7 +80,7 @@ public class UniRunSubscriptionOnTest {
         Uni.createFrom().<Void> failure(new IOException("boom"))
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor())
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IOException.class, "boom");
     }
 
@@ -117,7 +117,7 @@ public class UniRunSubscriptionOnTest {
                 .runSubscriptionOn(pool)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         assertThat(called).isFalse();
-        subscriber.await()
+        subscriber.awaitFailure()
                 .assertFailedWith(RejectedExecutionException.class, "");
     }
 
@@ -135,7 +135,7 @@ public class UniRunSubscriptionOnTest {
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         assertThat(called).isFalse();
         subscriber
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IllegalArgumentException.class, "boom");
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniSerializedSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniSerializedSubscriberTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -204,13 +205,14 @@ public class UniSerializedSubscriberTest {
 
         runnables.forEach(r -> new Thread(r).start());
 
-        subscriber.await();
+        Awaitility.await().untilAsserted(subscriber::assertTerminated);
 
         if (subscriber.getFailure() != null) {
             subscriber.assertFailed()
                     .assertFailedWith(IOException.class, "boom");
         } else {
-            subscriber.assertCompleted()
+            subscriber
+                    .assertCompleted()
                     .assertItem(1);
         }
         subscriber.assertSignalsReceivedInOrder();
@@ -245,7 +247,7 @@ public class UniSerializedSubscriberTest {
 
         runnables.forEach(r -> new Thread(r).start());
 
-        subscriber.await();
+        Awaitility.await().untilAsserted(subscriber::assertTerminated);
 
         if (subscriber.getFailure() != null) {
             subscriber.assertFailed()
@@ -292,8 +294,7 @@ public class UniSerializedSubscriberTest {
 
         runnables.forEach(r -> new Thread(r).start());
 
-        subscriber.await();
-        subscriber.assertCompleted();
+        subscriber.awaitItem();
         assertThat(subscriber.getItem()).isBetween(1, 3);
         subscriber.assertSignalsReceivedInOrder();
     }
@@ -333,8 +334,7 @@ public class UniSerializedSubscriberTest {
 
         runnables.forEach(r -> new Thread(r).start());
 
-        subscriber.await();
-        subscriber.assertCompleted();
+        subscriber.awaitItem();
         assertThat(subscriber.getItem()).isBetween(1, 3);
         subscriber.assertSignalsReceivedInOrder();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniToMultiTest.java
@@ -136,15 +136,13 @@ public class UniToMultiTest {
         Multi<Integer> multi = Uni.createFrom()
                 .completionStage(() -> CompletableFuture.supplyAsync(count::incrementAndGet)).toMulti();
         multi.subscribe().withSubscriber(AssertSubscriber.create(1))
-                .await()
-                .assertItems(1)
-                .assertCompleted();
+                .awaitCompletion()
+                .assertItems(1);
         multi.subscribe().withSubscriber(AssertSubscriber.create(0)).assertNotTerminated()
                 .assertHasNotReceivedAnyItem()
                 .request(1)
-                .await()
-                .assertItems(2)
-                .assertCompleted();
+                .awaitCompletion()
+                .assertItems(2);
     }
 
     @Test
@@ -153,15 +151,13 @@ public class UniToMultiTest {
         Multi<Integer> multi = Multi.createFrom().uni(Uni.createFrom()
                 .completionStage(() -> CompletableFuture.supplyAsync(count::incrementAndGet)));
         multi.subscribe().withSubscriber(AssertSubscriber.create(1))
-                .await()
-                .assertItems(1)
-                .assertCompleted();
+                .awaitCompletion()
+                .assertItems(1);
         multi.subscribe().withSubscriber(AssertSubscriber.create(0)).assertNotTerminated()
                 .assertHasNotReceivedAnyItem()
                 .request(1)
-                .await()
-                .assertItems(2)
-                .assertCompleted();
+                .awaitCompletion()
+                .assertItems(2);
     }
 
     @Test
@@ -169,15 +165,13 @@ public class UniToMultiTest {
         Multi<Integer> multi = Uni.createFrom()
                 .completionStage(() -> CompletableFuture.<Integer> supplyAsync(() -> null)).toMulti();
         multi.subscribe().withSubscriber(AssertSubscriber.create(1))
-                .await()
-                .assertHasNotReceivedAnyItem()
-                .assertCompleted();
+                .awaitCompletion()
+                .assertHasNotReceivedAnyItem();
         multi.subscribe().withSubscriber(AssertSubscriber.create(0))
                 .assertNotTerminated()
                 .request(1)
-                .await()
-                .assertHasNotReceivedAnyItem()
-                .assertCompleted();
+                .awaitCompletion()
+                .assertHasNotReceivedAnyItem();
     }
 
     @Test
@@ -185,14 +179,12 @@ public class UniToMultiTest {
         Multi<Integer> multi = Multi.createFrom()
                 .uni(Uni.createFrom().completionStage(() -> CompletableFuture.supplyAsync(() -> null)));
         multi.subscribe().withSubscriber(AssertSubscriber.create(1))
-                .await()
-                .assertHasNotReceivedAnyItem()
-                .assertCompleted();
+                .awaitCompletion()
+                .assertHasNotReceivedAnyItem();
         multi.subscribe().withSubscriber(AssertSubscriber.create(0))
                 .assertNotTerminated()
                 .request(1)
-                .await()
-                .assertHasNotReceivedAnyItem()
-                .assertCompleted();
+                .awaitCompletion()
+                .assertHasNotReceivedAnyItem();
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
@@ -88,7 +88,7 @@ public class UniZipTest {
         UniAssertSubscriber<Integer> subscriber = Uni.combine().all().unis(uni1, uni2, uni3)
                 .combinedWith((i1, i2, i3) -> i1 + i2 + i3)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
-        subscriber.await().assertItem(6);
+        subscriber.awaitItem().assertItem(6);
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/EmitterBasedMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/EmitterBasedMultiTest.java
@@ -103,7 +103,7 @@ public class EmitterBasedMultiTest {
             e.emit("a");
             e.emit(null);
         }).subscribe().withSubscriber(AssertSubscriber.create(2))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(NullPointerException.class, "")
                 .assertItems("a");
         assertThat(terminated).isTrue();
@@ -113,7 +113,7 @@ public class EmitterBasedMultiTest {
             e.emit(null);
         }, BackPressureStrategy.LATEST)
                 .subscribe().withSubscriber(AssertSubscriber.create(2))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(NullPointerException.class, "")
                 .assertItems("a");
 
@@ -122,7 +122,7 @@ public class EmitterBasedMultiTest {
             e.emit(null);
         }, BackPressureStrategy.DROP)
                 .subscribe().withSubscriber(AssertSubscriber.create(2))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(NullPointerException.class, "")
                 .assertItems("a");
 
@@ -131,7 +131,7 @@ public class EmitterBasedMultiTest {
             e.emit(null);
         }, BackPressureStrategy.ERROR)
                 .subscribe().withSubscriber(AssertSubscriber.create(2))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(NullPointerException.class, "")
                 .assertItems("a");
 
@@ -140,7 +140,7 @@ public class EmitterBasedMultiTest {
             e.emit(null);
         }, BackPressureStrategy.IGNORE)
                 .subscribe().withSubscriber(AssertSubscriber.create(2))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(NullPointerException.class, "")
                 .assertItems("a");
 
@@ -154,7 +154,7 @@ public class EmitterBasedMultiTest {
             e.emit("a");
             e.fail(null);
         }).subscribe().withSubscriber(AssertSubscriber.create(2))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(NullPointerException.class, "")
                 .assertItems("a");
         assertThat(terminated).isTrue();
@@ -164,7 +164,7 @@ public class EmitterBasedMultiTest {
             e.fail(null);
         }, BackPressureStrategy.LATEST)
                 .subscribe().withSubscriber(AssertSubscriber.create(2))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(NullPointerException.class, "")
                 .assertItems("a");
 
@@ -173,7 +173,7 @@ public class EmitterBasedMultiTest {
             e.fail(null);
         }, BackPressureStrategy.DROP)
                 .subscribe().withSubscriber(AssertSubscriber.create(2))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(NullPointerException.class, "")
                 .assertItems("a");
 
@@ -182,7 +182,7 @@ public class EmitterBasedMultiTest {
             e.fail(null);
         }, BackPressureStrategy.ERROR)
                 .subscribe().withSubscriber(AssertSubscriber.create(2))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(NullPointerException.class, "")
                 .assertItems("a");
 
@@ -191,7 +191,7 @@ public class EmitterBasedMultiTest {
             e.fail(null);
         }, BackPressureStrategy.IGNORE)
                 .subscribe().withSubscriber(AssertSubscriber.create(2))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(NullPointerException.class, "")
                 .assertItems("a");
 
@@ -276,7 +276,9 @@ public class EmitterBasedMultiTest {
         service.submit(r1);
         service.submit(r2);
 
-        subscriber.await().assertFailedWith(Exception.class, "boom");
+        subscriber
+                .awaitFailure()
+                .assertFailedWith(Exception.class, "boom");
         service.shutdown();
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
@@ -454,9 +454,8 @@ public class MultiFromResourceTest {
                 .select().first(3);
 
         multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
-                .await()
-                .assertItems("0", "1", "2")
-                .assertCompleted();
+                .awaitCompletion()
+                .assertItems("0", "1", "2");
 
         assertThat(resource.subscribed).isTrue();
         assertThat(resource.onCompleteSubscribed).isFalse();
@@ -474,9 +473,8 @@ public class MultiFromResourceTest {
                 .select().first(3);
 
         multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
-                .await()
-                .assertItems("0", "1", "2")
-                .assertCompleted();
+                .awaitCompletion()
+                .assertItems("0", "1", "2");
 
         assertThat(resource.subscribed).isTrue();
         assertThat(resource.onCompleteSubscribed).isFalse();
@@ -494,9 +492,8 @@ public class MultiFromResourceTest {
                 .select().first(3);
 
         multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
-                .await()
-                .assertItems("0", "1", "2")
-                .assertCompleted();
+                .awaitCompletion()
+                .assertItems("0", "1", "2");
 
         assertThat(resource.subscribed).isTrue();
         assertThat(resource.onCompleteSubscribed).isFalse();
@@ -515,7 +512,7 @@ public class MultiFromResourceTest {
                 .select().first(3);
 
         multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
-                .await()
+                .awaitFailure()
                 .assertItems("in transaction")
                 .assertFailedWith(IOException.class, "boom");
 
@@ -536,7 +533,7 @@ public class MultiFromResourceTest {
                 .select().first(3);
 
         multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
-                .await()
+                .awaitFailure()
                 .assertItems("in transaction")
                 .assertFailedWith(IOException.class, "commit failed");
 
@@ -558,7 +555,7 @@ public class MultiFromResourceTest {
                 .select().first(3);
 
         multi.subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE))
-                .await()
+                .awaitFailure()
                 .assertItems("in transaction")
                 .assertFailedWith(NullPointerException.class, "`null`");
 
@@ -578,7 +575,7 @@ public class MultiFromResourceTest {
                         FakeTransactionalResource::cancel);
 
         multi.subscribe().withSubscriber(AssertSubscriber.create(20))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(CompositeException.class, "boom")
                 .assertFailedWith(CompositeException.class, "rollback failed");
 
@@ -599,7 +596,7 @@ public class MultiFromResourceTest {
                         FakeTransactionalResource::cancel);
 
         multi.subscribe().withSubscriber(AssertSubscriber.create(20))
-                .await()
+                .awaitFailure()
                 .assertFailedWith(CompositeException.class, "boom")
                 .assertFailedWith(CompositeException.class, "`null`");
 
@@ -655,8 +652,7 @@ public class MultiFromResourceTest {
                 })
                 .select().first(5);
         multi.subscribe().withSubscriber(AssertSubscriber.create(20))
-                .await()
-                .assertCompleted()
+                .awaitCompletion()
                 .assertItems(0L, 1L, 2L, 3L, 4L);
         assertThat(subscribed).isTrue();
     }
@@ -672,8 +668,7 @@ public class MultiFromResourceTest {
                         FakeTransactionalResource::cancel)
                 .subscribe(subscriber);
         subscriber
-                .await()
-                .assertCompleted()
+                .awaitCompletion()
                 .cancel();
 
         assertThat(resource.onCompleteSubscribed).isTrue();
@@ -692,7 +687,7 @@ public class MultiFromResourceTest {
                         FakeTransactionalResource::cancel)
                 .subscribe(subscriber);
         subscriber
-                .await()
+                .awaitFailure()
                 .assertFailedWith(IOException.class, "boom")
                 .cancel();
 

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/SerializedSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/SerializedSubscriberTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
@@ -296,7 +297,7 @@ public class SerializedSubscriberTest {
         };
         Arrays.asList(runnable, runnable).forEach(r -> new Thread(r).start());
 
-        subscriber.await().assertCompleted();
+        subscriber.awaitCompletion();
     }
 
     @RepeatedTest(10)
@@ -324,7 +325,7 @@ public class SerializedSubscriberTest {
         Collections.shuffle(runnables);
         runnables.forEach(r -> new Thread(r).start());
 
-        subscriber.await().assertCompleted();
+        subscriber.awaitCompletion();
         assertThat(subscriber.getItems()).hasSizeBetween(0, 1);
     }
 
@@ -353,7 +354,7 @@ public class SerializedSubscriberTest {
         Collections.shuffle(runnables);
         runnables.forEach(r -> new Thread(r).start());
 
-        subscriber.await().assertFailedWith(TestException.class, "boom");
+        subscriber.awaitFailure().assertFailedWith(TestException.class, "boom");
         assertThat(subscriber.getItems()).hasSizeBetween(0, 1);
     }
 
@@ -382,7 +383,7 @@ public class SerializedSubscriberTest {
         Collections.shuffle(runnables);
         runnables.forEach(r -> new Thread(r).start());
 
-        subscriber.await();
+        Awaitility.await().until(() -> subscriber.hasCompleted() || subscriber.getFailure() != null);
         if (subscriber.hasCompleted()) {
             subscriber.assertCompleted().assertHasNotReceivedAnyItem();
         } else {

--- a/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/DeferredAsUniTest.kt
+++ b/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/DeferredAsUniTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import java.util.UUID
 import kotlin.test.Test
 
@@ -25,7 +26,7 @@ class DeferredAsUniTest {
             deferred.asUni().subscribe().withSubscriber(subscriber)
 
             // Then
-            subscriber.await().assertItem(value)
+            assertThat(subscriber.awaitItem().item).isEqualTo(value)
         }
     }
 
@@ -40,7 +41,7 @@ class DeferredAsUniTest {
             deferred.asUni().subscribe().withSubscriber(subscriber)
 
             // Then
-            subscriber.await().assertFailedWith(IllegalStateException::class.java, "kaboom")
+            subscriber.awaitFailure().assertFailedWith(IllegalStateException::class.java, "kaboom")
         }
     }
 
@@ -59,7 +60,7 @@ class DeferredAsUniTest {
             deferred.cancel(CancellationException("abort"))
 
             // Then
-            subscriber.await().assertFailedWith(CancellationException::class.java, "abort")
+            subscriber.awaitFailure().assertFailedWith(CancellationException::class.java, "abort")
         }
     }
 
@@ -74,7 +75,7 @@ class DeferredAsUniTest {
             deferred.asUni().subscribe().withSubscriber(subscriber)
 
             // Then
-            subscriber.await().assertItem(null)
+            assertThat(subscriber.awaitItem().item).isNull()
         }
     }
 }

--- a/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/FlowAsMultiTest.kt
+++ b/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/FlowAsMultiTest.kt
@@ -26,7 +26,7 @@ class FlowAsMultiTest {
 
             // Then
             assertThat(collectedItems).containsExactly(item)
-            subscriber.await().assertItems(item)
+            subscriber.awaitCompletion().assertItems(item)
         }
     }
 
@@ -45,7 +45,7 @@ class FlowAsMultiTest {
 
             // Then
             assertThat(collectedItems).containsExactly(*items)
-            subscriber.await().assertItems(*items)
+            subscriber.awaitCompletion().assertItems(*items)
         }
     }
 
@@ -62,7 +62,8 @@ class FlowAsMultiTest {
             flow.asMulti().subscribe().withSubscriber(subscriber)
 
             // Then
-            subscriber.await().assertFailedWith(IllegalStateException::class.java, "boom")
+            subscriber.awaitFailure()
+                    .assertFailedWith(IllegalStateException::class.java, "boom")
         }
     }
 
@@ -87,7 +88,7 @@ class FlowAsMultiTest {
             Thread.sleep(350)
 
             // Then
-            subscriber.await().assertFailedWith(CancellationException::class.java, "abort")
+            subscriber.awaitFailure().assertFailedWith(CancellationException::class.java, "abort")
         }
     }
 


### PR DESCRIPTION
Fix #465 


The PR adds:

in `UniAssertSubscriber`:

* `awaitItem` - with and without duration
* `awaitFailure`- with and without duration and validation of the failure
* `awaitSubscription` - with or without duration

in `AssertSubscriber`:

* `awaitCompletion` - with and without duration
* `awaitFailure`- with and without duration and validation of the failure
* `awaitNextItems` and `awaitNextItem`
* `awaitSubscription` - with or without duration
* `assertLastItem` and `getLastItem`
