### PR TITLE
Break dependency to mutiny-test-utils

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -31,6 +31,7 @@
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny-test-utils</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Move it to the test scope, avoiding a hard runtime dependency.