### PR TITLE
Move dokka plugin to its own profile to be able to skip it

### DIFF
--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -101,24 +101,37 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.jetbrains.dokka</groupId>
-                <artifactId>dokka-maven-plugin</artifactId>
-                <version>${dokka.version}</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadoc</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>javadocJar</goal>
-                        </goals>
-                        <configuration>
-                            <attach>true</attach>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dokka</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
+                        <version>${dokka.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadoc</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>javadocJar</goal>
+                                </goals>
+                                <configuration>
+                                    <attach>true</attach>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     
 </project>


### PR DESCRIPTION
Hi. This minor change would be a great improvement for productization purposes. The problem with dokka plugin is that it does not work in the productization environment (Project Newcastle), so we need a way to turn it off.
Until now, productization engineers have been removing the plugin manually before each release. As part of streamlining and automating the build, it would be nice to have a way to simply turn it off from the command line.

Maybe there's a command line option to skip it, but I couldn't find it in the docs https://kotlin.github.io/dokka/1.4.32/user_guide/maven/usage/, so I suppose the best way to go forward would be to move the plugin into a profile that's active by default, so adding `-P!dokka` to the cmdline will skip it. WDYT?
