### PR TITLE
New Uni join API

### DIFF
--- a/documentation/src/main/jekyll/_data/categories.yml
+++ b/documentation/src/main/jekyll/_data/categories.yml
@@ -12,6 +12,7 @@
 
 - name: Operators
   guides:
+    - joining-unis
     - merge-concat
     - collecting-items
     - combining-items

--- a/documentation/src/main/jekyll/_data/guides.yml
+++ b/documentation/src/main/jekyll/_data/guides.yml
@@ -231,6 +231,16 @@ combining-items:
     - beginner
   related:
     - guide: merge-concat
+    - guide: joining-unis
+
+joining-unis:
+  title: Joining several unis
+  text: Learn how to join several unis, collect results or pick the first one.
+  labels:
+    - beginner
+  related:
+    - guide: combining-items
+    - guide: merge-concat
 
 converters:
   title: Using other reactive programming libraries

--- a/documentation/src/main/jekyll/guides/joining-unis.adoc
+++ b/documentation/src/main/jekyll/guides/joining-unis.adoc
@@ -1,0 +1,68 @@
+:page-layout: guides
+:page-guide-id: joining-unis
+:page-liquid:
+:include_dir: ../../../../src/test/java/guides/operators
+:imagesdir: ../assets/images
+
+A `Uni` represents an operation that either emits a value or a failure.
+Examples of operations that fit into a `Uni` include: HTTP client requests, database `insert` queries, sending messages to a broker, etc.
+
+It is common to trigger several _concurrent_ operations, then _join_ on the results.
+For instance you can make HTTP requests to 3 different HTTP APIs, then collect all HTTP responses.
+Or you can just take the response from the one who was the fastest.
+
+`Uni` offers the `join` group to assemble all results from a list of `Uni`, pick the first one that terminates, or pick the first one that terminates with a value.
+
+== Joining multiple unis
+
+Given multiple `Uni`, you can join them all and obtain a `Uni` that emits a list of values:
+
+[source, java, indent=0]
+----
+include::{include_dir}/UniJoinTest.java[tag=join-all]
+----
+
+The assembled values are in the same order as the list of unis.
+The last call to `.andCollectFailures()` specifies that if one or several `Uni` fail, then the failures are assembled in a `CompositeException`.
+
+Sometimes you just want to _fail fast_ if any of the `Uni` fails, and not wait for all unis to terminate:
+
+[source, java, indent=0]
+----
+include::{include_dir}/UniJoinTest.java[tag=join-all-ff]
+----
+
+When any `Uni` fails, then the failure is directly forwarded as a failure of `res`.
+
+== Joining on the first Uni
+
+In some cases you do not want to have all the results but just that of the first `Uni` to respond.
+There are actually 2 different cases, depending on whether you want the result of the first `Uni` that emits a value, or just the result of the first `Uni` to terminate.
+
+If you want to get the first `Uni` that terminates:
+
+[source, java, indent=0]
+----
+include::{include_dir}/UniJoinTest.java[tag=join-first]
+----
+
+If you want to have the first `Uni` that emits a value (and forget the first failures), then:
+
+[source, java, indent=0]
+----
+include::{include_dir}/UniJoinTest.java[tag=join-first-withitem]
+----
+
+When all unis fail then `res` fails with a `CompositeException` that reports all failures.
+
+== Using a builder object
+
+There are situations where it can be more convenient to gather the unis to join in an iterative fashion.
+For this purpose you can use a builder object, as in:
+
+[source, java, indent=0]
+----
+include::{include_dir}/UniJoinTest.java[tag=builder]
+----
+
+The builder offers `joinAll()` and `joinFirst()` methods.

