### PR TITLE
Fix duplicate items issue when create a multi from a collection

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/CollectionBasedMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/CollectionBasedMulti.java
@@ -116,7 +116,10 @@ public class CollectionBasedMulti<T> extends AbstractMulti<T> {
         }
 
         void produceWithoutBackPressure() {
-            for (T item : collection) {
+            // We must be sure we don't replay already send item, so we must skip "index" items
+            int size = collection.size();
+            for (int i = index; i < size; i++) {
+                T item = collection.get(i);
                 if (cancelled) {
                     return;
                 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
@@ -46,6 +46,25 @@ public class MultiFromIterableTest {
         verify(subscriber, times(1)).onComplete();
     }
 
+    @Test
+    public void testSwitchFromRequestToUnbounded() {
+        Multi<Integer> multi = Multi.createFrom().items(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        AssertSubscriber<Integer> subscriber = multi.subscribe()
+                .withSubscriber(AssertSubscriber.create(0));
+
+        subscriber.request(1)
+                .awaitItems(1)
+                .assertItems(1);
+
+        subscriber.request(1)
+                .awaitItems(2)
+                .assertItems(1, 2);
+
+        subscriber.request(Long.MAX_VALUE)
+                .awaitCompletion()
+                .assertItems(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
     /**
      * This tests the path that can not optimize based on size so must use setProducer.
      */


### PR DESCRIPTION
If the create multi get bounded requests and then an unbounded request, it restarts consuming the collection from the initial index, which is obviously wrong.
This PR skips the already sent items.
