### PR TITLE
Implement mathematical operators

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -55,6 +55,11 @@
                 <artifactId>mutiny-test-utils</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>mutiny-math</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/math/README.md
+++ b/math/README.md
@@ -1,0 +1,33 @@
+# Mutiny Math Operators
+
+This library provides a set of _operators_ for [Mutiny](https://smallrye.io/smallrye-mutiny).
+
+You can use these operators using the `plug` method offered by Mutiny:
+
+```java
+Multi<Long> counts = Multi.createFrom().items("a", "b", "c", "d", "e")
+                            .plug(Math.count())
+```
+
+These operators provide streams (`Multi`) emitting new values when the computed value changes. To get the last value, use `collect().last()`:
+
+```java
+String max = Multi.createFrom().items("e", "b", "c", "f", "g", "e")
+                .plug(Math.max())
+                .collect().last()
+                .await().indefinitely();
+```
+
+The `io.smallrye.math.Math` class provides the entry point to the offered operators:
+
+* count - emits the number of items emitted by the upstream
+* index - emits `Tuple2<Long, T>` for each item from the upstream. The first element of the tuple is the index (0-based), and the second if the item 
+* min / max - emits the min/max item from the upstream, using Java comparator
+* top(x) - emits the top x items from the upstream, a new ranking is emitted every time it changes.
+* sum - emits the sum of all the items emitted by the upstream
+* average - emits the average of all the items emitted by the upstream
+* median - emits the median of all the items emitted by the upstream
+* statistics - emits statistics about the emitted items
+
+
+

--- a/math/pom.xml
+++ b/math/pom.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>mutiny-project</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <name>SmallRye Mutiny :: Math Operators</name>
+    <artifactId>mutiny-math</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>reactive-streams-junit5-tck</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+            <version>${reactive-streams.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Disable TestNG -->
+                            <testNGArtifactName>none:none</testNGArtifactName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <module>
+                                <moduleInfoFile>src/main/module/module-info.java</moduleInfoFile>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <id>java-9+</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <!-- wonderful reliability of javadoc used with modules breaking on non exposed packages -->
+                            <source>8</source>
+                            <release>8</release>
+                            <detectJavaApiLink>false</detectJavaApiLink>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/math/revapi.json
+++ b/math/revapi.json
@@ -1,0 +1,37 @@
+[ {
+  "extension" : "revapi.java",
+  "id" : "java",
+  "configuration" : {
+    "missing-classes" : {
+      "behavior" : "report",
+      "ignoreMissingAnnotations" : false
+    },
+    "filter" : {
+      "packages" : {
+        "regex" : true,
+        "include" : [ "io\\.smallrye\\.mutiny\\.math(\\..+)?" ]
+      }
+    }
+  }
+}, {
+  "extension" : "revapi.differences",
+  "id" : "breaking-changes",
+  "configuration" : {
+    "criticality" : "highlight",
+    "minSeverity" : "POTENTIALLY_BREAKING",
+    "minCriticality" : "documented",
+    "differences" : [
+
+    ]
+  }
+}, {
+  "extension" : "revapi.reporter.json",
+  "configuration" : {
+    "minSeverity" : "POTENTIALLY_BREAKING",
+    "minCriticality" : "documented",
+    "output" : "target/compatibility.json",
+    "indent" : true,
+    "append" : false,
+    "keepEmptyFile" : true
+  }
+} ]

--- a/math/src/main/java/io/smallrye/mutiny/math/AverageOperator.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/AverageOperator.java
@@ -1,0 +1,31 @@
+package io.smallrye.mutiny.math;
+
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Average operator emitting the average of the items emitted by the upstream.
+ * <p>
+ * Everytime it gets an item from upstream, it emits the <em>average</em> of the already received items.
+ * If the stream emits the completion event without having emitting any item before, 0 is emitted, followed by the
+ * completion event.
+ * If the upstream emits a failure, then, the failure is propagated.
+ */
+public class AverageOperator<T extends Number>
+        implements Function<Multi<T>, Multi<Double>> {
+
+    private double sum = 0.0d;
+    private long count = 0L;
+
+    @Override
+    public Multi<Double> apply(Multi<T> multi) {
+        return multi
+                .onItem().transform(x -> {
+                    count = count + 1L;
+                    sum = sum + x.doubleValue();
+                    return sum / count;
+                })
+                .onCompletion().ifEmpty().continueWith(0.0d);
+    }
+}

--- a/math/src/main/java/io/smallrye/mutiny/math/CountOperator.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/CountOperator.java
@@ -1,0 +1,30 @@
+package io.smallrye.mutiny.math;
+
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Count operator emitting the current count.
+ * Everytime it gets an item from upstream, it emits the <em>count</em>.
+ * If the stream emits the completion event without having emitting any item before, 0 is emitted, followed by the
+ * completion event.
+ * If the upstream emits a failure, the failure is propagated.
+ *
+ * @param <T> type of the incoming items.
+ */
+public class CountOperator<T>
+        implements Function<Multi<T>, Multi<Long>> {
+
+    private long count = 0L;
+
+    @Override
+    public Multi<Long> apply(Multi<T> multi) {
+        return multi
+                .onItem().transform(x -> {
+                    count = count + 1L;
+                    return count;
+                })
+                .onCompletion().ifEmpty().continueWith(0L);
+    }
+}

--- a/math/src/main/java/io/smallrye/mutiny/math/IndexOperator.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/IndexOperator.java
@@ -1,0 +1,26 @@
+package io.smallrye.mutiny.math;
+
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.tuples.Tuple2;
+
+/**
+ * Index operator emitting a {@link io.smallrye.mutiny.tuples.Tuple2 Tuple2&lt;Long, T&gt;}, with the index (0-based) of the
+ * element and the element from upstream.
+ *
+ * If the upstream emits a failure, then, the failure is propagated.
+ *
+ * @param <T> type of the incoming items.
+ */
+public class IndexOperator<T>
+        implements Function<Multi<T>, Multi<Tuple2<Long, T>>> {
+
+    private long index = 0L;
+
+    @Override
+    public Multi<Tuple2<Long, T>> apply(Multi<T> multi) {
+        return multi
+                .onItem().transform(x -> Tuple2.of(index++, x));
+    }
+}

--- a/math/src/main/java/io/smallrye/mutiny/math/Math.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/Math.java
@@ -1,0 +1,219 @@
+package io.smallrye.mutiny.math;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.tuples.Tuple2;
+
+/**
+ * A set of Mutiny operators related to various mathematical functions.
+ * These operators are intended to be used using {@code plug}. For example:
+ * {@code multi.plug(Math.count())}
+ */
+public class Math {
+
+    /**
+     * Emits the number of items emitted by the upstream.
+     * On each received item, the new count is emitted downstream.
+     * <p>
+     * The final count can be retrieved using {@code multi.plug(Math.count()).collect().last()}.
+     * Do not use that approach on unbounded streams.
+     * <p>
+     * If the upstream emits a failure, the failure is propagated downstream.
+     * If the upstream completes without having emitted any item, 0 is emitted, followed by the completion event.
+     *
+     * @param <T> the type of item emitted by the upstream
+     * @return a multi emitting the number of items emitted by the upstream
+     */
+    public static <T> Function<Multi<T>, Multi<Long>> count() {
+        return new CountOperator<>();
+    }
+
+    /**
+     * Emits the sum of all the items previously emitted by the upstream.
+     * On each received item, the new sum is emitted downstream.
+     * <p>
+     * The final sum can be retrieved using {@code multi.plug(Math.sum()).collect().last()}.
+     * Do not use that approach on unbounded streams.
+     * <p>
+     * If the upstream emits a failure, the failure is propagated downstream.
+     * If the upstream completes without having emitted any item, 0 is emitted, followed by the completion event.
+     * <p>
+     * Note the the sum are provided as {@link Double}.
+     *
+     * @param <T> the type of item emitted by the upstream
+     * @return a multi emitting the sum of the items emitted by the upstream
+     */
+    public static <T extends Number> Function<Multi<T>, Multi<Double>> sum() {
+        return new SumOperator<>();
+    }
+
+    /**
+     * Emits the index (0-based) of items emitted by the upstream.
+     * On each received item, the new index structure is emitted downstream.
+     * <p>
+     * The index is given as a {@link Tuple2 Tuple2&lt;Long, T&gt;}, with the first item is the index and the second item
+     * is the item.
+     * <p>
+     * If the upstream emits a failure, the failure is propagated downstream.
+     * If the upstream completes without having emitted any item, it sends the completion event.
+     *
+     * @param <T> the type of item emitted by the upstream
+     * @return a multi emitting the tuples containing the index and the item emitted by the upstream
+     */
+    public static <T> Function<Multi<T>, Multi<Tuple2<Long, T>>> index() {
+        return new IndexOperator<>();
+    }
+
+    /**
+     * Emits the average of the items previously emitted by the upstream.
+     * On each received item, the new average is emitted downstream.
+     * <p>
+     * The final average can be retrieved using {@code multi.plug(Math.average()).collect().last()}.
+     * Do not use that approach on unbounded streams.
+     * <p>
+     * If the upstream emits a failure, the failure is propagated downstream.
+     * If the upstream completes without having emitted any item, 0.0 is emitted, followed by the completion event.
+     * <p>
+     *
+     * @param <T> the type of item emitted by the upstream
+     * @return a multi emitting the average of the items emitted by the upstream
+     */
+    public static <T extends Number> Function<Multi<T>, Multi<Double>> average() {
+        return new AverageOperator<>();
+    }
+
+    /**
+     * Emits the median of the items previously emitted by the upstream.
+     * On each received item, the new median is emitted downstream.
+     * <p>
+     * Do not use that approach on unbounded streams.
+     * <p>
+     * The final median can be retrieved using {@code multi.plug(Math.median()).collect().last()}.
+     * <p>
+     * If the upstream emits a failure, the failure is propagated downstream.
+     * If the upstream completes without having emitted any item, the completion event is sent without any item emitted
+     * before.
+     * <p>
+     *
+     * <strong>Note:</strong> The median is a measure of central tendency. It represents the value for which 50% of
+     * observations a lower and 50% are higher. Put simply, it is the value at the center of the sorted observations.
+     *
+     * @param <T> the type of item emitted by the upstream
+     * @return a multi emitting the median of the items emitted by the upstream
+     */
+    public static <T extends Number & Comparable<T>> Function<Multi<T>, Multi<Double>> median() {
+        return new MedianOperator<>();
+    }
+
+    /**
+     * Emits statistics (average, variance, standard deviation, min, max, count, skewness and kurtosis) of the items
+     * previously emitted by the upstream. On each received item, a new statistic object is emitted downstream.
+     * <p>
+     * The final average can be retrieved using {@code multi.plug(Math.statistics()).collect().last()}.
+     * Do not use that approach on unbounded streams.
+     * <p>
+     * If the upstream emits a failure, the failure is propagated downstream.
+     * <p>
+     *
+     * @param <T> the type of item emitted by the upstream
+     * @return a multi emitting the statistics of the items emitted by the upstream
+     */
+    public static <T extends Number & Comparable<T>> Function<Multi<T>, Multi<Statistic<T>>> statistics() {
+        return new StatisticsOperator<>();
+    }
+
+    /**
+     * Emits the minimum of the item emitted by the upstream.
+     * Each time that the upstream emits an item, this operator check if this item is <em>smaller</em> than the
+     * previous minimum. If so, it emits the new minimum downstream.
+     * <p>
+     * The final minimum can be retrieved using {@code multi.plug(Math.min()).collect().last()}.
+     * Do not use that approach on unbounded streams.
+     * <p>
+     * This operator uses {@link Comparable} items, the the {@link Comparable#compareTo(Object)} method is used to determine
+     * the minimum.
+     * <p>
+     * If the upstream emits a failure, the failure is propagated downstream.
+     * If the upstream completes without having emitted any item, 0 is emitted, followed by the completion event.
+     *
+     * @param <T> the type of item emitted by the upstream
+     * @return a multi emitting the <em>smallest</em> item emitted by the upstream. The operator emits a new minimum every time
+     *         a new minimum is received from the upstream.
+     */
+    public static <T extends Comparable<T>> Function<Multi<T>, Multi<T>> min() {
+        return new MinOperator<>();
+    }
+
+    /**
+     * Emits the maximum of the item emitted by the upstream.
+     * Each time that the upstream emits an item, this operator check if this item is <em>larger</em> than the
+     * previous maximum. If so, it emits the new maximum downstream.
+     * <p>
+     * The final minimum can be retrieved using {@code multi.plug(Math.max()).collect().last()}.
+     * Do not use that approach on unbounded streams.
+     * <p>
+     * This operator uses {@link Comparable} items, the the {@link Comparable#compareTo(Object)} method is used to determine
+     * the maximum.
+     * <p>
+     * If the upstream emits a failure, the failure is propagated downstream.
+     * If the upstream completes without having emitted any item, 0 is emitted, followed by the completion event.
+     *
+     * @param <T> the type of item emitted by the upstream
+     * @return a multi emitting the <em>largest</em> item emitted by the upstream. The operator emits a new maximum every time a
+     *         new maximum is received from the upstream.
+     */
+    public static <T extends Comparable<T>> Function<Multi<T>, Multi<T>> max() {
+        return new MaxOperator<>();
+    }
+
+    /**
+     * Emits the top {@code count} items that have been emitted by the upstream.
+     * This operator sorts the top {@code count} items from the upstream and emits the ranking.
+     * <p>
+     * On each received item, the new ranking is emitted downstream if the ranking changes.
+     * <p>
+     * The final ranking can be retrieved using {@code multi.plug(Math.top(3)).collect().last()}.
+     * Do not use that approach on unbounded streams.
+     * <p>
+     * If the upstream emits a failure, the failure is propagated downstream.
+     * If the upstream completes without having emitted any item, it emits the completion event.
+     * <p>
+     * This operator maintains a sorted ranking of the item emitted by the upstream. The hold structured is cleared on
+     * termination (including on cancellation).
+     * It compares the item using the {@link Comparable#compareTo(Object)} method. Each time that the maintained ranking
+     * changes, it emits the newly computed ranking downstream.
+     * That emitted structure is a {@link List List&lt;T&gt;} containing at most {@code count} items.
+     *
+     * @param count the number of items composing the ranking, for example, 3 for a top 3, 10 for a top 10.
+     * @param <T> the type of item emitted by the upstream
+     * @return a multi emitting the top x items emitted by the upstream
+     */
+    public static <T extends Comparable<T>> Function<Multi<T>, Multi<List<T>>> top(int count) {
+        return new TopOperator<>(count);
+    }
+
+    /**
+     * Emits the number of occurrences of each item emitted by the upstream.
+     * <p>
+     * This operator keeps track all of the item emitted by the upstream and stores how many times each items is emitted.
+     * Do not use this operator if the item domain is unbounded.
+     * <p>
+     * After each emitted item, this operator emits a
+     * {@link Map Map&lt;T, Long&gt;} containing for each seen item, how many times they have been seen.
+     * <p>
+     * If the upstream sends the completion even before having sent any item, this operators emits an empty map, followed
+     * with the completion event.
+     * If the upstream emits a failure, the failure is passed downstream.
+     * <p>
+     * On termination, including cancellation, the hold counts are cleared.
+     *
+     * @param <T> the type of item, must be a valid {@link java.util.HashMap} key.
+     * @return the multi emitting the number of occurrences for each item.
+     */
+    public static <T> Function<Multi<T>, Multi<Map<T, Long>>> occurrence() {
+        return new OccurrenceOperator<>();
+    }
+}

--- a/math/src/main/java/io/smallrye/mutiny/math/MaxOperator.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/MaxOperator.java
@@ -1,0 +1,33 @@
+package io.smallrye.mutiny.math;
+
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Max operator emitting the max of the emitted items from upstream.
+ * If the upstream emits a failure, the failure is propagated.
+ *
+ * It only emits the maximum if the received item is larger than the previously emitted maxmimum.
+ *
+ * Note that this operator relies on {@link Comparable}.
+ *
+ * @param <T> type of the incoming items.
+ */
+public class MaxOperator<T extends Comparable<T>>
+        implements Function<Multi<T>, Multi<T>> {
+
+    private T max = null;
+
+    @Override
+    public Multi<T> apply(Multi<T> multi) {
+        return multi
+                .onItem().transformToMultiAndConcatenate(item -> {
+                    if (max == null || max.compareTo(item) < 0) {
+                        max = item;
+                        return Multi.createFrom().item(max);
+                    }
+                    return Multi.createFrom().empty();
+                });
+    }
+}

--- a/math/src/main/java/io/smallrye/mutiny/math/MedianOperator.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/MedianOperator.java
@@ -1,0 +1,55 @@
+package io.smallrye.mutiny.math;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Median operator emitting the median all all the item emitter by the upstream.
+ * <p>
+ * Everytime it gets an item from upstream, it emits the <em>median</em> of the already received items.
+ * If the stream emits the completion event without having emitting any item before, the completion event is emitted.
+ * If the upstream emits a failure, then, the failure is propagated.
+ */
+public class MedianOperator<T extends Number & Comparable<T>>
+        implements Function<Multi<T>, Multi<Double>> {
+
+    private final Queue<T> minHeap;
+    private final Queue<T> maxHeap;
+
+    public MedianOperator() {
+        minHeap = new PriorityQueue<>();
+        maxHeap = new PriorityQueue<>(Comparator.reverseOrder());
+    }
+
+    @Override
+    public Multi<Double> apply(Multi<T> multi) {
+        return multi
+                .onItem().transform(x -> {
+                    push(x);
+                    return getMedian();
+                });
+    }
+
+    void push(T num) {
+        if (minHeap.size() == maxHeap.size()) {
+            maxHeap.offer(num);
+            minHeap.offer(maxHeap.poll());
+        } else {
+            minHeap.offer(num);
+            maxHeap.offer(minHeap.poll());
+        }
+    }
+
+    double getMedian() {
+        if (minHeap.size() > maxHeap.size()) {
+            return minHeap.peek().doubleValue();
+        } else {
+            return (minHeap.peek().doubleValue() + maxHeap.peek().doubleValue()) / 2.0d;
+        }
+    }
+
+}

--- a/math/src/main/java/io/smallrye/mutiny/math/MinOperator.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/MinOperator.java
@@ -1,0 +1,33 @@
+package io.smallrye.mutiny.math;
+
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Min operator emitting the min of the emitted items from upstream.
+ * If the upstream emits a failure, the failure is propagated.
+ *
+ * It only emits the minimum if the received item is smaller than the previously emitted minimum.
+ *
+ * Note that this operator relies on {@link Comparable}.
+ *
+ * @param <T> type of the incoming items.
+ */
+public class MinOperator<T extends Comparable<T>>
+        implements Function<Multi<T>, Multi<T>> {
+
+    private T min = null;
+
+    @Override
+    public Multi<T> apply(Multi<T> multi) {
+        return multi
+                .onItem().transformToMultiAndConcatenate(item -> {
+                    if (min == null || min.compareTo(item) > 0) {
+                        min = item;
+                        return Multi.createFrom().item(min);
+                    }
+                    return Multi.createFrom().empty();
+                });
+    }
+}

--- a/math/src/main/java/io/smallrye/mutiny/math/OccurrenceOperator.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/OccurrenceOperator.java
@@ -1,0 +1,23 @@
+package io.smallrye.mutiny.math;
+
+import java.util.*;
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Multi;
+
+public class OccurrenceOperator<T>
+        implements Function<Multi<T>, Multi<Map<T, Long>>> {
+
+    private final Map<T, Long> occurrences = new HashMap<>();
+
+    @Override
+    public Multi<Map<T, Long>> apply(Multi<T> multi) {
+        return multi
+                .onTermination().invoke(occurrences::clear)
+                .onItem().transform(item -> {
+                    occurrences.compute(item, (it, c) -> c == null ? 1 : c + 1);
+                    return (Map<T, Long>) new HashMap<>(occurrences);
+                })
+                .onCompletion().ifEmpty().continueWith(Collections.emptyMap());
+    }
+}

--- a/math/src/main/java/io/smallrye/mutiny/math/Statistic.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/Statistic.java
@@ -1,0 +1,141 @@
+package io.smallrye.mutiny.math;
+
+import static java.lang.Math.pow;
+import static java.lang.Math.sqrt;
+
+import java.util.Objects;
+
+/**
+ * A state object for collecting statistics such as count, average, min, max, variance, standard deviation, skewness,
+ * and kurtosis.
+ *
+ * <ul>
+ * <li>Count: the number of element emitted by the upstream, 0 for empty streams.</li>
+ * <li>Average: the average of the element emitted by the upstream, 0.0 for empty streams.</li>
+ * <li>Min: the minimum element emitted by the upstream, {@code null} for empty streams.</li>
+ * <li>Max: the maximum element emitted by the upstream, {@code null} for empty streams.</li>
+ * <li>Variance: squared deviation of a items from the upstreams. It measures how far a set of items is spread out from their
+ * average value.</li>
+ * <li>Standard Deviation: measure of the dispersion of the set of items. A low standard deviation indicates that
+ * the values tend to be close to the current average, while a high standard deviation indicates that the items are spread out
+ * over a wider range.</li>
+ * <li>Skewness: measure of the asymmetry of the distribution of the emitted items about its average. The skewness value can be
+ * positive, zero, negative, or {@code NaN}.</li>
+ * <li>Kurtosis: statistical measure that defines how heavily the tails of a item distribution differ from the tails of a normal
+ * distribution.</li>
+ * </ul>
+ * <p>
+ * Computation is based on https://www.johndcook.com/blog/skewness_kurtosis/.
+ *
+ * @param <T> the type of the element (Number and Comparable)
+ */
+public class Statistic<T> {
+
+    private final long n;
+    private final double m1;
+    private final double m2;
+    private final double m3;
+    private final double m4;
+    private final T min;
+    private final T max;
+
+    public Statistic(long n, double m1, double m2, double m3, double m4, T min, T max) {
+        this.n = n;
+        this.m1 = m1;
+        this.m2 = m2;
+        this.m3 = m3;
+        this.m4 = m4;
+        this.min = min;
+        this.max = max;
+    }
+
+    /**
+     * @return the average (mean) of the emitted items.
+     */
+    public double getAverage() {
+        return m1;
+    }
+
+    /**
+     * @return the variance of the emitted items
+     */
+    public double getVariance() {
+        return m2 / (n - 1.0);
+    }
+
+    /**
+     * @return the standard deviation
+     */
+    public double getStandardDeviation() {
+        return sqrt(getVariance());
+    }
+
+    /**
+     * @return the skewness, can be {@code NaN}
+     */
+    public double getSkewness() {
+        return sqrt(((double) n)) * m3 / pow(m2, 1.5);
+    }
+
+    /**
+     * @return the kurtosis, can be {@code Nan}
+     */
+    public double getKurtosis() {
+        return ((double) n) * m4 / (m2 * m2) - 3.0;
+    }
+
+    /**
+     * @return the number of items
+     */
+    public long getCount() {
+        return n;
+    }
+
+    /**
+     * @return the minimum item, {@code null} if no items have been emitted
+     */
+    public T getMin() {
+        return min;
+    }
+
+    /**
+     * @return the maximum item, {@code null} if no items have been emitted
+     */
+    public T getMax() {
+        return max;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Statistic<?> statistic = (Statistic<?>) o;
+        return n == statistic.n && Double.compare(statistic.m1, m1) == 0
+                && Double.compare(statistic.m2, m2) == 0 && Double.compare(statistic.m3, m3) == 0
+                && Double.compare(statistic.m4, m4) == 0 && Objects.equals(min, statistic.min)
+                && Objects.equals(max, statistic.max);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(n, m1, m2, m3, m4, min, max);
+    }
+
+    @Override
+    public String toString() {
+        return "Statistic{" +
+                "size=" + n +
+                ", min=" + min +
+                ", max=" + max +
+                ", average=" + getAverage() +
+                ", variance=" + getVariance() +
+                ", stdDeviation=" + getStandardDeviation() +
+                ", skewness=" + getSkewness() +
+                ", kurtosis=" + getKurtosis() +
+                '}';
+    }
+}

--- a/math/src/main/java/io/smallrye/mutiny/math/StatisticsOperator.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/StatisticsOperator.java
@@ -1,0 +1,68 @@
+package io.smallrye.mutiny.math;
+
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Operator computing statistics based on the items emitted by the upstreams.
+ * For each items from upstream, it structure containing the:
+ * <ul>
+ * <li>Count (number of items emitted by the upstream)</li>
+ * <li>Average (Mean)</li>
+ * <li>Variance</li>
+ * <li>Standard Deviation</li>
+ * <li>Skewness</li>
+ * <li>Kurtosis</li>
+ * <li>Min</li>
+ * <li>Max</li>
+ * </ul>
+ * <p>
+ * Computation following https://www.johndcook.com/blog/skewness_kurtosis/.
+ */
+public class StatisticsOperator<T extends Number & Comparable<T>>
+        implements Function<Multi<T>, Multi<Statistic<T>>> {
+
+    private static final Statistic<?> EMPTY = new Statistic<>(0L, 0.0d, 0.0d, 0.0d, 0.0d, null, null);
+
+    private long n = 0;
+    private double m1 = 0.0;
+    private double m2 = 0.0;
+    private double m3 = 0.0;
+    private double m4 = 0.0;
+
+    private T min;
+    private T max;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Multi<Statistic<T>> apply(Multi<T> multi) {
+        return multi
+                .onItem().transform(this::push)
+                .onCompletion().ifEmpty().continueWith((Statistic<T>) EMPTY);
+    }
+
+    private Statistic<T> push(T number) {
+        double delta, delta_n, delta_n2, term1;
+        long n1 = n;
+
+        n++;
+        delta = number.doubleValue() - m1;
+        delta_n = delta / n;
+        delta_n2 = delta_n * delta_n;
+        term1 = delta * delta_n * n1;
+        m1 += delta_n;
+        m4 += term1 * delta_n2 * (n * n - 3 * n + 3) + 6 * delta_n2 * m2 - 4 * delta_n * m3;
+        m3 += term1 * delta_n * (n - 2) - 3 * delta_n * m2;
+        m2 += term1;
+
+        if (min == null || min.compareTo(number) > 0) {
+            min = number;
+        }
+        if (max == null || max.compareTo(number) < 0) {
+            max = number;
+        }
+
+        return new Statistic<>(n, m1, m2, m3, m4, min, max);
+    }
+}

--- a/math/src/main/java/io/smallrye/mutiny/math/SumOperator.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/SumOperator.java
@@ -1,0 +1,30 @@
+package io.smallrye.mutiny.math;
+
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Sum operator emitting the current sum of the item emitted by the upstream.
+ * Everytime it gets an item from upstream, it emits the <em>sum</em> of the previous elements
+ * If the stream emits the completion event without having emitting any item before, 0 is emitted, followed by the
+ * completion event.
+ * If the upstream emits a failure, the failure is propagated.
+ *
+ * @param <T> type of the incoming items, must be a {@link Number}.
+ */
+public class SumOperator<T extends Number>
+        implements Function<Multi<T>, Multi<Double>> {
+
+    private double sum = 0.0d;
+
+    @Override
+    public Multi<Double> apply(Multi<T> multi) {
+        return multi
+                .onItem().transform(x -> {
+                    sum = sum + x.doubleValue();
+                    return sum;
+                })
+                .onCompletion().ifEmpty().continueWith(0.0d);
+    }
+}

--- a/math/src/main/java/io/smallrye/mutiny/math/TopOperator.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/TopOperator.java
@@ -1,0 +1,45 @@
+package io.smallrye.mutiny.math;
+
+import java.util.*;
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Multi;
+
+public class TopOperator<T extends Comparable<T>>
+        implements Function<Multi<T>, Multi<List<T>>> {
+
+    private final int count;
+    private final SortedSet<T> list;
+
+    public TopOperator(int count) {
+        this.count = count;
+        this.list = new TreeSet<>(Comparator.reverseOrder());
+    }
+
+    @Override
+    public Multi<List<T>> apply(Multi<T> multi) {
+        return multi
+                .onTermination().invoke(list::clear)
+                .onItem().transformToMultiAndConcatenate(item -> {
+                    // Add the item
+                    if (!this.list.add(item)) {
+                        // not inserted
+                        return Multi.createFrom().empty();
+                    }
+
+                    // Overflow case
+                    if (this.list.size() > count) {
+                        // Get last and remove it
+                        T last = this.list.last();
+                        this.list.remove(last);
+                        // It the given item was the last one, nothing to do, otherwise emit
+                        if (last != item) {
+                            return Multi.createFrom().item(new ArrayList<>(this.list));
+                        }
+                        return Multi.createFrom().empty();
+                    } else {
+                        return Multi.createFrom().item(new ArrayList<>(this.list));
+                    }
+                });
+    }
+}

--- a/math/src/main/module/module-info.java
+++ b/math/src/main/module/module-info.java
@@ -1,0 +1,6 @@
+module io.smallrye.mutiny.math {
+    requires org.reactivestreams;
+    requires io.smallrye.mutiny;
+
+    exports io.smallrye.mutiny.math;
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/AverageOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/AverageOperatorTest.java
@@ -1,0 +1,75 @@
+package io.smallrye.mutiny.math;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class AverageOperatorTest {
+
+    @Test
+    public void testWithEmpty() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().<Long> empty()
+                .plug(Math.average())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.awaitItems(1)
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testWithNever() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().<Long> nothing()
+                .plug(Math.average())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.cancel();
+        subscriber.assertNotTerminated();
+        Assertions.assertEquals(0, subscriber.getItems().size());
+    }
+
+    @Test
+    public void testWithItems() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().items(1L, 2L, 3L, 4L, 2L, 5L)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.average())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1.0, 1.5, 2.0)
+                .request(10)
+                .awaitItems(6)
+                .assertItems(1.0, 1.5, 2.0, 10.0 / 4, 12.0 / 5, 17.0 / 6)
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testLatest() {
+        double average = Multi.createFrom().items(1L, 2L, 3L, 4L, 2L, 5L)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.average())
+                .collect().last()
+                .await().indefinitely();
+
+        Assertions.assertEquals(17.0 / 6, average);
+    }
+
+    @Test
+    public void testWithItemsAndFailure() {
+        AssertSubscriber<Double> subscriber = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items(1L, 2L, 3L, 4L, 2L),
+                Multi.createFrom().failure(new Exception("boom")))
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.average())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1.0, 1.5, 2.0)
+                .request(10)
+                .awaitItems(5)
+                .assertItems(1.0, 1.5, 2.0, 10.0 / 4, 12.0 / 5)
+                .awaitFailure();
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/AverageOperatorWithDoubleTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/AverageOperatorWithDoubleTest.java
@@ -1,0 +1,75 @@
+package io.smallrye.mutiny.math;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class AverageOperatorWithDoubleTest {
+
+    @Test
+    public void testWithEmpty() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().<Double> empty()
+                .plug(Math.average())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.awaitItems(1)
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testWithNever() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().<Double> nothing()
+                .plug(Math.average())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.cancel();
+        subscriber.assertNotTerminated();
+        Assertions.assertEquals(0, subscriber.getItems().size());
+    }
+
+    @Test
+    public void testWithItems() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().items(1.0, 2.0, 3.0, 4.0, 2.0, 5.0)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.average())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1.0, 1.5, 2.0)
+                .request(10)
+                .awaitItems(6)
+                .assertItems(1.0, 1.5, 2.0, 10.0 / 4, 12.0 / 5, 17.0 / 6)
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testLatest() {
+        double average = Multi.createFrom().items(1.0, 2.0, 3.0, 4.0, 2.0, 5.0)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.average())
+                .collect().last()
+                .await().indefinitely();
+
+        Assertions.assertEquals(17.0 / 6, average);
+    }
+
+    @Test
+    public void testWithItemsAndFailure() {
+        AssertSubscriber<Double> subscriber = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items(1.0, 2.0, 3.0, 4.0, 2.0),
+                Multi.createFrom().failure(new Exception("boom")))
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.average())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1.0, 1.5, 2.0)
+                .request(10)
+                .awaitItems(5)
+                .assertItems(1.0, 1.5, 2.0, 10.0 / 4, 12.0 / 5)
+                .awaitFailure();
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/AverageOperatorWithIntegerTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/AverageOperatorWithIntegerTest.java
@@ -1,0 +1,75 @@
+package io.smallrye.mutiny.math;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class AverageOperatorWithIntegerTest {
+
+    @Test
+    public void testWithEmpty() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().<Integer> empty()
+                .plug(Math.average())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.awaitItems(1)
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testWithNever() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().<Integer> nothing()
+                .plug(Math.average())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.cancel();
+        subscriber.assertNotTerminated();
+        Assertions.assertEquals(0, subscriber.getItems().size());
+    }
+
+    @Test
+    public void testWithItems() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().items(1, 2, 3, 4, 2, 5)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.average())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1.0, 1.5, 2.0)
+                .request(10)
+                .awaitItems(6)
+                .assertItems(1.0, 1.5, 2.0, 10.0 / 4, 12.0 / 5, 17.0 / 6)
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testLatest() {
+        double average = Multi.createFrom().items(1, 2, 3, 4, 2, 5)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.average())
+                .collect().last()
+                .await().indefinitely();
+
+        Assertions.assertEquals(17.0 / 6, average);
+    }
+
+    @Test
+    public void testWithItemsAndFailure() {
+        AssertSubscriber<Double> subscriber = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items(1, 2, 3, 4, 2),
+                Multi.createFrom().failure(new Exception("boom")))
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.average())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1.0, 1.5, 2.0)
+                .request(10)
+                .awaitItems(5)
+                .assertItems(1.0, 1.5, 2.0, 10.0 / 4, 12.0 / 5)
+                .awaitFailure();
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/CountOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/CountOperatorTest.java
@@ -1,0 +1,77 @@
+package io.smallrye.mutiny.math;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class CountOperatorTest {
+
+    @Test
+    public void testWithEmpty() {
+        AssertSubscriber<Long> subscriber = Multi.createFrom().empty()
+                .plug(Math.count())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.awaitItems(1)
+                .assertItems(0L)
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testWithNever() {
+        AssertSubscriber<Long> subscriber = Multi.createFrom().nothing()
+                .plug(Math.count())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.cancel();
+        subscriber.assertNotTerminated();
+        Assertions.assertEquals(0, subscriber.getItems().size());
+    }
+
+    @Test
+    public void testWithItems() {
+        AssertSubscriber<Long> subscriber = Multi.createFrom().items("a", "b", "c", "d", "e")
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.count())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1L, 2L, 3L)
+                .request(10)
+                .awaitItems(5)
+                .assertItems(1L, 2L, 3L, 4L, 5L)
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testLatest() {
+        double count = Multi.createFrom().items("a", "b", "c", "d", "e")
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.count())
+                .collect().last()
+                .await().indefinitely();
+
+        Assertions.assertEquals(5, count);
+    }
+
+    @Test
+    public void testWithItemsAndFailure() {
+        AssertSubscriber<Long> subscriber = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items("a", "b", "c", "d", "e"),
+                Multi.createFrom().failure(new Exception("boom")))
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.count())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1L, 2L, 3L)
+                .request(10)
+                .awaitItems(5)
+                .assertItems(1L, 2L, 3L, 4L, 5L)
+                .awaitFailure();
+    }
+
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/IndexOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/IndexOperatorTest.java
@@ -1,0 +1,78 @@
+package io.smallrye.mutiny.math;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.tuples.Tuple2;
+
+public class IndexOperatorTest {
+
+    @Test
+    public void testWithEmpty() {
+        AssertSubscriber<Tuple2<Long, String>> subscriber = Multi.createFrom().<String> empty()
+                .plug(Math.index())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber
+                .awaitCompletion()
+                .assertHasNotReceivedAnyItem();
+    }
+
+    @Test
+    public void testWithNever() {
+        AssertSubscriber<Tuple2<Long, String>> subscriber = Multi.createFrom().<String> nothing()
+                .plug(Math.index())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.cancel();
+        subscriber.assertNotTerminated();
+        Assertions.assertEquals(0, subscriber.getItems().size());
+    }
+
+    @Test
+    public void testWithItems() {
+        AssertSubscriber<Tuple2<Long, String>> subscriber = Multi.createFrom().items("a", "b", "c", "d", "e")
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.index())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(Tuple2.of(0L, "a"), Tuple2.of(1L, "b"), Tuple2.of(2L, "c"))
+                .request(10)
+                .awaitItems(5)
+                .assertItems(Tuple2.of(0L, "a"), Tuple2.of(1L, "b"), Tuple2.of(2L, "c"),
+                        Tuple2.of(3L, "d"), Tuple2.of(4L, "e"))
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testLatest() {
+        Tuple2<Long, String> index = Multi.createFrom().items("a", "b", "c", "d", "e")
+                .plug(Math.index())
+                .collect().last()
+                .await().indefinitely();
+
+        Assertions.assertEquals(Tuple2.of(4L, "e"), index);
+    }
+
+    @Test
+    public void testWithItemsAndFailure() {
+        AssertSubscriber<Tuple2<Long, String>> subscriber = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items("a", "b", "c", "d", "e"),
+                Multi.createFrom().failure(new Exception("boom")))
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.index())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(Tuple2.of(0L, "a"), Tuple2.of(1L, "b"), Tuple2.of(2L, "c"))
+                .request(10)
+                .awaitItems(5)
+                .assertItems(Tuple2.of(0L, "a"), Tuple2.of(1L, "b"), Tuple2.of(2L, "c"),
+                        Tuple2.of(3L, "d"), Tuple2.of(4L, "e"))
+                .awaitFailure();
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/MaxOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/MaxOperatorTest.java
@@ -1,0 +1,75 @@
+package io.smallrye.mutiny.math;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class MaxOperatorTest {
+
+    @Test
+    public void testWithEmpty() {
+        AssertSubscriber<Long> subscriber = Multi.createFrom().<Long> empty()
+                .plug(Math.max())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber
+                .awaitCompletion()
+                .assertHasNotReceivedAnyItem();
+    }
+
+    @Test
+    public void testWithNever() {
+        AssertSubscriber<Long> subscriber = Multi.createFrom().<Long> nothing()
+                .plug(Math.max())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.cancel();
+        subscriber.assertNotTerminated();
+        Assertions.assertEquals(0, subscriber.getItems().size());
+    }
+
+    @Test
+    public void testWithItems() {
+        AssertSubscriber<String> subscriber = Multi.createFrom().items("e", "b", "c", "f", "g", "e")
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.max())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems("e", "f", "g")
+                .request(10)
+                .awaitCompletion()
+                .assertItems("e", "f", "g");
+    }
+
+    @Test
+    public void testLatest() {
+        String max = Multi.createFrom().items("e", "b", "c", "f", "g", "e")
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.max())
+                .collect().last()
+                .await().indefinitely();
+
+        Assertions.assertEquals("g", max);
+    }
+
+    @Test
+    public void testWithItemsAndFailure() {
+        AssertSubscriber<String> subscriber = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items("a", "b", "c", "c", "a", "e", "a", "q", "x"),
+                Multi.createFrom().failure(new Exception("boom")))
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.max())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems("a", "b", "c")
+                .request(10)
+                .awaitItems(6)
+                .assertItems("a", "b", "c", "e", "q", "x")
+                .awaitFailure();
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/MedianOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/MedianOperatorTest.java
@@ -1,0 +1,123 @@
+package io.smallrye.mutiny.math;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class MedianOperatorTest {
+
+    @Test
+    public void testWithEmpty() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().<Integer> empty()
+                .plug(Math.median())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber
+                .awaitCompletion()
+                .assertHasNotReceivedAnyItem();
+    }
+
+    @Test
+    public void testWithNever() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().<Long> nothing()
+                .plug(Math.median())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.cancel();
+        subscriber.assertNotTerminated();
+        Assertions.assertEquals(0, subscriber.getItems().size());
+    }
+
+    @Test
+    public void testWithIntegerItems() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().items(1, 2, 3, 4, 5, 6)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.median())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1.0, 1.5, 2.0)
+                .request(10)
+                .awaitCompletion()
+                .assertItems(1.0, 1.5, 2.0, 2.5, 3.0, 3.5);
+    }
+
+    @Test
+    public void testWithIntegerItemsShuffled() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().items(6, 1, 2, 5, 3, 1)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.median())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(6.0, 3.5, 2.0)
+                .request(10)
+                .awaitCompletion()
+                .assertItems(6.0, 3.5, 2.0, 3.5, 3.0, 2.5);
+    }
+
+    @Test
+    public void testLatest() {
+        List<Integer> list = Arrays.asList(3, 4, 1, 2, 6, 7, 9, 2, 4, 5, 2, 7, 9, 10, 2, 5, 3, 4, 3, 8, 4, 7, 9);
+        Collections.shuffle(list);
+        double median = Multi.createFrom().iterable(list)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.median())
+                .collect().last()
+                .await().indefinitely();
+
+        Assertions.assertEquals(4.0, median);
+    }
+
+    @Test
+    public void testWithLongItems() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().items(6L, 1L, 2L, 5L, 3L, 1L)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.median())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(6.0, 3.5, 2.0)
+                .request(10)
+                .awaitCompletion()
+                .assertItems(6.0, 3.5, 2.0, 3.5, 3.0, 2.5);
+    }
+
+    @Test
+    public void testWithDoubleItems() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().items(6.0, 1.0, 2.0, 5.0, 3.0, 1.0)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.median())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(6.0, 3.5, 2.0)
+                .request(10)
+                .awaitCompletion()
+                .assertItems(6.0, 3.5, 2.0, 3.5, 3.0, 2.5);
+    }
+
+    @Test
+    public void testWithItemsAndFailure() {
+        AssertSubscriber<Double> subscriber = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items(6, 1, 2, 5, 3, 1),
+                Multi.createFrom().failure(new Exception("boom")))
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.median())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(6.0, 3.5, 2.0)
+                .request(10)
+                .awaitFailure()
+                .assertItems(6.0, 3.5, 2.0, 3.5, 3.0, 2.5);
+    }
+
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/MinOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/MinOperatorTest.java
@@ -1,0 +1,74 @@
+package io.smallrye.mutiny.math;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class MinOperatorTest {
+
+    @Test
+    public void testWithEmpty() {
+        AssertSubscriber<Long> subscriber = Multi.createFrom().<Long> empty()
+                .plug(Math.min())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber
+                .awaitCompletion()
+                .assertHasNotReceivedAnyItem();
+    }
+
+    @Test
+    public void testWithNever() {
+        AssertSubscriber<Long> subscriber = Multi.createFrom().<Long> nothing()
+                .plug(Math.min())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.cancel();
+        subscriber.assertNotTerminated();
+        Assertions.assertEquals(0, subscriber.getItems().size());
+    }
+
+    @Test
+    public void testWithItems() {
+        AssertSubscriber<String> subscriber = Multi.createFrom().items("e", "b", "c", "c", "a", "e")
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.min())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems("e", "b", "a")
+                .request(10)
+                .awaitCompletion()
+                .assertItems("e", "b", "a");
+    }
+
+    @Test
+    public void testLatest() {
+        String min = Multi.createFrom().items("e", "b", "c", "c", "a", "e")
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.min())
+                .collect().last()
+                .await().indefinitely();
+
+        Assertions.assertEquals("a", min);
+    }
+
+    @Test
+    public void testWithItemsAndFailure() {
+        AssertSubscriber<String> subscriber = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items("e", "b", "c", "c", "a", "e", "a", "v", "x"),
+                Multi.createFrom().failure(new Exception("boom")))
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.min())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems("e", "b", "a")
+                .request(10)
+                .awaitFailure()
+                .assertItems("e", "b", "a");
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/OccurrenceOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/OccurrenceOperatorTest.java
@@ -1,0 +1,72 @@
+package io.smallrye.mutiny.math;
+
+import static org.assertj.core.api.AssertionsForClassTypes.entry;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class OccurrenceOperatorTest {
+
+    @Test
+    public void testWithEmpty() {
+        AssertSubscriber<Map<String, Long>> subscriber = Multi.createFrom().<String> empty()
+                .plug(Math.occurrence())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber
+                .awaitItems(1)
+                .assertItems(Collections.emptyMap())
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testWithNever() {
+        AssertSubscriber<Map<String, Long>> subscriber = Multi.createFrom().<String> nothing()
+                .plug(Math.occurrence())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.cancel();
+        subscriber.assertNotTerminated();
+        Assertions.assertEquals(0, subscriber.getItems().size());
+    }
+
+    @Test
+    public void testWithItems() {
+        AssertSubscriber<Map<String, Long>> subscriber = Multi.createFrom()
+                .items("a", "b", "a", "c", "b", "e", "e", "a")
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.occurrence())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .run(() -> assertThat(subscriber.getItems()).hasSize(3)
+                        .anySatisfy(m -> assertThat(m).hasSize(1).contains(entry("a", 1L)))
+                        .anySatisfy(m -> assertThat(m).hasSize(2).contains(entry("a", 1L), entry("b", 1L)))
+                        .anySatisfy(m -> assertThat(m).hasSize(2).contains(entry("a", 2L), entry("b", 1L))))
+                .request(10)
+                .awaitCompletion()
+                .run(() -> assertThat(subscriber.getItems()).hasSize(8)
+                        .anySatisfy(m -> assertThat(m).hasSize(4)
+                                .contains(entry("a", 3L), entry("b", 2L), entry("c", 1L), entry("e", 2L))));
+    }
+
+    @Test
+    public void testLatest() {
+        Map<String, Long> last = Multi.createFrom().items("a", "b", "a", "c", "b", "e", "e", "a")
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.occurrence())
+                .collect().last()
+                .await().indefinitely();
+
+        assertThat(last).hasSize(4).contains(entry("a", 3L), entry("b", 2L), entry("c", 1L), entry("e", 2L));
+    }
+
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/StatisticOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/StatisticOperatorTest.java
@@ -1,0 +1,131 @@
+package io.smallrye.mutiny.math;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class StatisticOperatorTest {
+
+    @Test
+    public void testWithEmpty() {
+        AssertSubscriber<Statistic<Long>> subscriber = Multi.createFrom().<Long> empty()
+                .plug(Math.statistics())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.awaitItems(1)
+                .awaitCompletion()
+                .assertLastItem(new Statistic<>(0, 0.0, 0.0, 0.0, 0.0, null, null));
+    }
+
+    @Test
+    public void testWithNever() {
+        AssertSubscriber<Statistic<Long>> subscriber = Multi.createFrom().<Long> nothing()
+                .plug(Math.statistics())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.cancel();
+        subscriber.assertNotTerminated();
+        Assertions.assertEquals(0, subscriber.getItems().size());
+    }
+
+    @Test
+    public void testWithItems() {
+        AssertSubscriber<Statistic<Integer>> subscriber = Multi.createFrom().items(1, 2, 3, 4, 2, 5)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.statistics())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .run(() -> {
+                    assertThat(subscriber.getItems()).hasSize(3);
+                    assertThat(subscriber.getItems().get(0)).satisfies(s -> {
+                        assertThat(s.getCount()).isEqualTo(1);
+                        assertThat(s.getAverage()).isEqualTo(1.0);
+                        assertThat(s.getVariance()).isNaN();
+                        assertThat(s.getStandardDeviation()).isNaN();
+                        assertThat(s.getSkewness()).isNaN();
+                        assertThat(s.getKurtosis()).isNaN();
+                        assertThat(s.getMin()).isEqualTo(1L);
+                        assertThat(s.getMax()).isEqualTo(1L);
+                    });
+                    assertThat(subscriber.getItems().get(1)).satisfies(s -> {
+                        assertThat(s.getCount()).isEqualTo(2);
+                        assertThat(s.getAverage()).isEqualTo(1.5);
+                        assertThat(s.getVariance()).isEqualTo(0.5);
+                        assertThat(s.getStandardDeviation()).isCloseTo(0.707107, Offset.offset(0.001));
+                        assertThat(s.getSkewness()).isEqualTo(0.0);
+                        assertThat(s.getKurtosis()).isEqualTo(-2);
+                        assertThat(s.getMin()).isEqualTo(1L);
+                        assertThat(s.getMax()).isEqualTo(2L);
+                    });
+                    assertThat(subscriber.getItems().get(2)).satisfies(s -> {
+                        assertThat(s.getCount()).isEqualTo(3);
+                        assertThat(s.getAverage()).isEqualTo(2.0);
+                        assertThat(s.getVariance()).isEqualTo(1.0);
+                        assertThat(s.getStandardDeviation()).isEqualTo(1.0);
+                        assertThat(s.getSkewness()).isEqualTo(0.0);
+                        assertThat(s.getKurtosis()).isEqualTo(-1.5);
+                        assertThat(s.getMin()).isEqualTo(1L);
+                        assertThat(s.getMax()).isEqualTo(3L);
+                    });
+                })
+                .request(10)
+                .awaitItems(6)
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testLatest() {
+        Statistic<Long> statistics = Multi.createFrom().items(1L, 2L, 3L, 4L, 2L, 5L)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.statistics())
+                .collect().last()
+                .await().indefinitely();
+
+        assertThat(statistics.getCount()).isEqualTo(6);
+        assertThat(statistics.getMin()).isEqualTo(1L);
+        assertThat(statistics.getMax()).isEqualTo(5L);
+        assertThat(statistics.getAverage()).isCloseTo(2.833, Offset.offset(0.001));
+        assertThat(statistics.getVariance()).isCloseTo(2.167, Offset.offset(0.001));
+        assertThat(statistics.getStandardDeviation()).isCloseTo(1.472, Offset.offset(0.001));
+        assertThat(statistics.getSkewness()).isCloseTo(0.3053, Offset.offset(0.001));
+        assertThat(statistics.getKurtosis()).isCloseTo(-1.152, Offset.offset(0.001));
+    }
+
+    @Test
+    public void testLatestShuffled() {
+        Statistic<Long> statistics = Multi.createFrom().items(5L, 1L, 4L, 3L, 2L, 2L)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.statistics())
+                .collect().last()
+                .await().indefinitely();
+
+        assertThat(statistics.getCount()).isEqualTo(6);
+        assertThat(statistics.getAverage()).isCloseTo(2.833, Offset.offset(0.001));
+        assertThat(statistics.getVariance()).isCloseTo(2.167, Offset.offset(0.001));
+        assertThat(statistics.getStandardDeviation()).isCloseTo(1.472, Offset.offset(0.001));
+        assertThat(statistics.getSkewness()).isCloseTo(0.3053, Offset.offset(0.001));
+        assertThat(statistics.getKurtosis()).isCloseTo(-1.152, Offset.offset(0.001));
+    }
+
+    @Test
+    public void testWithItemsAndFailure() {
+        AssertSubscriber<Statistic<Long>> subscriber = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items(1L, 2L, 3L, 4L, 2L),
+                Multi.createFrom().failure(new Exception("boom")))
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.statistics())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .request(10)
+                .awaitItems(5)
+                .awaitFailure();
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/SumOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/SumOperatorTest.java
@@ -1,0 +1,103 @@
+package io.smallrye.mutiny.math;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class SumOperatorTest {
+
+    @Test
+    public void testWithEmpty() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().<Integer> empty()
+                .plug(Math.sum())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.awaitItems(1)
+                .assertItems(0.0d)
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testWithNever() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().<Long> nothing()
+                .plug(Math.sum())
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.cancel();
+        subscriber.assertNotTerminated();
+        Assertions.assertEquals(0, subscriber.getItems().size());
+    }
+
+    @Test
+    public void testWithIntegerItems() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().items(1, 2, 3, 4, 5, 6)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.sum())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1.0, 3.0, 6.0)
+                .request(10)
+                .awaitCompletion()
+                .assertItems(1.0, 3.0, 6.0, 10.0, 15.0, 21.0);
+    }
+
+    @Test
+    public void testLatest() {
+        double sum = Multi.createFrom().items(1, 2, 3, 4, 5, 6)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.sum())
+                .collect().last()
+                .await().indefinitely();
+
+        Assertions.assertEquals(21.0, sum);
+    }
+
+    @Test
+    public void testWithLongItems() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().items(1L, 2L, 3L, 4L, 5L, 6L)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.sum())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1.0, 3.0, 6.0)
+                .request(10)
+                .awaitCompletion()
+                .assertItems(1.0, 3.0, 6.0, 10.0, 15.0, 21.0);
+    }
+
+    @Test
+    public void testWithDoubleItems() {
+        AssertSubscriber<Double> subscriber = Multi.createFrom().items(1.1, 2.0, 3.5, 4.0, 5.0, 6.0)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.sum())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1.1, 3.1, 6.6)
+                .request(10)
+                .awaitCompletion()
+                .assertItems(1.1, 3.1, 6.6, 10.6, 15.6, 21.6);
+    }
+
+    @Test
+    public void testWithItemsAndFailure() {
+        AssertSubscriber<Double> subscriber = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items(1, 2, 3, 4, 5, 6),
+                Multi.createFrom().failure(new Exception("boom")))
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.sum())
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(1.0, 3.0, 6.0)
+                .request(10)
+                .awaitFailure()
+                .assertItems(1.0, 3.0, 6.0, 10.0, 15.0, 21.0);
+    }
+
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/TopOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/TopOperatorTest.java
@@ -1,0 +1,102 @@
+package io.smallrye.mutiny.math;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class TopOperatorTest {
+
+    @Test
+    public void testWithEmpty() {
+        AssertSubscriber<List<Long>> subscriber = Multi.createFrom().<Long> empty()
+                .plug(Math.top(10))
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber
+                .awaitCompletion()
+                .assertHasNotReceivedAnyItem();
+    }
+
+    @Test
+    public void testWithNever() {
+        AssertSubscriber<List<Long>> subscriber = Multi.createFrom().<Long> nothing()
+                .plug(Math.top(3))
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        subscriber.cancel();
+        subscriber.assertNotTerminated();
+        Assertions.assertEquals(0, subscriber.getItems().size());
+    }
+
+    @Test
+    public void testWithItems() {
+        AssertSubscriber<List<String>> subscriber = Multi.createFrom()
+                .items("a", "b", "a", "e", "f", "b", "a", "g", "g", "e", "z")
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.top(3))
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(list("a"), list("b", "a"), list("e", "b", "a"))
+                .request(10)
+                .awaitItems(6)
+                .assertItems(list("a"), list("b", "a"), list("e", "b", "a"), list("f", "e", "b"),
+                        list("g", "f", "e"), list("z", "g", "f"))
+                .awaitCompletion();
+    }
+
+    @Test
+    public void testLast() {
+        List<String> last = Multi.createFrom().items("a", "b", "a", "e", "f", "b", "a", "g", "g", "e", "z")
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.top(3))
+                .collect().last()
+                .await().indefinitely();
+
+        Assertions.assertEquals(list("z", "g", "f"), last);
+    }
+
+    @Test
+    public void testEquality() {
+        AssertSubscriber<List<String>> subscriber = Multi.createFrom()
+                .items("a", "b", "c", "a", "b", "c", "c", "b", "a", "a", "c")
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.top(3))
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(list("a"), list("b", "a"), list("c", "b", "a"))
+                .request(10)
+                .awaitCompletion()
+                .assertItems(list("a"), list("b", "a"), list("c", "b", "a"));
+    }
+
+    @Test
+    public void testWithItemsAndFailure() {
+        AssertSubscriber<List<String>> subscriber = Multi.createBy().concatenating().streams(
+                Multi.createFrom().items("a", "b", "a", "e", "f", "b", "g", "g", "e", "z"),
+                Multi.createFrom().failure(new Exception("boom")))
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .plug(Math.top(3))
+                .subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        subscriber.awaitItems(3)
+                .assertItems(list("a"), list("b", "a"), list("e", "b", "a"))
+                .request(10)
+                .awaitItems(6)
+                .assertItems(list("a"), list("b", "a"), list("e", "b", "a"), list("f", "e", "b"),
+                        list("g", "f", "e"), list("z", "g", "f"))
+                .awaitFailure();
+    }
+
+    private static List<String> list(String... items) {
+        return Arrays.asList(items);
+    }
+
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/tck/AverageTckTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/tck/AverageTckTest.java
@@ -1,0 +1,33 @@
+package io.smallrye.mutiny.math.tck;
+
+import static io.smallrye.mutiny.math.tck.TckHelper.iterate;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.support.TestException;
+import org.reactivestreams.tck.junit5.PublisherVerification;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.math.Math;
+
+public class AverageTckTest extends PublisherVerification<Double> {
+    public AverageTckTest() {
+        super(new TestEnvironment(100));
+    }
+
+    @Override
+    public Publisher<Double> createPublisher(long elements) {
+        if (elements == 0L) {
+            return Multi.createFrom().empty();
+        }
+        Multi<Long> multi = Multi.createFrom().iterable(iterate(elements));
+        return multi
+                .plug(Math.average());
+    }
+
+    @Override
+    public Publisher<Double> createFailedPublisher() {
+        return Multi.createFrom().<Long> failure(new TestException())
+                .plug(Math.average());
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/tck/CountOperatorTckTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/tck/CountOperatorTckTest.java
@@ -1,0 +1,32 @@
+package io.smallrye.mutiny.math.tck;
+
+import static io.smallrye.mutiny.math.tck.TckHelper.iterate;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.support.TestException;
+import org.reactivestreams.tck.junit5.PublisherVerification;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.math.Math;
+
+public class CountOperatorTckTest extends PublisherVerification<Long> {
+    public CountOperatorTckTest() {
+        super(new TestEnvironment(100));
+    }
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        if (elements == 0L) {
+            return Multi.createFrom().empty();
+        }
+        Multi<Long> multi = Multi.createFrom().iterable(iterate(elements));
+        return multi.plug(Math.count());
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        return Multi.createFrom().failure(new TestException())
+                .plug(Math.count());
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/tck/IndexOperatorTckTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/tck/IndexOperatorTckTest.java
@@ -1,0 +1,30 @@
+package io.smallrye.mutiny.math.tck;
+
+import static io.smallrye.mutiny.math.tck.TckHelper.iterate;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.support.TestException;
+import org.reactivestreams.tck.junit5.PublisherVerification;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.math.Math;
+import io.smallrye.mutiny.tuples.Tuple2;
+
+public class IndexOperatorTckTest extends PublisherVerification<Tuple2<Long, Long>> {
+    public IndexOperatorTckTest() {
+        super(new TestEnvironment(100));
+    }
+
+    @Override
+    public Publisher<Tuple2<Long, Long>> createPublisher(long elements) {
+        Multi<Long> multi = Multi.createFrom().iterable(iterate(elements));
+        return multi.plug(Math.index());
+    }
+
+    @Override
+    public Publisher<Tuple2<Long, Long>> createFailedPublisher() {
+        return Multi.createFrom().<Long> failure(new TestException())
+                .plug(Math.index());
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/tck/MaxOperatorTckTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/tck/MaxOperatorTckTest.java
@@ -1,0 +1,31 @@
+package io.smallrye.mutiny.math.tck;
+
+import static io.smallrye.mutiny.math.tck.TckHelper.iterate;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.support.TestException;
+import org.reactivestreams.tck.junit5.PublisherVerification;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.math.Math;
+
+public class MaxOperatorTckTest extends PublisherVerification<Long> {
+    public MaxOperatorTckTest() {
+        super(new TestEnvironment(100));
+    }
+
+    // NOTE: It works as the upstream generates always increasing numbers.
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        Multi<Long> multi = Multi.createFrom().iterable(iterate(elements));
+        return multi.plug(Math.max());
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        return Multi.createFrom().<Long> failure(new TestException())
+                .plug(Math.max());
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/tck/MedianTckTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/tck/MedianTckTest.java
@@ -1,0 +1,30 @@
+package io.smallrye.mutiny.math.tck;
+
+import static io.smallrye.mutiny.math.tck.TckHelper.iterate;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.support.TestException;
+import org.reactivestreams.tck.junit5.PublisherVerification;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.math.Math;
+
+public class MedianTckTest extends PublisherVerification<Double> {
+    public MedianTckTest() {
+        super(new TestEnvironment(100));
+    }
+
+    @Override
+    public Publisher<Double> createPublisher(long elements) {
+        Multi<Long> multi = Multi.createFrom().iterable(iterate(elements));
+        return multi
+                .plug(Math.median());
+    }
+
+    @Override
+    public Publisher<Double> createFailedPublisher() {
+        return Multi.createFrom().<Long> failure(new TestException())
+                .plug(Math.median());
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/tck/MinOperatorTckTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/tck/MinOperatorTckTest.java
@@ -1,0 +1,32 @@
+package io.smallrye.mutiny.math.tck;
+
+import static io.smallrye.mutiny.math.tck.TckHelper.iterate;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.support.TestException;
+import org.reactivestreams.tck.junit5.PublisherVerification;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.math.Math;
+
+public class MinOperatorTckTest extends PublisherVerification<Long> {
+    public MinOperatorTckTest() {
+        super(new TestEnvironment(100));
+    }
+
+    // NOTE: It works as the upstream generates always increasing numbers.
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        Multi<Long> multi = Multi.createFrom().iterable(iterate(elements))
+                .map(l -> l * -1);
+        return multi.plug(Math.min());
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        return Multi.createFrom().<Long> failure(new TestException())
+                .plug(Math.min());
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/tck/StatisticsTckTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/tck/StatisticsTckTest.java
@@ -1,0 +1,33 @@
+package io.smallrye.mutiny.math.tck;
+
+import static io.smallrye.mutiny.math.tck.TckHelper.iterate;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.support.TestException;
+import org.reactivestreams.tck.junit5.PublisherVerification;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.math.Math;
+import io.smallrye.mutiny.math.Statistic;
+
+public class StatisticsTckTest extends PublisherVerification<Statistic<Long>> {
+    public StatisticsTckTest() {
+        super(new TestEnvironment(100));
+    }
+
+    @Override
+    public Publisher<Statistic<Long>> createPublisher(long elements) {
+        Multi<Long> multi = Multi.createFrom().iterable(iterate(elements));
+        return multi
+                .plug(Math.statistics())
+                .skip().where(s -> s.getMin() == null); // Skip the value send on empty streams
+    }
+
+    @Override
+    public Publisher<Statistic<Long>> createFailedPublisher() {
+        return Multi.createFrom().<Long> failure(new TestException())
+                .plug(Math.statistics())
+                .skip().where(s -> s.getMin() == null);
+    }
+}

--- a/math/src/test/java/io/smallrye/mutiny/math/tck/TckHelper.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/tck/TckHelper.java
@@ -1,0 +1,87 @@
+package io.smallrye.mutiny.math.tck;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public final class TckHelper {
+
+    private TckHelper() {
+        // avoid direct instantiation
+    }
+
+    public static Iterable<Long> iterate(long elements) {
+        return iterate(elements > Integer.MAX_VALUE, elements);
+    }
+
+    public static Iterable<Long> iterate(boolean useInfinite, long elements) {
+        return useInfinite ? new InfiniteRange() : new FiniteRange(elements);
+    }
+
+    static final class FiniteRange implements Iterable<Long> {
+        final long end;
+
+        FiniteRange(long end) {
+            this.end = end;
+        }
+
+        @Override
+        public Iterator<Long> iterator() {
+            return new FiniteRangeIterator(end);
+        }
+
+        static final class FiniteRangeIterator implements Iterator<Long> {
+            final long end;
+            long count;
+
+            FiniteRangeIterator(long end) {
+                this.end = end;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return count != end;
+            }
+
+            @Override
+            public Long next() {
+                long c = count;
+                if (c != end) {
+                    count = c + 1;
+                    return c;
+                }
+                throw new NoSuchElementException();
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        }
+    }
+
+    static final class InfiniteRange implements Iterable<Long> {
+        @Override
+        public Iterator<Long> iterator() {
+            return new InfiniteRangeIterator();
+        }
+
+        static final class InfiniteRangeIterator implements Iterator<Long> {
+            long count;
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Long next() {
+                return count++;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <module>reactive-streams-junit5-tck</module>
         <module>kotlin</module>
         <module>bom</module>
+        <module>math</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Provides:

* count - emits the number of items emitted by the upstream
* index - emits `Tuple2<Long, T>` for each item from the upstream. The first element of the tuple is the index (0-based), and the second if the item
* min / max - emits the min/max item from the upstream, using Java comparator
* top(x) - emits the top x items from the upstream, a new ranking is emitted every time it changes.
* sum - emits the sum of all the items emitted by the upstream
* average - emits the average of all the items emitted by the upstream
