### PR TITLE
Catch Throwable rather than RuntimeException

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
@@ -231,9 +231,9 @@ public class MultiCreate {
             T item;
             try {
                 item = actual.get();
-            } catch (RuntimeException e) {
+            } catch (Throwable err) {
                 // Exception from the supplier, propagate it.
-                emitter.fail(e);
+                emitter.fail(err);
                 return;
             }
             if (item != null) {

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiRetry.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiRetry.java
@@ -114,8 +114,8 @@ public class MultiRetry<T> {
                         } else {
                             emitter.fail(throwable);
                         }
-                    } catch (RuntimeException e) {
-                        emitter.fail(e);
+                    } catch (Throwable err) {
+                        emitter.fail(err);
                     }
                 })).concatenate());
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniRetry.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniRetry.java
@@ -109,8 +109,8 @@ public class UniRetry<T> {
                         } else {
                             emitter.fail(throwable);
                         }
-                    } catch (RuntimeException e) {
-                        emitter.fail(e);
+                    } catch (Throwable err) {
+                        emitter.fail(err);
                     }
                 })).concatenate());
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniDelayOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniDelayOnItem.java
@@ -52,7 +52,7 @@ public class UniDelayOnItem<T> extends UniOperator<T, T> {
                 try {
                     Runnable dispatch = () -> downstream.onItem(item);
                     scheduledFuture = executor.schedule(dispatch, duration.toMillis(), TimeUnit.MILLISECONDS);
-                } catch (RuntimeException err) {
+                } catch (Throwable err) {
                     downstream.onFailure(err);
                 }
             }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniDelayUntil.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniDelayUntil.java
@@ -40,8 +40,8 @@ public class UniDelayUntil<T> extends UniOperator<T, T> {
                         return;
                     }
                     uni.runSubscriptionOn(executor).subscribe().with(ignored -> super.onItem(item), super::onFailure);
