### PR TITLE
Fix a request / consume race when using .request(x).awaitNextItems(x)

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertSubscriber.java
@@ -264,7 +264,7 @@ public class AssertSubscriber<T> implements Subscriber<T> {
      * Awaits for the next item.
      * If no item have been received before the default timeout, an {@link AssertionError} is thrown.
      * <p>
-     * Note that ti requests one item from the upstream.
+Note that it requests one item from the upstream.
      *
      * @return this {@link AssertSubscriber}
      * @see #awaitNextItems(int, int)

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertSubscriber.java
@@ -263,8 +263,11 @@ public class AssertSubscriber<T> implements Subscriber<T> {
     /**
      * Awaits for the next item.
      * If no item have been received before the default timeout, an {@link AssertionError} is thrown.
+     * <p>
+     * Note that ti requests one item from the upstream.
      *
      * @return this {@link AssertSubscriber}
+     * @see #awaitNextItems(int, int)
      */
     public AssertSubscriber<T> awaitNextItem() {
         return awaitNextItems(1);
@@ -273,20 +276,26 @@ public class AssertSubscriber<T> implements Subscriber<T> {
     /**
      * Awaits for the next item.
      * If no item have been received before the given timeout, an {@link AssertionError} is thrown.
+     * <p>
+     * Note that it requests one item from the upstream.
      *
      * @param duration the timeout, must not be {@code null}
      * @return this {@link AssertSubscriber}
+     * @see #awaitNextItems(int, int)
      */
     public AssertSubscriber<T> awaitNextItem(Duration duration) {
-        return awaitNextItems(1, duration);
+        return awaitNextItems(1, 1, duration);
     }
 
     /**
      * Awaits for the next {@code number} items.
      * If not enough items have been received before the default timeout, an {@link AssertionError} is thrown.
+     * <p>
+     * This method requests {@code number} items the upstream.
      *
-     * @param number the number of item to expect, must not be 0 or negative.
+     * @param number the number of items to expect, must be neither 0 nor negative.
      * @return this {@link AssertSubscriber}
+     * @see #awaitNextItems(int, int)
      */
     public AssertSubscriber<T> awaitNextItems(int number) {
         return awaitNextItems(number, DEFAULT_TIMEOUT);
@@ -294,13 +303,40 @@ public class AssertSubscriber<T> implements Subscriber<T> {
 
     /**
      * Awaits for the next {@code number} items.
-     * If not enough items have been received before the given timeout, an {@link AssertionError} is thrown.
+     * If not enough items have been received before the default timeout, an {@link AssertionError} is thrown.
      *
-     * @param number the number of item to expect, must not be 0 or negative.
+     * @param number the number of items to expect, must neither be 0 nor negative.
+     * @param request if not 0, the number of items to request upstream.
+     * @return this {@link AssertSubscriber}
+     */
+    public AssertSubscriber<T> awaitNextItems(int number, int request) {
+        return awaitNextItems(number, request, DEFAULT_TIMEOUT);
+    }
+
+    /**
+     * Awaits for the next {@code number} items.
+     * If not enough items have been received before the given timeout, an {@link AssertionError} is thrown.
+     * <p>
+     * This method requests {@code number} items upstream.
+     *
+     * @param number the number of items to expect, must be neither 0 nor negative.
      * @param duration the timeout, must not be {@code null}
      * @return this {@link AssertSubscriber}
      */
     public AssertSubscriber<T> awaitNextItems(int number, Duration duration) {
+        return awaitNextItems(number, number, duration);
+    }
+
+    /**
+     * Awaits for the next {@code number} items.
+     * If not enough items have been received before the given timeout, an {@link AssertionError} is thrown.
+     *
+     * @param number the number of items to expect, must be neither 0 nor negative.
+     * @param request if not 0, the number of items to request upstream.
+     * @param duration the timeout, must not be {@code null}
+     * @return this {@link AssertSubscriber}
+     */
+    public AssertSubscriber<T> awaitNextItems(int number, int request, Duration duration) {
         if (hasCompleted() || getFailure() != null) {
             if (hasCompleted()) {
                 throw new AssertionError("Expecting a next items, but a completion event has already being received");
@@ -310,7 +346,7 @@ public class AssertSubscriber<T> implements Subscriber<T> {
             }
         }
 
-        awaitNextItemEvents(number, duration);
+        awaitNextItemEvents(number, request, duration);
 
         return this;
     }
@@ -320,7 +356,9 @@ public class AssertSubscriber<T> implements Subscriber<T> {
      * this method).
      * If not enough items have been received before the default timeout, an {@link AssertionError} is thrown.
      *
-     * @param number the number of item to expect, must not be 0 or negative.
+     * Unlike {@link #awaitNextItems(int, int)}, this method does not request items from the upstream.
+     *
+     * @param number the number of items to expect, must be neither 0 nor negative.
      * @return this {@link AssertSubscriber}
      */
     public AssertSubscriber<T> awaitItems(int number) {
@@ -332,7 +370,9 @@ public class AssertSubscriber<T> implements Subscriber<T> {
      * this method).
      * If not enough items have been received before the given timeout, an {@link AssertionError} is thrown.
      *
-     * @param number the number of item to expect, must not be 0 or negative.
+     * Unlike {@link #awaitNextItems(int, int)}, this method does not requests items from the upstream.
+     *
+     * @param number the number of items to expect, must be neither 0 nor negative.
      * @param duration the timeout, must not be {@code null}
      * @return this {@link AssertSubscriber}
      */
@@ -521,11 +561,15 @@ public class AssertSubscriber<T> implements Subscriber<T> {
 
     private final List<EventListener> eventListeners = new CopyOnWriteArrayList<>();
 
-    private void awaitNextItemEvents(int number, Duration duration) {
+    private void awaitNextItemEvents(int number, int request, Duration duration) {
         NextItemTask<T> task = new NextItemTask<>(number, this);
+        CompletableFuture<Void> future = task.future();
+        if (request > 0) {
+            request(request);
+        }
         int size = items.size();
         try {
-            task.future().get(duration.toMillis(), TimeUnit.MILLISECONDS);
+            future.get(duration.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (ExecutionException e) {
@@ -533,7 +577,8 @@ public class AssertSubscriber<T> implements Subscriber<T> {
             int received = items.size() - size;
             if (isCancelled()) {
                 throw new AssertionError(
-                        "Expected " + number + " items, but received a cancellation event while waiting. Only " + received
+                        "Expected " + number + " items, but received a cancellation event while waiting. Only "
+                                + received
                                 + " item(s) have been received.");
             } else if (hasCompleted()) {
                 throw new AssertionError(
@@ -541,7 +586,8 @@ public class AssertSubscriber<T> implements Subscriber<T> {
                                 + " item(s) have been received.");
             } else {
                 throw new AssertionError(
-                        "Expected " + number + " items, but received a failure event while waiting: " + getFailure() + ". Only "
+                        "Expected " + number + " items, but received a failure event while waiting: " + getFailure()
+                                + ". Only "
                                 + received + " item(s) have been received.");
             }
         } catch (TimeoutException e) {
@@ -563,11 +609,13 @@ public class AssertSubscriber<T> implements Subscriber<T> {
             // Terminal event received
             if (isCancelled()) {
                 throw new AssertionError(
-                        "Expected " + expected + " items, but received a cancellation event while waiting. Only " + items.size()
+                        "Expected " + expected + " items, but received a cancellation event while waiting. Only "
+                                + items.size()
                                 + " items have been received.");
             } else if (hasCompleted()) {
                 throw new AssertionError(
-                        "Expected " + expected + " items, but received a completion event while waiting. Only " + items.size()
+                        "Expected " + expected + " items, but received a completion event while waiting. Only " + items
+                                .size()
                                 + " items have been received.");
             } else {
                 throw new AssertionError(

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/test/AssertSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/test/AssertSubscriberTest.java
@@ -487,12 +487,34 @@ public class AssertSubscriberTest {
                 .awaitNextItems(2)).isInstanceOf(AssertionError.class)
                         .hasMessageContaining("completion").hasMessageContaining("item");
 
+        assertThatThrownBy(() -> Multi.createFrom().empty()
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItems(2, 1)).isInstanceOf(AssertionError.class)
+                .hasMessageContaining("completion").hasMessageContaining("item");
+
+        assertThatThrownBy(() -> Multi.createFrom().empty()
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItems(2, 1, Duration.ofSeconds(1))).isInstanceOf(AssertionError.class)
+                .hasMessageContaining("completion").hasMessageContaining("item");
+
         // Already failed
         assertThatThrownBy(() -> Multi.createFrom().failure(new TestException())
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItems(2)).isInstanceOf(AssertionError.class)
                         .hasMessageContaining("failure").hasMessageContaining("item")
                         .hasMessageContaining(TestException.class.getName());
+
+        assertThatThrownBy(() -> Multi.createFrom().failure(new TestException())
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItems(2, 1)).isInstanceOf(AssertionError.class)
+                .hasMessageContaining("failure").hasMessageContaining("item")
+                .hasMessageContaining(TestException.class.getName());
+
+        assertThatThrownBy(() -> Multi.createFrom().failure(new TestException())
+                .subscribe().withSubscriber(AssertSubscriber.create(1))
+                .awaitNextItems(2, 1, Duration.ofSeconds(1))).isInstanceOf(AssertionError.class)
+                .hasMessageContaining("failure").hasMessageContaining("item")
+                .hasMessageContaining(TestException.class.getName());
 
         // Completion instead of item
         assertThatThrownBy(() -> Multi.createFrom().emitter(e -> e.emit(1).complete())

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmitOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiEmitOnTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.RejectedExecutionException;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 
@@ -32,17 +33,16 @@ public class MultiEmitOnTest {
         executor.shutdown();
     }
 
-    @Test
+    @RepeatedTest(10)
     public void testWithSequenceOfItems() {
         AssertSubscriber<Integer> subscriber = Multi.createFrom().items(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
                 .emitOn(executor)
                 .subscribe().withSubscriber(AssertSubscriber.create());
 
-        subscriber.request(2)
-                .awaitNextItems(2)
+        subscriber
+                .awaitNextItems(2, 2)
                 .assertItems(1, 2)
-                .request(20)
-                .awaitNextItems(8)
+                .awaitNextItems(8, 20)
                 .assertItems(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
 


### PR DESCRIPTION
To work around the race condition, the awaitNextItem method handles the requests to attach the event listener before emitting the demands.
