### PR TITLE
Fix race condition in test

### DIFF
--- a/math/src/main/java/io/smallrye/mutiny/math/MaxOperator.java
+++ b/math/src/main/java/io/smallrye/mutiny/math/MaxOperator.java
@@ -1,15 +1,17 @@
 package io.smallrye.mutiny.math;
 
-import java.util.function.Function;
-
 import io.smallrye.mutiny.Multi;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 /**
  * Max operator emitting the max of the emitted items from upstream.
  * If the upstream emits a failure, the failure is propagated.
- *
+ * <p>
  * It only emits the maximum if the received item is larger than the previously emitted maxmimum.
- *
+ * <p>
  * Note that this operator relies on {@link Comparable}.
  *
  * @param <T> type of the incoming items.
@@ -17,17 +19,26 @@ import io.smallrye.mutiny.Multi;
 public class MaxOperator<T extends Comparable<T>>
         implements Function<Multi<T>, Multi<T>> {
 
-    private T max = null;
+    private final AtomicReference<T> max = new AtomicReference<>();
 
     @Override
     public Multi<T> apply(Multi<T> multi) {
         return multi
                 .onItem().transformToMultiAndConcatenate(item -> {
-                    if (max == null || max.compareTo(item) < 0) {
-                        max = item;
-                        return Multi.createFrom().item(max);
+                    if (max.compareAndSet(null, item)) {
+                        return Multi.createFrom().item(item);
                     }
+
+                    if (item == max.updateAndGet(t -> {
+                        if (t.compareTo(item) < 0) {
+                            return item;
+                        }
+                        return t;
+                    })) {
+                        return Multi.createFrom().item(item);
+                    }
+
                     return Multi.createFrom().empty();
-                });
+                }).skip().repetitions();
     }
 }

--- a/math/src/test/java/io/smallrye/mutiny/math/AverageOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/AverageOperatorTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.math;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
@@ -56,7 +57,7 @@ public class AverageOperatorTest {
         Assertions.assertEquals(17.0 / 6, average);
     }
 
-    @Test
+    @RepeatedTest(1000)
     public void testWithItemsAndFailure() {
         AssertSubscriber<Double> subscriber = Multi.createBy().concatenating().streams(
                 Multi.createFrom().items(1L, 2L, 3L, 4L, 2L),

--- a/math/src/test/java/io/smallrye/mutiny/math/AverageOperatorWithDoubleTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/AverageOperatorWithDoubleTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.math;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
@@ -56,7 +57,7 @@ public class AverageOperatorWithDoubleTest {
         Assertions.assertEquals(17.0 / 6, average);
     }
 
-    @Test
+    @RepeatedTest(1000)
     public void testWithItemsAndFailure() {
         AssertSubscriber<Double> subscriber = Multi.createBy().concatenating().streams(
                 Multi.createFrom().items(1.0, 2.0, 3.0, 4.0, 2.0),

--- a/math/src/test/java/io/smallrye/mutiny/math/AverageOperatorWithIntegerTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/AverageOperatorWithIntegerTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.math;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
@@ -56,7 +57,7 @@ public class AverageOperatorWithIntegerTest {
         Assertions.assertEquals(17.0 / 6, average);
     }
 
-    @Test
+    @RepeatedTest(1000)
     public void testWithItemsAndFailure() {
         AssertSubscriber<Double> subscriber = Multi.createBy().concatenating().streams(
                 Multi.createFrom().items(1, 2, 3, 4, 2),

--- a/math/src/test/java/io/smallrye/mutiny/math/CountOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/CountOperatorTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.math;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
@@ -57,7 +58,7 @@ public class CountOperatorTest {
         Assertions.assertEquals(5, count);
     }
 
-    @Test
+    @RepeatedTest(1000)
     public void testWithItemsAndFailure() {
         AssertSubscriber<Long> subscriber = Multi.createBy().concatenating().streams(
                 Multi.createFrom().items("a", "b", "c", "d", "e"),

--- a/math/src/test/java/io/smallrye/mutiny/math/IndexOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/IndexOperatorTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.math;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
@@ -58,7 +59,7 @@ public class IndexOperatorTest {
         Assertions.assertEquals(Tuple2.of(4L, "e"), index);
     }
 
-    @Test
+    @RepeatedTest(1000)
     public void testWithItemsAndFailure() {
         AssertSubscriber<Tuple2<Long, String>> subscriber = Multi.createBy().concatenating().streams(
                 Multi.createFrom().items("a", "b", "c", "d", "e"),

--- a/math/src/test/java/io/smallrye/mutiny/math/MedianOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/MedianOperatorTest.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
@@ -104,7 +105,7 @@ public class MedianOperatorTest {
                 .assertItems(6.0, 3.5, 2.0, 3.5, 3.0, 2.5);
     }
 
-    @Test
+    @RepeatedTest(1000)
     public void testWithItemsAndFailure() {
         AssertSubscriber<Double> subscriber = Multi.createBy().concatenating().streams(
                 Multi.createFrom().items(6, 1, 2, 5, 3, 1),

--- a/math/src/test/java/io/smallrye/mutiny/math/MinOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/MinOperatorTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.math;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
@@ -56,12 +57,11 @@ public class MinOperatorTest {
         Assertions.assertEquals("a", min);
     }
 
-    @Test
+    @RepeatedTest(1000)
     public void testWithItemsAndFailure() {
-        AssertSubscriber<String> subscriber = Multi.createBy().concatenating().streams(
-                Multi.createFrom().items("e", "b", "c", "c", "a", "e", "a", "v", "x"),
-                Multi.createFrom().failure(new Exception("boom")))
-                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+        AssertSubscriber<String> subscriber = Multi.createFrom().items("e", "b", "c", "c", "a", "e", "a", "v", "x")
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .onCompletion().failWith(new Exception("boom"))
                 .plug(Math.min())
                 .subscribe().withSubscriber(AssertSubscriber.create(3));
 

--- a/math/src/test/java/io/smallrye/mutiny/math/StatisticOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/StatisticOperatorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
@@ -114,7 +115,7 @@ public class StatisticOperatorTest {
         assertThat(statistics.getKurtosis()).isCloseTo(-1.152, Offset.offset(0.001));
     }
 
-    @Test
+    @RepeatedTest(1000)
     public void testWithItemsAndFailure() {
         AssertSubscriber<Statistic<Long>> subscriber = Multi.createBy().concatenating().streams(
                 Multi.createFrom().items(1L, 2L, 3L, 4L, 2L),

--- a/math/src/test/java/io/smallrye/mutiny/math/SumOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/SumOperatorTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.mutiny.math;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
@@ -84,7 +85,7 @@ public class SumOperatorTest {
                 .assertItems(1.1, 3.1, 6.6, 10.6, 15.6, 21.6);
     }
 
-    @Test
+    @RepeatedTest(1000)
     public void testWithItemsAndFailure() {
         AssertSubscriber<Double> subscriber = Multi.createBy().concatenating().streams(
                 Multi.createFrom().items(1, 2, 3, 4, 5, 6),

--- a/math/src/test/java/io/smallrye/mutiny/math/TopOperatorTest.java
+++ b/math/src/test/java/io/smallrye/mutiny/math/TopOperatorTest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
@@ -77,7 +78,7 @@ public class TopOperatorTest {
                 .assertItems(list("a"), list("b", "a"), list("c", "b", "a"));
     }
 
-    @Test
+    @RepeatedTest(1000)
     public void testWithItemsAndFailure() {
         AssertSubscriber<List<String>> subscriber = Multi.createBy().concatenating().streams(
                 Multi.createFrom().items("a", "b", "a", "e", "f", "b", "g", "g", "e", "z"),


### PR DESCRIPTION
Rewrite some of the tests to avoid race conditions when waiting for items vs. terminal events. 
These tests are now repeated 1000 times.