-                } catch (RuntimeException e) {
-                    super.onFailure(e);
+                } catch (Throwable err) {
+                    super.onFailure(err);
                 }
             }
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnFailureTransform.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnFailureTransform.java
@@ -43,8 +43,8 @@ public class UniOnFailureTransform<I, O> extends UniOperator<I, O> {
                 boolean test;
                 try {
                     test = predicate.test(failure);
-                } catch (RuntimeException e) {
-                    downstream.onFailure(new CompositeException(failure, e));
+                } catch (Throwable err) {
+                    downstream.onFailure(new CompositeException(failure, err));
                     return;
                 }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromCompletionStageWithState.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromCompletionStageWithState.java
@@ -34,9 +34,9 @@ public class UniCreateFromCompletionStageWithState<T, S> extends AbstractUni<T> 
         try {
             state = holder.get();
             // get() throws an NPE is the produced state is null.
-        } catch (Exception e) {
+        } catch (Throwable err) {
             subscriber.onSubscribe(EmptyUniSubscription.DONE);
-            subscriber.onFailure(e);
+            subscriber.onFailure(err);
             return;
         }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromDeferredSupplierWithState.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromDeferredSupplierWithState.java
@@ -28,18 +28,18 @@ public class UniCreateFromDeferredSupplierWithState<S, T> extends AbstractUni<T>
         try {
             state = holder.get();
             // get() throws an NPE is the produced state is null.
-        } catch (Exception e) {
+        } catch (Throwable err) {
             subscriber.onSubscribe(DONE);
-            subscriber.onFailure(e);
+            subscriber.onFailure(err);
             return;
         }
 
         Uni<? extends T> uni;
         try {
             uni = mapper.apply(state);
-        } catch (Throwable e) {
+        } catch (Throwable err) {
             subscriber.onSubscribe(DONE);
-            subscriber.onFailure(e);
+            subscriber.onFailure(err);
             return;
         }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromEmitterWithState.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromEmitterWithState.java
@@ -32,9 +32,9 @@ public class UniCreateFromEmitterWithState<T, S> extends AbstractUni<T> {
         try {
             state = holder.get();
             // get() throws an NPE is the produced state is null.
-        } catch (Exception e) {
+        } catch (Throwable err) {
             subscriber.onSubscribe(EmptyUniSubscription.DONE);
-            subscriber.onFailure(e);
+            subscriber.onFailure(err);
             return;
         }
 
@@ -42,10 +42,10 @@ public class UniCreateFromEmitterWithState<T, S> extends AbstractUni<T> {
         subscriber.onSubscribe(emitter);
         try {
             consumer.accept(state, emitter);
-        } catch (RuntimeException e) {
+        } catch (Throwable err) {
             // we use the emitter to be sure that if the failure happens after the first event being fired, it
             // will be dropped.
-            emitter.fail(e);
+            emitter.fail(err);
         }
 
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromFailureSupplier.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromFailureSupplier.java
@@ -32,7 +32,7 @@ public class UniCreateFromFailureSupplier<T> extends AbstractUni<T> {
             } else {
                 subscriber.onFailure(failure);
             }
-        } catch (RuntimeException err) {
+        } catch (Throwable err) {
             subscriber.onFailure(err);
         }
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromFuture.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromFuture.java
@@ -57,7 +57,7 @@ public class UniCreateFromFuture<T> extends AbstractUni<T> {
             downstream.onSubscribe(DONE);
             downstream.onFailure(e.getCause());
             return;
-        } catch (Exception err) {
+        } catch (Throwable err) {
             if (err instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromItemSupplier.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromItemSupplier.java
@@ -27,7 +27,7 @@ public class UniCreateFromItemSupplier<T> extends AbstractUni<T> {
         try {
             T item = supplier.get();
             subscriber.onItem(item);
-        } catch (RuntimeException err) {
+        } catch (Throwable err) {
             subscriber.onFailure(err);
         }
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromItemWithState.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromItemWithState.java
@@ -32,8 +32,8 @@ public class UniCreateFromItemWithState<T, S> extends AbstractUni<T> {
         try {
             state = holder.get();
             // get() throws an NPE is the produced state is null.
-        } catch (Exception e) {
-            subscriber.onFailure(e);
+        } catch (Throwable err) {
+            subscriber.onFailure(err);
             return;
         }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateWithEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateWithEmitter.java
@@ -20,10 +20,10 @@ public class UniCreateWithEmitter<T> extends AbstractUni<T> {
 
         try {
             consumer.accept(emitter);
-        } catch (RuntimeException e) {
+        } catch (Throwable err) {
             // we use the emitter to be sure that if the failure happens after the first event being fired, it
             // will be dropped.
-            emitter.fail(e);
+            emitter.fail(err);
         }
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/SneakyThrow.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/SneakyThrow.java
@@ -1,0 +1,12 @@
+package io.smallrye.mutiny.helpers;
+
+/**
+ * The infamous sneaky throw helper.
+ */
+public interface SneakyThrow {
+
+    @SuppressWarnings("unchecked")
+    static <E extends Throwable> RuntimeException sneakyThrow(Throwable e) throws E {
+        throw (E) e;
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromItemsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromItemsTest.java
@@ -1,5 +1,6 @@
 package io.smallrye.mutiny.operators;
 
+import static io.smallrye.mutiny.helpers.SneakyThrow.sneakyThrow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -77,6 +78,16 @@ public class MultiCreateFromItemsTest {
         multi.subscribe().withSubscriber(AssertSubscriber.create())
                 .assertHasNotReceivedAnyItem()
                 .assertFailedWith(IllegalStateException.class, "boom");
+    }
+
+    @Test
+    public void testCreationWithCheckedExceptionThrownBySupplier() {
+        Multi<Integer> multi = Multi.createFrom().item(() -> {
+            throw sneakyThrow(new Exception("boom"));
+        });
+        multi.subscribe().withSubscriber(AssertSubscriber.create())
+                .assertHasNotReceivedAnyItem()
+                .assertFailedWith(Exception.class, "boom");
     }
 
     @Test


### PR DESCRIPTION
Under Java semantics it's not normally possible to throw a checked exception from some method that does not declare it, but using the infamous sneaky throw technique or languages like Kotlin this is totally doable.

This commit catches Throwable rather than RuntimeException in places where this may happen.