### PR TITLE
#516 Let MultiMerge.streams accept Iterable<? extends Publisher<T>>

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiMerge.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiMerge.java
@@ -78,7 +78,7 @@ public class MultiMerge {
      * @param <T> the type of item
      * @return the new {@link Multi} emitting the items from the given set of {@link Publisher}
      */
-    public <T> Multi<T> streams(Iterable<Publisher<T>> iterable) {
+    public <T> Multi<T> streams(Iterable<? extends Publisher<T>> iterable) {
         List<Publisher<T>> list = new ArrayList<>();
         iterable.forEach(list::add);
         return MultiCombine.merge(list, collectFailures, requests, concurrency);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiMergeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiMergeTest.java
@@ -3,6 +3,7 @@ package io.smallrye.mutiny.operators;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -97,11 +98,11 @@ public class MultiMergeTest {
 
     @Test
     public void testMergeOfSeveralMultisAsIterable() {
-        AssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(
-                Arrays.asList(
-                        Multi.createFrom().item(5),
-                        Multi.createFrom().range(1, 3),
-                        Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1)))
+        final List<Multi<Integer>> multis = Arrays.asList(
+                Multi.createFrom().item(5),
+                Multi.createFrom().range(1, 3),
+                Multi.createFrom().items(8, 9, 10).onItem().transform(i -> i + 1));
+        AssertSubscriber<Integer> subscriber = Multi.createBy().merging().streams(multis)
                 .subscribe().withSubscriber(new AssertSubscriber<>(100));
 
         subscriber.assertCompleted()


### PR DESCRIPTION
Resolving #516:
- MultiMerge.streams now accepts Iterable<? extends Publisher<T>> instead of Iterable<Publisher<T>>
- MultiMergeTest now tests this behaviour