### PR TITLE
Use the thread-local ThreadContext in order to be able to define which contexts get propagated

### DIFF
--- a/context-propagation/src/main/java/io/smallrye/mutiny/context/DefaultContextPropagationInterceptor.java
+++ b/context-propagation/src/main/java/io/smallrye/mutiny/context/DefaultContextPropagationInterceptor.java
@@ -1,7 +1,5 @@
 package io.smallrye.mutiny.context;
 
-import org.eclipse.microprofile.context.spi.ContextManagerProvider;
-
 import io.smallrye.context.SmallRyeThreadContext;
 
 /**
@@ -9,12 +7,8 @@ import io.smallrye.context.SmallRyeThreadContext;
  */
 public class DefaultContextPropagationInterceptor extends BaseContextPropagationInterceptor {
 
-    static final SmallRyeThreadContext THREAD_CONTEXT = (SmallRyeThreadContext) ContextManagerProvider.instance()
-            .getContextManager()
-            .newThreadContextBuilder().build();
-
     @Override
     protected SmallRyeThreadContext getThreadContext() {
-        return THREAD_CONTEXT;
+        return SmallRyeThreadContext.getCurrentThreadContextOrPropagatedContexts();
     }
 }

--- a/context-propagation/src/main/java/io/smallrye/mutiny/context/MutinyContextManagerExtension.java
+++ b/context-propagation/src/main/java/io/smallrye/mutiny/context/MutinyContextManagerExtension.java
@@ -1,17 +1,26 @@
 package io.smallrye.mutiny.context;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.function.UnaryOperator;
+
 import org.eclipse.microprofile.context.ThreadContext;
 import org.eclipse.microprofile.context.spi.ContextManager;
 import org.eclipse.microprofile.context.spi.ContextManagerExtension;
 
+import io.smallrye.context.SmallRyeThreadContext;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 
 public class MutinyContextManagerExtension implements ContextManagerExtension {
 
     @Override
     public void setup(ContextManager manager) {
-        ThreadContext threadContext = manager.newThreadContextBuilder().build();
-        Infrastructure.setCompletableFutureWrapper(threadContext::withContextCapture);
+        Infrastructure.setCompletableFutureWrapper(new UnaryOperator<CompletableFuture<?>>() {
+            @Override
+            public CompletableFuture<?> apply(CompletableFuture<?> t) {
+                ThreadContext threadContext = SmallRyeThreadContext.getCurrentThreadContextOrPropagatedContexts();
+                return threadContext.withContextCapture(t);
+            }
+        });
     }
 
 }


### PR DESCRIPTION
This is required by https://github.com/quarkusio/quarkus/issues/18689

Fixes #626