### PR TITLE
Release the downstream subscriber upon cancellation.

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOp.java
@@ -136,13 +136,14 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
 
             if (flush) {
                 long req = requested.get();
+                MultiSubscriber<? super List<T>> subscriber = downstream;
                 if (req != 0L) {
                     if (req != Long.MAX_VALUE) {
                         long next;
                         for (;;) {
                             next = req - 1;
                             if (requested.compareAndSet(req, next)) {
-                                downstream.onItem(cur);
+                                subscriber.onItem(cur);
                                 return;
                             }
 
@@ -152,13 +153,13 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
                             }
                         }
                     } else {
-                        downstream.onItem(cur);
+                        subscriber.onItem(cur);
                         return;
                     }
                 }
 
                 cancel();
-                downstream.onFailure(new BackPressureFailure("Cannot emit item due to lack of requests"));
+                subscriber.onFailure(new BackPressureFailure("Cannot emit item due to lack of requests"));
             }
         }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCollectorOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCollectorOp.java
@@ -87,18 +87,19 @@ public final class MultiCollectorOp<T, A, R> extends AbstractMultiOperator<T, R>
             if (subscription != Subscriptions.CANCELLED) {
                 R result;
 
+                MultiSubscriber<? super R> subscriber = downstream;
                 try {
                     result = finisher.apply(intermediate);
                 } catch (Throwable ex) {
-                    downstream.onFailure(ex);
+                    subscriber.onFailure(ex);
                     return;
                 }
 
                 intermediate = null;
                 if (result != null) {
-                    downstream.onItem(result);
+                    subscriber.onItem(result);
                 }
-                downstream.onCompletion();
+                subscriber.onCompletion();
             }
         }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiLastItemOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiLastItemOp.java
@@ -57,11 +57,12 @@ public final class MultiLastItemOp<T> extends AbstractMultiOperator<T, T> {
             Subscription subscription = upstream.getAndSet(CANCELLED);
             if (subscription != CANCELLED) {
                 T item = last;
+                MultiSubscriber<? super T> subscriber = downstream;
                 if (item != null) {
                     last = null; // release before calling the callback.
-                    downstream.onItem(item);
+                    subscriber.onItem(item);
                 }
-                downstream.onCompletion();
+                subscriber.onCompletion();
             }
         }
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnItemInvoke.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnItemInvoke.java
@@ -31,13 +31,14 @@ public class MultiOnItemInvoke<T> extends AbstractMultiOperator<T, T> {
         @Override
         public void onItem(T item) {
             if (upstream.get() != Subscriptions.CANCELLED) {
+                MultiSubscriber<? super T> subscriber = this.downstream;
                 try {
                     callback.accept(item);
                 } catch (Throwable t) {
                     failAndCancel(t);
                     return;
                 }
-                downstream.onItem(item);
+                subscriber.onItem(item);
             }
         }
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOperatorProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOperatorProcessor.java
@@ -14,7 +14,8 @@ import io.smallrye.mutiny.subscription.MultiSubscriber;
 
 public abstract class MultiOperatorProcessor<I, O> implements MultiSubscriber<I>, Subscription {
 
-    protected final MultiSubscriber<? super O> downstream;
+    // Cannot be final, the TCK checks it gets released.
+    protected volatile MultiSubscriber<? super O> downstream;
     protected AtomicReference<Subscription> upstream = new AtomicReference<>();
     AtomicBoolean hasDownstreamCancelled = new AtomicBoolean();
 
@@ -91,7 +92,12 @@ public abstract class MultiOperatorProcessor<I, O> implements MultiSubscriber<I>
     public void cancel() {
         if (hasDownstreamCancelled.compareAndSet(false, true)) {
             Subscriptions.cancel(upstream);
+            cleanup();
         }
+    }
+
+    protected void cleanup() {
+        downstream = null;
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSelectFirstWhileOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSelectFirstWhileOp.java
@@ -49,13 +49,14 @@ public final class MultiSelectFirstWhileOp<T> extends AbstractMultiOperator<T, T
                 return;
             }
 
+            MultiSubscriber<? super T> subscriber = downstream;
             if (!pass) {
                 cancel();
-                downstream.onCompletion();
+                subscriber.onCompletion();
                 return;
             }
 
-            downstream.onItem(t);
+            subscriber.onItem(t);
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromPublisher.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromPublisher.java
@@ -21,12 +21,12 @@ public class UniCreateFromPublisher<T> extends AbstractUni<T> {
         this.publisher = nonNull(publisher, "publisher");
     }
 
-    @SuppressWarnings("ReactiveStreamsSubscriberImplementation")
     @Override
     public void subscribe(UniSubscriber<? super T> subscriber) {
         new PublisherSubscriber(subscriber).forward();
     }
 
+    @SuppressWarnings("ReactiveStreamsSubscriberImplementation")
     private class PublisherSubscriber implements UniSubscription, Subscriber<T> {
 
         private final UniSubscriber<? super T> subscriber;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCombineTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCombineTest.java
@@ -23,7 +23,6 @@ import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.tuples.*;
 
-@SuppressWarnings("ConstantConditions")
 public class MultiCombineTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
@@ -223,8 +223,7 @@ public class MultiGroupTest {
         subscriber.assertFailedWith(IOException.class, "boom");
     }
 
-    @SuppressWarnings("ConstantConditions")
-    @Test
+    @RepeatedTest(5)
     public void testAsListsWithDurationAndLackOfRequests() {
         AtomicBoolean cancelled = new AtomicBoolean();
         Multi<Long> publisher = Multi.createFrom().publisher(Multi.createFrom().ticks().every(Duration.ofMillis(2)))

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
@@ -23,7 +23,6 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 
-@SuppressWarnings("ConstantConditions")
 public class MultiFromResourceTest {
 
     @Test


### PR DESCRIPTION
In various place, we needed to keep a local reference, to avoid running into NPE.