### PR TITLE
Fix NPE happening after cancellation in MultiSelectFirstOp

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSelectFirstOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSelectFirstOp.java
@@ -64,11 +64,13 @@ public final class MultiSelectFirstOp<T> extends AbstractMultiOperator<T, T> {
                 return;
             }
 
+            MultiSubscriber<? super T> actual = downstream;
+
             long r = remaining;
 
             if (r == 0) {
                 upstream.getAndSet(Subscriptions.CANCELLED).cancel();
-                downstream.onCompletion();
+                actual.onCompletion();
                 return;
             }
 
@@ -76,7 +78,7 @@ public final class MultiSelectFirstOp<T> extends AbstractMultiOperator<T, T> {
             downstream.onItem(t);
             if (r == 0L) {
                 upstream.getAndSet(Subscriptions.CANCELLED).cancel();
-                downstream.onCompletion();
+                actual.onCompletion();
             }
         }
 


### PR DESCRIPTION
Fix #605.
Keep a reference on the downstream so we can send the completion event after the cancellation