--- a/documentation/src/test/java/guides/operators/UniJoinTest.java
+++ b/documentation/src/test/java/guides/operators/UniJoinTest.java
@@ -1,0 +1,54 @@
+package guides.operators;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.groups.UniJoin;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
+class UniJoinTest {
+
+    @Test
+    void joinAll() {
+        // tag::join-all[]
+        Uni<Integer> a = Uni.createFrom().item(1);
+        Uni<Integer> b = Uni.createFrom().item(2);
+        Uni<Integer> c = Uni.createFrom().item(3);
+
+        Uni<List<Integer>> res = Uni.join().all(a, b, c).andCollectFailures();
+        // end::join-all[]
+
+        // tag::join-all-ff[]
+        res = Uni.join().all(a, b, c).andFailFast();
+        // end::join-all-ff[]
+    }
+
+    void joinFirst(Uni<Integer> a, Uni<Integer> b, Uni<Integer> c) {
+
+        // tag::join-first[]
+        Uni<Integer> res = Uni.join().first(a, b, c).toTerminate();
+        // end::join-first[]
+
+        // tag::join-first-withitem[]
+        res = Uni.join().first(a, b, c).withItem();
+        // end::join-first-withitem[]
+
+        Supplier<Uni<Integer>> supplier = () -> Uni.createFrom().item(63);
+        boolean someCondition = false;
+
+        // tag::builder[]
+        UniJoin.Builder<Integer> builder = Uni.join().builder();
+
+        while (someCondition) {
+            Uni<Integer> uni = supplier.get();
+            builder.add(uni);
+        }
+
+        Uni<List<Integer>> all = builder.joinAll().andFailFast();
+
+        Uni<Integer> first = builder.joinFirst().withItem();
+        // end::builder[]
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -740,6 +740,6 @@ public interface Uni<T> {
     Uni<T> log();
 
     static UniJoin join() {
-        return new UniJoin();
+        return UniJoin.SHARED_INSTANCE;
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -307,7 +307,7 @@ public interface Uni<T> {
 
     /**
      * Configure memoization of the {@link Uni} item or failure.
-     * 
+     *
      * @return the object to configure memoization
      * @apiNote This is an experimental API
      */
@@ -432,7 +432,7 @@ public interface Uni<T> {
     /**
      * Once the observed {@code Uni} emits an item, execute the given {@code mapper}. This mapper produces another
      * {@code Uni}. The downstream receives the events emitted by this produced {@code Uni}.
-     *
+     * <p>
      * This operation allows <em>chaining</em> asynchronous operations: when the upstream completes with an item, run
      * the mapper and emits the item (or failure) sent by the produced {@code Uni}:
      *
@@ -442,7 +442,7 @@ public interface Uni<T> {
      *         .chain(session -&gt; session.flush())
      *         .map(x -&gt; Response.ok(fruit).status(201).build());
      * </pre>
-     *
+     * <p>
      * The mapper is called with the item event of the current {@link Uni} and produces an {@link Uni}, possibly
      * using another type of item ({@code O}). The events fired by produced {@link Uni} are forwarded to the
      * {@link Uni} returned by this method.
@@ -465,7 +465,7 @@ public interface Uni<T> {
     /**
      * Once the observed {@code Uni} emits an item, execute the given {@code supplier}. This supplier produces another
      * {@code Uni}. The downstream receives the events emitted by this produced {@code Uni}.
-     *
+     * <p>
      * This operation allows <em>chaining</em> asynchronous operations: when the upstream completes with an item, run
      * the supplier and emits the item (or failure) sent by the produced {@code Uni}:
      *
@@ -475,7 +475,7 @@ public interface Uni<T> {
      *         .chain(session -&gt; session.flush())
      *         .chain(() -&gt; server.close());
      * </pre>
-     *
+     * <p>
      * The supplier ignores the item event of the current {@link Uni} and produces an {@link Uni}, possibly
      * using another type of item ({@code O}). The events fired by produced {@link Uni} are forwarded to the
      * {@link Uni} returned by this method.
@@ -601,21 +601,21 @@ public interface Uni<T> {
     /**
      * Configures actions to be performed on termination, that is, on item, on failure, or when the subscriber cancels
      * the subscription.
-     * 
+     *
      * @return the object to configure the termination actions.
      */
     UniOnTerminate<T> onTermination();
 
     /**
      * Configures actions to be performed when the subscriber cancels the subscription.
-     * 
+     *
      * @return the object to configure the cancellation actions.
      */
     UniOnCancel<T> onCancellation();
 
     /**
      * Plug a user-defined operator that does not belong to the existing Mutiny API.
-     * 
+     *
      * @param operatorProvider a function to create and bind a new operator instance, taking {@code this} {@link Uni} as a
      *        parameter and returning a new {@link Uni}. Must neither be {@code null} nor return {@code null}.
      * @param <R> the output type
@@ -630,7 +630,7 @@ public interface Uni<T> {
      * Ignore the item emitted by this {@link Uni} and replace it with another value.
      * <p>
      * This is a shortcut for {@code uni.onItem().transform(ignore -> item)}.
-     * 
+     *
      * @param item the replacement value
      * @param <O> the output type
      * @return the new {@link Uni}
@@ -669,7 +669,7 @@ public interface Uni<T> {
      * Ignore the item emitted by this {@link Uni} and replace it with {@code null}.
      * <p>
      * This is a shortcut for {@code uni.onItem().transform(ignore -> null)}.
-     * 
+     *
      * @return the new {@link Uni}
      */
     default Uni<T> replaceWithNull() {
@@ -683,7 +683,7 @@ public interface Uni<T> {
      * instead of a {@code Uni<T>}.
      * <p>
      * This is a shortcut for {@code uni.onItem().transform(ignored -> null)}.
-     * 
+     *
      * @return the new {@link Uni}
      */
     default Uni<Void> replaceWithVoid() {
@@ -692,7 +692,7 @@ public interface Uni<T> {
 
     /**
      * When this {@link Uni} emits {@code null}, replace with the value provided by the given {@link Supplier}.
-     *
+     * <p>
      * This is a shortcut for {@code uni.onItem().ifNull().continueWith(supplier)}
      *
      * @param supplier the supplier
@@ -704,7 +704,7 @@ public interface Uni<T> {
 
     /**
      * When this {@link Uni} emits {@code null}, replace with the provided value.
-     *
+     * <p>
      * This is a shortcut for {@code uni.onItem().ifNull().continueWith(value)}
      *
      * @param value the value
@@ -716,7 +716,7 @@ public interface Uni<T> {
 
     /**
      * Log events (onSubscribe, onItem, ...) as they come from the upstream or the subscriber.
-     *
+     * <p>
      * Events will be logged as long as the {@link Uni} hasn't been cancelled or terminated.
      * Logging is framework-agnostic and can be configured in the {@link Infrastructure} class.
      *
@@ -729,7 +729,7 @@ public interface Uni<T> {
     /**
      * Log events (onSubscribe, onItem, ...) as they come from the upstream or the subscriber, and derives the identifier from
      * the upstream operator class "simple name".
-     *
+     * <p>
      * Events will be logged as long as the {@link Uni} hasn't been cancelled or terminated.
      * Logging is framework-agnostic and can be configured in the {@link Infrastructure} class.
      *
@@ -738,4 +738,8 @@ public interface Uni<T> {
      * @see Infrastructure#setOperatorLogger(Infrastructure.OperatorLogger)
      */
     Uni<T> log();
+
+    static UniJoin join() {
+        return new UniJoin();
+    }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -754,6 +754,7 @@ public interface Uni<T> {
      *
      * @return the object to configure the join behavior.
      */
+    @Experimental("New API based on observations that Uni.combine() is often used with homogeneous types, and combination often just a mapping to a collection.")
     static UniJoin join() {
         return UniJoin.SHARED_INSTANCE;
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -739,6 +739,21 @@ public interface Uni<T> {
      */
     Uni<T> log();
 
+    /**
+     * Join the results from multiple {@link Uni} (e.g., collect all values, pick the first to respond, etc).
+     * <p>
+     * Here is an example where several {@link Uni} are joined, and result in a {@code Uni<List<Number>>}:
+     * 
+     * <pre>
+     * Uni<Number> a = Uni.createFrom().item(1);
+     * Uni<Number> b = Uni.createFrom().item(2L);
+     * Uni<Number> c = Uni.createFrom().item(3);
+     *
+     * Uni<List<Number>> uni = Uni.join().all(a, b, c).andCollectFailures();
+     * </pre>
+     *
+     * @return the object to configure the join behavior.
+     */
     static UniJoin join() {
         return UniJoin.SHARED_INSTANCE;
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -745,11 +745,11 @@ public interface Uni<T> {
      * Here is an example where several {@link Uni} are joined, and result in a {@code Uni<List<Number>>}:
      * 
      * <pre>
-     * Uni<Number> a = Uni.createFrom().item(1);
-     * Uni<Number> b = Uni.createFrom().item(2L);
-     * Uni<Number> c = Uni.createFrom().item(3);
+     * Uni&lt;Number&gt; a = Uni.createFrom().item(1);
+     * Uni&lt;Number&gt; b = Uni.createFrom().item(2L);
+     * Uni&lt;Number&gt; c = Uni.createFrom().item(3);
      *
-     * Uni<List<Number>> uni = Uni.join().all(a, b, c).andCollectFailures();
+     * Uni&lt;List&lt;Number&gt;&gt; uni = Uni.join().all(a, b, c).andCollectFailures();
      * </pre>
      *
      * @return the object to configure the join behavior.

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
@@ -1,0 +1,30 @@
+package io.smallrye.mutiny.groups;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.uni.builders.UniJoinAll;
+
+public class UniJoin {
+
+    @SafeVarargs
+    public final <T> Uni<List<T>> all(Uni<? extends T>... unis) {
+        return all(asList(nonNull(unis, "unis")));
+    }
+
+    public final <T> Uni<List<T>> all(List<Uni<? extends T>> unis) {
+        nonNull(unis, "unis");
+        int index = 0;
+        for (Uni<? extends T> uni : unis) {
+            if (uni == null) {
+                throw new IllegalArgumentException("The uni at index " + index + " is null");
+            }
+            index++;
+        }
+        return Infrastructure.onUniCreation(new UniJoinAll<>(unis));
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
@@ -1,5 +1,6 @@
 package io.smallrye.mutiny.groups;
 
+import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import static java.util.Arrays.asList;
 
@@ -25,8 +26,7 @@ public class UniJoin {
     }
 
     public final <T> UniJoinAllStrategy<T> all(List<Uni<? extends T>> unis) {
-        checkNoneNull(unis);
-        return new UniJoinAllStrategy<>(unis);
+        return new UniJoinAllStrategy<>(doesNotContainNull(unis, "unis"));
     }
 
     public static class UniJoinAllStrategy<T> {
@@ -52,8 +52,7 @@ public class UniJoin {
     }
 
     public final <T> UniJoinFirstStrategy<T> first(List<Uni<? extends T>> unis) {
-        checkNoneNull(unis);
-        return new UniJoinFirstStrategy<>(unis);
+        return new UniJoinFirstStrategy<>(doesNotContainNull(unis, "unis"));
     }
 
     public static class UniJoinFirstStrategy<T> {
@@ -92,17 +91,6 @@ public class UniJoin {
 
         public UniJoinFirstStrategy<T> joinFirst() {
             return UniJoin.this.first(unis);
-        }
-    }
-
-    private <T> void checkNoneNull(List<Uni<? extends T>> unis) {
-        nonNull(unis, "unis");
-        int index = 0;
-        for (Uni<? extends T> uni : unis) {
-            if (uni == null) {
-                throw new IllegalArgumentException("The uni at index " + index + " is null");
-            }
-            index++;
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
@@ -36,7 +36,17 @@ public class UniJoin {
 
     public final <T> Uni<T> first(List<Uni<? extends T>> unis) {
         checkNoneNull(unis);
-        return Infrastructure.onUniCreation(new UniJoinFirst<>(unis));
+        return Infrastructure.onUniCreation(new UniJoinFirst<>(unis, UniJoinFirst.Mode.FIRST_TO_EMIT));
+    }
+
+    @SafeVarargs
+    public final <T> Uni<T> firstWithItem(Uni<? extends T>... unis) {
+        return firstWithItem(asList(nonNull(unis, "unis")));
+    }
+
+    public final <T> Uni<T> firstWithItem(List<Uni<? extends T>> unis) {
+        checkNoneNull(unis);
+        return Infrastructure.onUniCreation(new UniJoinFirst<>(unis, UniJoinFirst.Mode.FIRST_WITH_ITEM));
     }
 
     private <T> void checkNoneNull(List<Uni<? extends T>> unis) {
@@ -69,6 +79,10 @@ public class UniJoin {
 
         public Uni<T> joinFirst() {
             return UniJoin.this.first(unis);
+        }
+
+        public Uni<T> joinFirstWithItem() {
+            return UniJoin.this.firstWithItem(unis);
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
@@ -9,6 +9,7 @@ import java.util.List;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.uni.builders.UniJoinAll;
+import io.smallrye.mutiny.operators.uni.builders.UniJoinFirst;
 
 public class UniJoin {
 
@@ -18,6 +19,21 @@ public class UniJoin {
     }
 
     public final <T> Uni<List<T>> all(List<Uni<? extends T>> unis) {
+        checkNoneNull(unis);
+        return Infrastructure.onUniCreation(new UniJoinAll<>(unis));
+    }
+
+    @SafeVarargs
+    public final <T> Uni<T> first(Uni<? extends T>... unis) {
+        return first(asList(nonNull(unis, "unis")));
+    }
+
+    public final <T> Uni<T> first(List<Uni<? extends T>> unis) {
+        checkNoneNull(unis);
+        return Infrastructure.onUniCreation(new UniJoinFirst<>(unis));
+    }
+
+    private <T> void checkNoneNull(List<Uni<? extends T>> unis) {
         nonNull(unis, "unis");
         int index = 0;
         for (Uni<? extends T> uni : unis) {
@@ -26,7 +42,6 @@ public class UniJoin {
             }
             index++;
         }
-        return Infrastructure.onUniCreation(new UniJoinAll<>(unis));
     }
 
     public <T> UniJoinBuilder<T> builder() {
@@ -44,6 +59,10 @@ public class UniJoin {
 
         public Uni<List<T>> joinAll() {
             return UniJoin.this.all(unis);
+        }
+
+        public Uni<T> joinFirst() {
+            return UniJoin.this.first(unis);
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
@@ -13,6 +13,12 @@ import io.smallrye.mutiny.operators.uni.builders.UniJoinFirst;
 
 public class UniJoin {
 
+    public static final UniJoin SHARED_INSTANCE = new UniJoin();
+
+    private UniJoin() {
+        // Do nothing
+    }
+
     @SafeVarargs
     public final <T> Uni<List<T>> all(Uni<? extends T>... unis) {
         return all(asList(nonNull(unis, "unis")));

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
@@ -154,8 +154,8 @@ public class UniJoin {
      * @param <T> the type of the {@link Uni} values
      * @return a new builder
      */
-    public <T> UniJoinBuilder<T> builder() {
-        return new UniJoinBuilder<>();
+    public <T> Builder<T> builder() {
+        return new Builder<>();
     }
 
     /**
@@ -163,7 +163,7 @@ public class UniJoin {
      *
      * @param <T> the type of the {@link Uni} values
      */
-    public class UniJoinBuilder<T> {
+    public class Builder<T> {
 
         private final List<Uni<? extends T>> unis = new ArrayList<>();
 
@@ -173,7 +173,7 @@ public class UniJoin {
          * @param uni a {@link Uni}
          * @return this builder instance
          */
-        public UniJoinBuilder<T> add(Uni<? extends T> uni) {
+        public Builder<T> add(Uni<? extends T> uni) {
             unis.add(uni);
             return this;
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
@@ -7,6 +7,7 @@ import static java.util.Arrays.asList;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.smallrye.common.annotation.Experimental;
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
@@ -16,6 +17,7 @@ import io.smallrye.mutiny.operators.uni.builders.UniJoinFirst;
 /**
  * Join multiple {@link Uni}.
  */
+@Experimental("New API based on observations that Uni.combine() is often used with homogeneous types, and combination often just a mapping to a collection.")
 public class UniJoin {
 
     public static final UniJoin SHARED_INSTANCE = new UniJoin();

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
@@ -47,23 +47,30 @@ public class UniJoin {
     }
 
     @SafeVarargs
-    public final <T> Uni<T> first(Uni<? extends T>... unis) {
+    public final <T> UniJoinFirstStrategy<T> first(Uni<? extends T>... unis) {
         return first(asList(nonNull(unis, "unis")));
     }
 
-    public final <T> Uni<T> first(List<Uni<? extends T>> unis) {
+    public final <T> UniJoinFirstStrategy<T> first(List<Uni<? extends T>> unis) {
         checkNoneNull(unis);
-        return Infrastructure.onUniCreation(new UniJoinFirst<>(unis, UniJoinFirst.Mode.FIRST_TO_EMIT));
+        return new UniJoinFirstStrategy<>(unis);
     }
 
-    @SafeVarargs
-    public final <T> Uni<T> firstWithItem(Uni<? extends T>... unis) {
-        return firstWithItem(asList(nonNull(unis, "unis")));
-    }
+    public static class UniJoinFirstStrategy<T> {
 
-    public final <T> Uni<T> firstWithItem(List<Uni<? extends T>> unis) {
-        checkNoneNull(unis);
-        return Infrastructure.onUniCreation(new UniJoinFirst<>(unis, UniJoinFirst.Mode.FIRST_WITH_ITEM));
+        private final List<Uni<? extends T>> unis;
+
+        private UniJoinFirstStrategy(List<Uni<? extends T>> unis) {
+            this.unis = unis;
+        }
+
+        public Uni<T> toEmit() {
+            return Infrastructure.onUniCreation(new UniJoinFirst<>(unis, UniJoinFirst.Mode.FIRST_TO_EMIT));
+        }
+
+        public Uni<T> withItem() {
+            return Infrastructure.onUniCreation(new UniJoinFirst<>(unis, UniJoinFirst.Mode.FIRST_WITH_ITEM));
+        }
     }
 
     public <T> UniJoinBuilder<T> builder() {
@@ -83,12 +90,8 @@ public class UniJoin {
             return UniJoin.this.all(unis);
         }
 
-        public Uni<T> joinFirst() {
+        public UniJoinFirstStrategy<T> joinFirst() {
             return UniJoin.this.first(unis);
-        }
-
-        public Uni<T> joinFirstWithItem() {
-            return UniJoin.this.firstWithItem(unis);
         }
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
@@ -3,6 +3,7 @@ package io.smallrye.mutiny.groups;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import static java.util.Arrays.asList;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import io.smallrye.mutiny.Uni;
@@ -26,5 +27,23 @@ public class UniJoin {
             index++;
         }
         return Infrastructure.onUniCreation(new UniJoinAll<>(unis));
+    }
+
+    public <T> UniJoinBuilder<T> builder() {
+        return new UniJoinBuilder<>();
+    }
+
+    public class UniJoinBuilder<T> {
+
+        private final List<Uni<? extends T>> unis = new ArrayList<>();
+
+        public UniJoinBuilder<T> add(Uni<? extends T> uni) {
+            unis.add(uni);
+            return this;
+        }
+
+        public Uni<List<T>> joinAll() {
+            return UniJoin.this.all(unis);
+        }
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
@@ -7,11 +7,15 @@ import static java.util.Arrays.asList;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.uni.builders.UniJoinAll;
 import io.smallrye.mutiny.operators.uni.builders.UniJoinFirst;
 
+/**
+ * Join multiple {@link Uni}.
+ */
 public class UniJoin {
 
     public static final UniJoin SHARED_INSTANCE = new UniJoin();
@@ -20,76 +24,175 @@ public class UniJoin {
         // Do nothing
     }
 
+    /**
+     * Join multiple {@link Uni} references and emit a list of values, this is a convenience delegate method for
+     * {@link #all(List)}.
+     *
+     * @param unis the list of {@link Uni} to join, must not be {@code null}, must not contain any {@code null} reference
+     * @param <T> the type of the {@link Uni} values
+     * @return the object to configure the failure management strategy
+     */
     @SafeVarargs
-    public final <T> UniJoinAllStrategy<T> all(Uni<? extends T>... unis) {
+    public final <T> JoinAllStrategy<T> all(Uni<? extends T>... unis) {
         return all(asList(nonNull(unis, "unis")));
     }
 
-    public final <T> UniJoinAllStrategy<T> all(List<Uni<? extends T>> unis) {
-        return new UniJoinAllStrategy<>(doesNotContainNull(unis, "unis"));
+    /**
+     * Join multiple {@link Uni} references and emit a list of values.
+     * <p>
+     * The resulting list of values is in order of the list of {@link Uni}.
+     * What happens when any of the {@link Uni} emits a failure rather than a value is specified by a subsequent call
+     * to any of the methods in {@link JoinAllStrategy}.
+     *
+     * @param unis the list of {@link Uni} to join, must not be {@code null}, must not contain any {@code null} reference
+     * @param <T> the type of the {@link Uni} values
+     * @return the object to configure the failure management strategy
+     */
+    public final <T> JoinAllStrategy<T> all(List<Uni<? extends T>> unis) {
+        return new JoinAllStrategy<>(doesNotContainNull(unis, "unis"));
     }
 
-    public static class UniJoinAllStrategy<T> {
+    /**
+     * Defines how to deal with failures while joining {@link Uni} references with {@link UniJoin#all(List)}.
+     *
+     * @param <T> the type of the {@link Uni} values
+     */
+    public static class JoinAllStrategy<T> {
 
         private final List<Uni<? extends T>> unis;
 
-        private UniJoinAllStrategy(List<Uni<? extends T>> unis) {
+        private JoinAllStrategy(List<Uni<? extends T>> unis) {
             this.unis = unis;
         }
 
+        /**
+         * Wait for all {@link Uni} references to terminate, and collect all failures in a
+         * {@link io.smallrye.mutiny.CompositeException}.
+         *
+         * @return a new {@link Uni}
+         */
         public Uni<List<T>> andCollectFailures() {
             return Infrastructure.onUniCreation(new UniJoinAll<>(unis, UniJoinAll.Mode.COLLECT_FAILURES));
         }
 
+        /**
+         * Immediately forward the first failure from any of the {@link Uni}, and cancel the remaining {@link Uni}
+         * subscriptions, ignoring eventual subsequent failures.
+         *
+         * @return a new {@link Uni}
+         */
         public Uni<List<T>> andFailFast() {
             return Infrastructure.onUniCreation(new UniJoinAll<>(unis, UniJoinAll.Mode.FAIL_FAST));
         }
     }
 
+    /**
+     * Join multiple {@link Uni} and emit the result from the first one to emit a signal, or the first one with a value.
+     * This is a convenience delegate method for {@link #first(List)}.
+     *
+     * @param unis the list of {@link Uni} to join, must not be {@code null}, must not contain any {@code null} reference
+     * @param <T> the type of the {@link Uni} values
+     * @return the object to configure the failure management strategy
+     */
     @SafeVarargs
-    public final <T> UniJoinFirstStrategy<T> first(Uni<? extends T>... unis) {
+    public final <T> JoinFirstStrategy<T> first(Uni<? extends T>... unis) {
         return first(asList(nonNull(unis, "unis")));
     }
 
-    public final <T> UniJoinFirstStrategy<T> first(List<Uni<? extends T>> unis) {
-        return new UniJoinFirstStrategy<>(doesNotContainNull(unis, "unis"));
+    /**
+     * Join multiple {@link Uni} and emit the result from the first one to emit a signal, or the first one with a value.
+     * <p>
+     * What happens when any of the {@link Uni} emits a failure rather than a value is specified by a subsequent call
+     * to any of the methods in {@link JoinFirstStrategy}.
+     *
+     * @param unis the list of {@link Uni} to join, must not be {@code null}, must not contain any {@code null} reference
+     * @param <T> the type of the {@link Uni} values
+     * @return the object to configure the failure management strategy
+     */
+    public final <T> JoinFirstStrategy<T> first(List<Uni<? extends T>> unis) {
+        return new JoinFirstStrategy<>(doesNotContainNull(unis, "unis"));
     }
 
-    public static class UniJoinFirstStrategy<T> {
+    /**
+     * Defines how to deal with failures while joining {@link Uni} references with {@link UniJoin#first(List)}}.
+     *
+     * @param <T> the type of the {@link Uni} values
+     */
+    public static class JoinFirstStrategy<T> {
 
         private final List<Uni<? extends T>> unis;
 
-        private UniJoinFirstStrategy(List<Uni<? extends T>> unis) {
+        private JoinFirstStrategy(List<Uni<? extends T>> unis) {
             this.unis = unis;
         }
 
-        public Uni<T> toEmit() {
+        /**
+         * Forward the value or failure from the first {@link Uni} to terminate.
+         *
+         * @return a new {@link Uni}
+         */
+        public Uni<T> toTerminate() {
             return Infrastructure.onUniCreation(new UniJoinFirst<>(unis, UniJoinFirst.Mode.FIRST_TO_EMIT));
         }
 
+        /**
+         * Forward the value from the first {@link Uni} to terminate with a value.
+         * <p>
+         * When all {@link Uni} references fail then failures are collected into a {@link CompositeException},
+         * which is then forwarded by the returned {@link Uni}.
+         *
+         * @return a new {@link Uni}
+         */
         public Uni<T> withItem() {
             return Infrastructure.onUniCreation(new UniJoinFirst<>(unis, UniJoinFirst.Mode.FIRST_WITH_ITEM));
         }
     }
 
+    /**
+     * Provide a builder to assemble the {@link Uni} references to join.
+     *
+     * @param <T> the type of the {@link Uni} values
+     * @return a new builder
+     */
     public <T> UniJoinBuilder<T> builder() {
         return new UniJoinBuilder<>();
     }
 
+    /**
+     * Builder to assemble {@link Uni} references to be joined.
+     *
+     * @param <T> the type of the {@link Uni} values
+     */
     public class UniJoinBuilder<T> {
 
         private final List<Uni<? extends T>> unis = new ArrayList<>();
 
+        /**
+         * Add a {@link Uni}.
+         *
+         * @param uni a {@link Uni}
+         * @return this builder instance
+         */
         public UniJoinBuilder<T> add(Uni<? extends T> uni) {
             unis.add(uni);
             return this;
         }
 
-        public UniJoinAllStrategy<T> joinAll() {
+        /**
+         * Join all {@link Uni} references.
+         *
+         * @return the object to configure the failure management strategy
+         */
+        public JoinAllStrategy<T> joinAll() {
             return UniJoin.this.all(unis);
         }
 
-        public UniJoinFirstStrategy<T> joinFirst() {
+        /**
+         * Join on one among the {@link Uni} references.
+         *
+         * @return the object to configure the failure management strategy
+         */
+        public JoinFirstStrategy<T> joinFirst() {
             return UniJoin.this.first(unis);
         }
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinAll.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinAll.java
@@ -1,0 +1,92 @@
+package io.smallrye.mutiny.operators.uni.builders;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.AbstractUni;
+import io.smallrye.mutiny.subscription.UniSubscriber;
+import io.smallrye.mutiny.subscription.UniSubscription;
+
+public class UniJoinAll<T> extends AbstractUni<List<T>> {
+
+    private final List<Uni<? extends T>> unis;
+
+    public UniJoinAll(List<Uni<? extends T>> unis) {
+        this.unis = unis;
+    }
+
+    @Override
+    public void subscribe(UniSubscriber<? super List<T>> subscriber) {
+        UniJoinAllSubscription joinAllSubscription = new UniJoinAllSubscription(subscriber);
+        subscriber.onSubscribe(joinAllSubscription);
+        joinAllSubscription.triggerSubscriptions();
+    }
+
+    private class UniJoinAllSubscription implements UniSubscription {
+
+        private final UniSubscriber<? super List<T>> subscriber;
+
+        private final AtomicReferenceArray<UniSubscription> subscriptions = new AtomicReferenceArray<>(unis.size());
+        private final AtomicBoolean cancelled = new AtomicBoolean();
+
+        private final AtomicReferenceArray<T> items = new AtomicReferenceArray<>(unis.size());
+        private final AtomicInteger itemsCount = new AtomicInteger();
+
+        public UniJoinAllSubscription(UniSubscriber<? super List<T>> subscriber) {
+            this.subscriber = subscriber;
+        }
+
+        public void triggerSubscriptions() {
+            for (int i = 0; i < unis.size() && !cancelled.get(); i++) {
+                int index = i;
+                Uni<? extends T> uni = unis.get(i);
+                uni.onSubscription()
+                        .invoke(subscription -> subscriptions.set(index, subscription))
+                        .subscribe().with(item -> this.onItem(index, item), this::onFailure);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            cancelled.set(true);
+            cancelSubscriptions();
+        }
+
+        private void cancelSubscriptions() {
+            for (int i = 0; i < unis.size(); i++) {
+                UniSubscription sub = subscriptions.get(i);
+                if (sub != null) {
+                    sub.cancel();
+                }
+            }
+        }
+
+        private void onItem(int index, T item) {
+            if (!cancelled.get()) {
+                items.set(index, item);
+                if (itemsCount.incrementAndGet() == unis.size()) {
+                    cancelled.set(true);
+                    ArrayList<T> result = new ArrayList<>(unis.size());
+                    for (int i = 0; i < unis.size(); i++) {
+                        result.add(items.get(i));
+                    }
+                    subscriber.onItem(result);
+                }
+            }
+        }
+
+        private void onFailure(Throwable failure) {
+            if (cancelled.compareAndSet(false, true)) {
+                cancelSubscriptions();
+                subscriber.onFailure(failure);
+            } else {
+                Infrastructure.handleDroppedException(failure);
+            }
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinFirst.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinFirst.java
@@ -1,0 +1,80 @@
+package io.smallrye.mutiny.operators.uni.builders;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.AbstractUni;
+import io.smallrye.mutiny.subscription.UniSubscriber;
+import io.smallrye.mutiny.subscription.UniSubscription;
+
+public class UniJoinFirst<T> extends AbstractUni<T> {
+
+    private final List<Uni<? extends T>> unis;
+
+    public UniJoinFirst(List<Uni<? extends T>> unis) {
+        this.unis = unis;
+    }
+
+    @Override
+    public void subscribe(UniSubscriber<? super T> subscriber) {
+        UniJoinFirstSubscription joinAllSubscription = new UniJoinFirstSubscription(subscriber);
+        subscriber.onSubscribe(joinAllSubscription);
+        joinAllSubscription.triggerSubscriptions();
+    }
+
+    private class UniJoinFirstSubscription implements UniSubscription {
+
+        private final UniSubscriber<? super T> subscriber;
+
+        private final AtomicReferenceArray<UniSubscription> subscriptions = new AtomicReferenceArray<>(unis.size());
+        private final AtomicBoolean cancelled = new AtomicBoolean();
+
+        public UniJoinFirstSubscription(UniSubscriber<? super T> subscriber) {
+            this.subscriber = subscriber;
+        }
+
+        public void triggerSubscriptions() {
+            for (int i = 0; i < unis.size() && !cancelled.get(); i++) {
+                int index = i;
+                Uni<? extends T> uni = unis.get(i);
+                uni.onSubscription()
+                        .invoke(subscription -> subscriptions.set(index, subscription))
+                        .subscribe().with(item -> this.onItem(index, item), this::onFailure);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            cancelled.set(true);
+            cancelSubscriptions();
+        }
+
+        private void cancelSubscriptions() {
+            for (int i = 0; i < unis.size(); i++) {
+                UniSubscription sub = subscriptions.get(i);
+                if (sub != null) {
+                    sub.cancel();
+                }
+            }
+        }
+
+        private void onItem(int index, T item) {
+            if (cancelled.compareAndSet(false, true)) {
+                cancelSubscriptions();
+                subscriber.onItem(item);
+            }
+        }
+
+        private void onFailure(Throwable failure) {
+            if (cancelled.compareAndSet(false, true)) {
+                cancelSubscriptions();
+                subscriber.onFailure(failure);
+            } else {
+                Infrastructure.handleDroppedException(failure);
+            }
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinFirst.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinFirst.java
@@ -1,17 +1,17 @@
 package io.smallrye.mutiny.operators.uni.builders;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.AbstractUni;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 
 public class UniJoinFirst<T> extends AbstractUni<T> {
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinFirst.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinFirst.java
@@ -42,7 +42,7 @@ public class UniJoinFirst<T> extends AbstractUni<T> {
                 Uni<? extends T> uni = unis.get(i);
                 uni.onSubscription()
                         .invoke(subscription -> subscriptions.set(index, subscription))
-                        .subscribe().with(item -> this.onItem(index, item), this::onFailure);
+                        .subscribe().with(this::onItem, this::onFailure);
             }
         }
 
@@ -61,7 +61,7 @@ public class UniJoinFirst<T> extends AbstractUni<T> {
             }
         }
 
-        private void onItem(int index, T item) {
+        private void onItem(T item) {
             if (cancelled.compareAndSet(false, true)) {
                 cancelSubscriptions();
                 subscriber.onItem(item);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinFirst.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinFirst.java
@@ -91,10 +91,14 @@ public class UniJoinFirst<T> extends AbstractUni<T> {
                     }
                     break;
                 case FIRST_WITH_ITEM:
-                    failures.add(failure);
-                    if (failures.size() == unis.size()) {
-                        cancelled.set(true);
-                        subscriber.onFailure(new CompositeException(failures));
+                    if (!cancelled.get()) {
+                        failures.add(failure);
+                        if (failures.size() == unis.size()) {
+                            cancelled.set(true);
+                            subscriber.onFailure(new CompositeException(failures));
+                        }
+                    } else {
+                        Infrastructure.handleDroppedException(failure);
                     }
                     break;
             }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
@@ -252,7 +252,7 @@ class UniJoinTest {
             Uni<Integer> b = Uni.createFrom().item(2);
             Uni<Integer> c = Uni.createFrom().item(3);
 
-            Uni<Integer> uni = Uni.join().first(a, b, c).toEmit();
+            Uni<Integer> uni = Uni.join().first(a, b, c).toTerminate();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertCompleted().assertItem(1);
@@ -311,7 +311,7 @@ class UniJoinTest {
 
             UniJoin.UniJoinBuilder<Integer> builder = Uni.join().builder();
             builder.add(a).add(b).add(c);
-            Uni<Integer> uni = builder.joinFirst().toEmit();
+            Uni<Integer> uni = builder.joinFirst().toTerminate();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertCompleted().assertItem(1);
@@ -327,7 +327,7 @@ class UniJoinTest {
                 // Do nothing
             });
 
-            Uni<Integer> uni = Uni.join().first(a, b, c).toEmit();
+            Uni<Integer> uni = Uni.join().first(a, b, c).toTerminate();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertCompleted().assertItem(2);
@@ -343,7 +343,7 @@ class UniJoinTest {
                 // Do nothing
             });
 
-            Uni<Integer> uni = Uni.join().first(a, b, c).toEmit();
+            Uni<Integer> uni = Uni.join().first(a, b, c).toTerminate();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertFailedWith(IOException.class, "boom");
@@ -355,7 +355,7 @@ class UniJoinTest {
             Uni<Integer> b = Uni.createFrom().item(2);
             Uni<Integer> c = Uni.createFrom().item(3);
 
-            Uni<Integer> uni = Uni.join().first(a, b, c).toEmit();
+            Uni<Integer> uni = Uni.join().first(a, b, c).toTerminate();
             UniOnItemSpy<Integer> spy = Spy.onItem(uni);
 
             UniAssertSubscriber<Integer> sub = new UniAssertSubscriber<>(true);
@@ -381,7 +381,7 @@ class UniJoinTest {
             UniOnCancellationSpy<Integer> sb = Spy.onCancellation(b);
             UniOnCancellationSpy<Integer> sc = Spy.onCancellation(c);
 
-            Uni<Integer> uni = Uni.join().first(sa, sb, sc).toEmit();
+            Uni<Integer> uni = Uni.join().first(sa, sb, sc).toTerminate();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertNotTerminated();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
@@ -1,20 +1,21 @@
 package io.smallrye.mutiny.operators.uni;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniJoin;
 import io.smallrye.mutiny.helpers.spies.Spy;
 import io.smallrye.mutiny.helpers.spies.UniOnCancellationSpy;
 import io.smallrye.mutiny.helpers.spies.UniOnItemSpy;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UniJoinTest {
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
@@ -1,0 +1,127 @@
+package io.smallrye.mutiny.operators.uni;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.spies.Spy;
+import io.smallrye.mutiny.helpers.spies.UniOnCancellationSpy;
+import io.smallrye.mutiny.helpers.spies.UniOnItemSpy;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+
+class UniJoinTest {
+
+    @Nested
+    class JoinAll {
+
+        @Test
+        void joinItems() {
+            Uni<Integer> a = Uni.createFrom().item(1);
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+
+            Uni<List<Integer>> uni = Uni.join().all(a, b, c);
+
+            UniAssertSubscriber<List<Integer>> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+            sub.assertCompleted().assertItem(Arrays.asList(1, 2, 3));
+        }
+
+        @Test
+        void joinNumericTypesItems() {
+            Uni<Number> a = Uni.createFrom().item(1);
+            Uni<Number> b = Uni.createFrom().item(2L);
+            Uni<Number> c = Uni.createFrom().item(3);
+
+            Uni<List<Number>> uni = Uni.join().all(a, b, c);
+
+            UniAssertSubscriber<List<Number>> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+            sub.assertCompleted().assertItem(Arrays.asList(1, 2L, 3));
+        }
+
+        @Test
+        void joinDisparateTypesItems() {
+            Uni<Object> a = Uni.createFrom().item(1);
+            Uni<Object> b = Uni.createFrom().item("2");
+            Uni<Object> c = Uni.createFrom().item(3L);
+
+            Uni<List<Object>> uni = Uni.join().all(a, b, c);
+
+            UniAssertSubscriber<List<Object>> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+            sub.assertCompleted().assertItem(Arrays.asList(1, "2", 3L));
+        }
+
+        @Test
+        void joinWithFailedItem() {
+            Uni<Integer> a = Uni.createFrom().item(1);
+            Uni<Integer> b = Uni.createFrom().failure(new IOException("boom"));
+            Uni<Integer> c = Uni.createFrom().item(3);
+
+            Uni<List<Integer>> uni = Uni.join().all(a, b, c);
+
+            UniAssertSubscriber<List<Integer>> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+            sub.assertFailedWith(IOException.class, "boom");
+        }
+
+        @Test
+        void joinWithFailedItems() {
+            Uni<Integer> a = Uni.createFrom().item(1);
+            Uni<Integer> b = Uni.createFrom().failure(new IOException("boom"));
+            Uni<Integer> c = Uni.createFrom().failure(new IOException("boomz"));
+
+            Uni<List<Integer>> uni = Uni.join().all(a, b, c);
+
+            UniAssertSubscriber<List<Integer>> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+            sub.assertFailedWith(IOException.class, "boom");
+        }
+
+        @Test
+        void earlyCancellation() {
+            Uni<Integer> a = Uni.createFrom().item(1);
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+
+            Uni<List<Integer>> uni = Uni.join().all(a, b, c);
+            UniOnItemSpy<List<Integer>> spy = Spy.onItem(uni);
+
+            UniAssertSubscriber<List<Integer>> sub = new UniAssertSubscriber<>(true);
+            spy.subscribe().withSubscriber(sub);
+            sub.assertNotTerminated();
+            assertThat(spy.invocationCount()).isEqualTo(0L);
+        }
+
+        @Test
+        void lateCancellation() {
+            Uni<Integer> a = Uni.createFrom().item(1);
+            Uni<Integer> b = Uni.createFrom().emitter(e -> {
+                // Do nothing
+            });
+            Uni<Integer> c = Uni.createFrom().item(3);
+
+            UniOnCancellationSpy<Integer> sa = Spy.onCancellation(a);
+            UniOnCancellationSpy<Integer> sb = Spy.onCancellation(b);
+            UniOnCancellationSpy<Integer> sc = Spy.onCancellation(c);
+
+            Uni<List<Integer>> uni = Uni.join().all(sa, sb, sc);
+
+            UniAssertSubscriber<List<Integer>> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+            sub.assertNotTerminated();
+
+            assertThat(sa.invocationCount()).isEqualTo(0L);
+            assertThat(sb.invocationCount()).isEqualTo(0L);
+            assertThat(sc.invocationCount()).isEqualTo(0L);
+
+            sub.cancel();
+            sub.assertNotTerminated();
+
+            assertThat(sa.invocationCount()).isEqualTo(0L);
+            assertThat(sb.invocationCount()).isEqualTo(1L);
+            assertThat(sc.invocationCount()).isEqualTo(0L);
+        }
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
@@ -226,6 +226,22 @@ class UniJoinTest {
         }
 
         @Test
+        void joinFailure() {
+            Uni<Integer> a = Uni.createFrom().emitter(emitter -> {
+                // Do nothing
+            });
+            Uni<Integer> b = Uni.createFrom().failure(new IOException("boom"));
+            Uni<Integer> c = Uni.createFrom().emitter(emitter -> {
+                // Do nothing
+            });
+
+            Uni<Integer> uni = Uni.join().first(a, b, c);
+
+            UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+            sub.assertFailedWith(IOException.class, "boom");
+        }
+
+        @Test
         void earlyCancellation() {
             Uni<Integer> a = Uni.createFrom().item(1);
             Uni<Integer> b = Uni.createFrom().item(2);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
@@ -1,21 +1,21 @@
 package io.smallrye.mutiny.operators.uni;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import io.smallrye.mutiny.CompositeException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniJoin;
 import io.smallrye.mutiny.helpers.spies.Spy;
 import io.smallrye.mutiny.helpers.spies.UniOnCancellationSpy;
 import io.smallrye.mutiny.helpers.spies.UniOnItemSpy;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
-
-import static org.assertj.core.api.Assertions.*;
 
 class UniJoinTest {
 
@@ -198,7 +198,6 @@ class UniJoinTest {
             sub.assertFailedWith(IOException.class, "boom");
         }
 
-
         @Test
         void earlyCancellation() {
             Uni<Integer> a = Uni.createFrom().item(1);
@@ -253,7 +252,7 @@ class UniJoinTest {
             Uni<Integer> b = Uni.createFrom().item(2);
             Uni<Integer> c = Uni.createFrom().item(3);
 
-            Uni<Integer> uni = Uni.join().first(a, b, c);
+            Uni<Integer> uni = Uni.join().first(a, b, c).toEmit();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertCompleted().assertItem(1);
@@ -265,7 +264,7 @@ class UniJoinTest {
             Uni<Integer> b = Uni.createFrom().failure(new IOException("boom #2"));
             Uni<Integer> c = Uni.createFrom().item(3);
 
-            Uni<Integer> uni = Uni.join().firstWithItem(a, b, c);
+            Uni<Integer> uni = Uni.join().first(a, b, c).withItem();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertCompleted().assertItem(3);
@@ -279,7 +278,7 @@ class UniJoinTest {
 
             UniJoin.UniJoinBuilder<Integer> builder = Uni.join().builder();
             builder.add(a).add(b).add(c);
-            Uni<Integer> uni = builder.joinFirstWithItem();
+            Uni<Integer> uni = builder.joinFirst().withItem();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertCompleted().assertItem(3);
@@ -291,7 +290,7 @@ class UniJoinTest {
             Uni<Integer> b = Uni.createFrom().failure(new IOException("boom #2"));
             Uni<Integer> c = Uni.createFrom().failure(new IOException("boom #3"));
 
-            Uni<Integer> uni = Uni.join().firstWithItem(a, b, c);
+            Uni<Integer> uni = Uni.join().first(a, b, c).withItem();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertFailedWith(CompositeException.class);
@@ -312,7 +311,7 @@ class UniJoinTest {
 
             UniJoin.UniJoinBuilder<Integer> builder = Uni.join().builder();
             builder.add(a).add(b).add(c);
-            Uni<Integer> uni = builder.joinFirst();
+            Uni<Integer> uni = builder.joinFirst().toEmit();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertCompleted().assertItem(1);
@@ -328,7 +327,7 @@ class UniJoinTest {
                 // Do nothing
             });
 
-            Uni<Integer> uni = Uni.join().first(a, b, c);
+            Uni<Integer> uni = Uni.join().first(a, b, c).toEmit();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertCompleted().assertItem(2);
@@ -344,7 +343,7 @@ class UniJoinTest {
                 // Do nothing
             });
 
-            Uni<Integer> uni = Uni.join().first(a, b, c);
+            Uni<Integer> uni = Uni.join().first(a, b, c).toEmit();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertFailedWith(IOException.class, "boom");
@@ -356,7 +355,7 @@ class UniJoinTest {
             Uni<Integer> b = Uni.createFrom().item(2);
             Uni<Integer> c = Uni.createFrom().item(3);
 
-            Uni<Integer> uni = Uni.join().first(a, b, c);
+            Uni<Integer> uni = Uni.join().first(a, b, c).toEmit();
             UniOnItemSpy<Integer> spy = Spy.onItem(uni);
 
             UniAssertSubscriber<Integer> sub = new UniAssertSubscriber<>(true);
@@ -382,7 +381,7 @@ class UniJoinTest {
             UniOnCancellationSpy<Integer> sb = Spy.onCancellation(b);
             UniOnCancellationSpy<Integer> sc = Spy.onCancellation(c);
 
-            Uni<Integer> uni = Uni.join().first(sa, sb, sc);
+            Uni<Integer> uni = Uni.join().first(sa, sb, sc).toEmit();
 
             UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertNotTerminated();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
@@ -26,7 +26,7 @@ class UniJoinTest {
         void allNull() {
             assertThatThrownBy(() -> Uni.join().all((Uni<?>) null))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("The uni at index 0 is null");
+                    .hasMessage("`unis` contains a `null` value");
 
             assertThatThrownBy(() -> Uni.join().all((List<Uni<?>>) null))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -37,7 +37,7 @@ class UniJoinTest {
         void firstNull() {
             assertThatThrownBy(() -> Uni.join().first((Uni<?>) null))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("The uni at index 0 is null");
+                    .hasMessage("`unis` contains a `null` value");
 
             assertThatThrownBy(() -> Uni.join().first((List<Uni<?>>) null))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -50,11 +50,11 @@ class UniJoinTest {
 
             assertThatThrownBy(() -> Uni.join().all(unis))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("The uni at index 1 is null");
+                    .hasMessage("`unis` contains a `null` value");
 
             assertThatThrownBy(() -> Uni.join().first(unis))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("The uni at index 1 is null");
+                    .hasMessage("`unis` contains a `null` value");
         }
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import io.smallrye.mutiny.groups.UniJoin;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +28,20 @@ class UniJoinTest {
             Uni<Integer> c = Uni.createFrom().item(3);
 
             Uni<List<Integer>> uni = Uni.join().all(a, b, c);
+
+            UniAssertSubscriber<List<Integer>> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+            sub.assertCompleted().assertItem(Arrays.asList(1, 2, 3));
+        }
+
+        @Test
+        void joinBuilder() {
+            Uni<Integer> a = Uni.createFrom().item(1);
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+
+            UniJoin.UniJoinBuilder<Integer> builder = Uni.join().builder();
+            builder.add(a).add(b).add(c);
+            Uni<List<Integer>> uni = builder.joinAll();
 
             UniAssertSubscriber<List<Integer>> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
             sub.assertCompleted().assertItem(Arrays.asList(1, 2, 3));

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
@@ -91,7 +91,7 @@ class UniJoinTest {
             Uni<Integer> b = Uni.createFrom().item(2);
             Uni<Integer> c = Uni.createFrom().item(3);
 
-            UniJoin.UniJoinBuilder<Integer> builder = Uni.join().builder();
+            UniJoin.Builder<Integer> builder = Uni.join().builder();
             builder.add(a).add(b).add(c);
             Uni<List<Integer>> uni = builder.joinAll().andCollectFailures();
 
@@ -105,7 +105,7 @@ class UniJoinTest {
             Uni<Integer> b = Uni.createFrom().item(2);
             Uni<Integer> c = Uni.createFrom().item(3);
 
-            UniJoin.UniJoinBuilder<Integer> builder = Uni.join().builder();
+            UniJoin.Builder<Integer> builder = Uni.join().builder();
             builder.add(a).add(b).add(c);
             Uni<List<Integer>> uni = builder.joinAll().andFailFast();
 
@@ -276,7 +276,7 @@ class UniJoinTest {
             Uni<Integer> b = Uni.createFrom().failure(new IOException("boom #2"));
             Uni<Integer> c = Uni.createFrom().item(3);
 
-            UniJoin.UniJoinBuilder<Integer> builder = Uni.join().builder();
+            UniJoin.Builder<Integer> builder = Uni.join().builder();
             builder.add(a).add(b).add(c);
             Uni<Integer> uni = builder.joinFirst().withItem();
 
@@ -309,7 +309,7 @@ class UniJoinTest {
             Uni<Integer> b = Uni.createFrom().item(2);
             Uni<Integer> c = Uni.createFrom().item(3);
 
-            UniJoin.UniJoinBuilder<Integer> builder = Uni.join().builder();
+            UniJoin.Builder<Integer> builder = Uni.join().builder();
             builder.add(a).add(b).add(c);
             Uni<Integer> uni = builder.joinFirst().toTerminate();
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
@@ -1,22 +1,61 @@
 package io.smallrye.mutiny.operators.uni;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniJoin;
 import io.smallrye.mutiny.helpers.spies.Spy;
 import io.smallrye.mutiny.helpers.spies.UniOnCancellationSpy;
 import io.smallrye.mutiny.helpers.spies.UniOnItemSpy;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UniJoinTest {
+
+    @Nested
+    class Nulls {
+
+        @Test
+        void allNull() {
+            assertThatThrownBy(() -> Uni.join().all((Uni<?>) null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("The uni at index 0 is null");
+
+            assertThatThrownBy(() -> Uni.join().all((List<Uni<?>>) null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("`unis` must not be `null`");
+        }
+
+        @Test
+        void firstNull() {
+            assertThatThrownBy(() -> Uni.join().first((Uni<?>) null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("The uni at index 0 is null");
+
+            assertThatThrownBy(() -> Uni.join().first((List<Uni<?>>) null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("`unis` must not be `null`");
+        }
+
+        @Test
+        void oneIsNull() {
+            List<Uni<?>> unis = Arrays.asList(Uni.createFrom().item(1), null, Uni.createFrom().item("3"));
+
+            assertThatThrownBy(() -> Uni.join().all(unis))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("The uni at index 1 is null");
+
+            assertThatThrownBy(() -> Uni.join().first(unis))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("The uni at index 1 is null");
+        }
+    }
 
     @Nested
     class JoinAll {

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import io.smallrye.mutiny.groups.UniJoin;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.groups.UniJoin;
 import io.smallrye.mutiny.helpers.spies.Spy;
 import io.smallrye.mutiny.helpers.spies.UniOnCancellationSpy;
 import io.smallrye.mutiny.helpers.spies.UniOnItemSpy;
@@ -137,6 +137,101 @@ class UniJoinTest {
             assertThat(sa.invocationCount()).isEqualTo(0L);
             assertThat(sb.invocationCount()).isEqualTo(1L);
             assertThat(sc.invocationCount()).isEqualTo(0L);
+        }
+    }
+
+    @Nested
+    class JoinFirst {
+
+        @Test
+        void joinItems() {
+            Uni<Integer> a = Uni.createFrom().item(1);
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+
+            Uni<Integer> uni = Uni.join().first(a, b, c);
+
+            UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+            sub.assertCompleted().assertItem(1);
+        }
+
+        @Test
+        void joinBuilder() {
+            Uni<Integer> a = Uni.createFrom().item(1);
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+
+            UniJoin.UniJoinBuilder<Integer> builder = Uni.join().builder();
+            builder.add(a).add(b).add(c);
+            Uni<Integer> uni = builder.joinFirst();
+
+            UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+            sub.assertCompleted().assertItem(1);
+        }
+
+        @Test
+        void joinOne() {
+            Uni<Integer> a = Uni.createFrom().emitter(emitter -> {
+                // Do nothing
+            });
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().emitter(emitter -> {
+                // Do nothing
+            });
+
+            Uni<Integer> uni = Uni.join().first(a, b, c);
+
+            UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+            sub.assertCompleted().assertItem(2);
+        }
+
+        @Test
+        void earlyCancellation() {
+            Uni<Integer> a = Uni.createFrom().item(1);
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+
+            Uni<Integer> uni = Uni.join().first(a, b, c);
+            UniOnItemSpy<Integer> spy = Spy.onItem(uni);
+
+            UniAssertSubscriber<Integer> sub = new UniAssertSubscriber<>(true);
+            spy.subscribe().withSubscriber(sub);
+            sub.assertNotTerminated();
+            assertThat(spy.invocationCount()).isEqualTo(0L);
+        }
+
+        @Test
+        void lateCancellation() {
+            Uni<Integer> a = Uni.createFrom().emitter(e -> {
+                // Do nothing
+            });
+            Uni<Integer> b = Uni.createFrom().emitter(e -> {
+                // Do nothing
+            });
+            Uni<Integer> c = Uni.createFrom().emitter(e -> {
+                // Do nothing
+            });
+            ;
+
+            UniOnCancellationSpy<Integer> sa = Spy.onCancellation(a);
+            UniOnCancellationSpy<Integer> sb = Spy.onCancellation(b);
+            UniOnCancellationSpy<Integer> sc = Spy.onCancellation(c);
+
+            Uni<Integer> uni = Uni.join().first(sa, sb, sc);
+
+            UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+            sub.assertNotTerminated();
+
+            assertThat(sa.invocationCount()).isEqualTo(0L);
+            assertThat(sb.invocationCount()).isEqualTo(0L);
+            assertThat(sc.invocationCount()).isEqualTo(0L);
+
+            sub.cancel();
+            sub.assertNotTerminated();
+
+            assertThat(sa.invocationCount()).isEqualTo(1L);
+            assertThat(sb.invocationCount()).isEqualTo(1L);
+            assertThat(sc.invocationCount()).isEqualTo(1L);
         }
     }
 }


### PR DESCRIPTION
`Uni.join().{builder/all/first}` API.

It is simpler than `Uni.combine()`, and likely better matches what users do (e.g., passing a list of homogeneous operations).

There is no transformation API, `Uni.join().all(...)` emits a `List<T>` that can be subsequently processed with `Uni.onItem().{...}`.