### PR TITLE
Fix documentation for Multi.map method

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -341,7 +341,7 @@ public interface Multi<T> extends Publisher<T> {
      * The function receives the received item as parameter, and can transform it. The returned object is sent
      * downstream as {@code item} event.
      * <p>
-     * This method is a shortcut for {@code multi.onItem().apply(mapper)}.
+     * This method is a shortcut for {@code multi.onItem().transform(mapper)}.
      *
      * @param mapper the mapper function, must not be {@code null}
      * @param <O> the type of item produced by the mapper function


### PR DESCRIPTION
The documentation for the `Multi.map` method is not correct. Specifically `This method is a shortcut for {@code multi.onItem().apply(mapper)}.` should be `This method is a shortcut for {@code multi.onItem().transform(mapper)}.`