### PR TITLE
Use atomic field updaters in selected Uni places

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniFailOnTimeout.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniFailOnTimeout.java
@@ -50,7 +50,7 @@ public class UniFailOnTimeout<I> extends UniOperator<I, I> {
                 timeoutFuture = executor.schedule(this::doTimeout, timeout.toMillis(), TimeUnit.MILLISECONDS);
             } catch (RejectedExecutionException e) {
                 // Executor out of service.
-                upstream.set(CANCELLED);
+                getAndSetUpstreamSubscription(CANCELLED);
                 subscription.cancel();
                 downstream.onSubscribe(EmptyUniSubscription.DONE);
                 downstream.onFailure(e);
@@ -61,7 +61,7 @@ public class UniFailOnTimeout<I> extends UniOperator<I, I> {
 
         @Override
         public void onItem(I item) {
-            UniSubscription sub = upstream.getAndSet(CANCELLED);
+            UniSubscription sub = getAndSetUpstreamSubscription(CANCELLED);
             if (sub != CANCELLED) {
                 if (timeoutFuture != null) {
                     timeoutFuture.cancel(false);
@@ -72,7 +72,7 @@ public class UniFailOnTimeout<I> extends UniOperator<I, I> {
 
         @Override
         public void onFailure(Throwable failure) {
-            UniSubscription sub = upstream.getAndSet(CANCELLED);
+            UniSubscription sub = getAndSetUpstreamSubscription(CANCELLED);
             if (sub != CANCELLED) {
                 if (timeoutFuture != null) {
                     timeoutFuture.cancel(false);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnCancellation.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnCancellation.java
@@ -54,7 +54,7 @@ public class UniOnCancellation<T> extends UniOperator<T, T> {
         @Override
         public void cancel() {
             if (state.compareAndSet(State.INIT, State.CANCELLED)) {
-                UniSubscription sub = upstream.getAndSet(CANCELLED);
+                UniSubscription sub = getAndSetUpstreamSubscription(CANCELLED);
                 callback.run();
                 if (sub != null) {
                     sub.cancel();

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnCancellation.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnCancellation.java
@@ -2,7 +2,7 @@ package io.smallrye.mutiny.operators.uni;
 
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;
 
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.AbstractUni;
@@ -11,6 +11,7 @@ import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
 
 public class UniOnCancellation<T> extends UniOperator<T, T> {
+
     private final Runnable callback;
 
     public UniOnCancellation(Uni<T> upstream, Runnable callback) {
@@ -20,7 +21,7 @@ public class UniOnCancellation<T> extends UniOperator<T, T> {
 
     @Override
     public void subscribe(UniSubscriber<? super T> subscriber) {
-        AbstractUni.subscribe(upstream(), new UniOnCancellationProcessor(subscriber));
+        AbstractUni.subscribe(upstream(), new UniOnCancellationProcessor<T>(callback, subscriber));
     }
 
     private enum State {
@@ -29,31 +30,36 @@ public class UniOnCancellation<T> extends UniOperator<T, T> {
         CANCELLED
     }
 
-    private class UniOnCancellationProcessor extends UniOperatorProcessor<T, T> {
+    private static class UniOnCancellationProcessor<T> extends UniOperatorProcessor<T, T> {
 
-        public UniOnCancellationProcessor(UniSubscriber<? super T> downstream) {
+        private final Runnable callback;
+
+        private volatile State state = State.INIT;
+        private static final AtomicReferenceFieldUpdater<UniOnCancellationProcessor, State> stateUpdater = AtomicReferenceFieldUpdater
+                .newUpdater(UniOnCancellationProcessor.class, State.class, "state");
+
+        public UniOnCancellationProcessor(Runnable callback, UniSubscriber<? super T> downstream) {
             super(downstream);
+            this.callback = callback;
         }
-
-        private final AtomicReference<State> state = new AtomicReference<>(State.INIT);
 
         @Override
         public void onItem(T item) {
-            if (state.compareAndSet(State.INIT, State.DONE)) {
+            if (stateUpdater.compareAndSet(this, State.INIT, State.DONE)) {
                 downstream.onItem(item);
             }
         }
 
         @Override
         public void onFailure(Throwable failure) {
-            if (state.compareAndSet(State.INIT, State.DONE)) {
+            if (stateUpdater.compareAndSet(this, State.INIT, State.DONE)) {
                 downstream.onFailure(failure);
             }
         }
 
         @Override
         public void cancel() {
-            if (state.compareAndSet(State.INIT, State.CANCELLED)) {
+            if (stateUpdater.compareAndSet(this, State.INIT, State.CANCELLED)) {
                 UniSubscription sub = getAndSetUpstreamSubscription(CANCELLED);
                 callback.run();
                 if (sub != null) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnCancellationCall.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnCancellationCall.java
@@ -58,7 +58,7 @@ public class UniOnCancellationCall<I> extends UniOperator<I, I> {
         @Override
         public void cancel() {
             if (state.compareAndSet(State.INIT, State.CANCELLED)) {
-                UniSubscription sub = upstream.getAndSet(CANCELLED);
+                UniSubscription sub = getAndSetUpstreamSubscription(CANCELLED);
                 execute().subscribe().with(
                         ignoredItem -> {
                             if (sub != null) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnCancellationCall.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnCancellationCall.java
@@ -3,7 +3,7 @@ package io.smallrye.mutiny.operators.uni;
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Supplier;
 
 import io.smallrye.mutiny.Uni;
@@ -24,7 +24,7 @@ public class UniOnCancellationCall<I> extends UniOperator<I, I> {
 
     @Override
     public void subscribe(UniSubscriber<? super I> subscriber) {
-        AbstractUni.subscribe(upstream(), new UniOnCancellationCallProcessor(subscriber));
+        AbstractUni.subscribe(upstream(), new UniOnCancellationCallProcessor<I>(supplier, subscriber));
     }
 
     private enum State {
@@ -33,31 +33,36 @@ public class UniOnCancellationCall<I> extends UniOperator<I, I> {
         CANCELLED
     }
 
-    private class UniOnCancellationCallProcessor extends UniOperatorProcessor<I, I> {
+    private static class UniOnCancellationCallProcessor<I> extends UniOperatorProcessor<I, I> {
 
-        public UniOnCancellationCallProcessor(UniSubscriber<? super I> downstream) {
+        private final Supplier<Uni<?>> supplier;
+
+        private volatile State state = State.INIT;
+        private static final AtomicReferenceFieldUpdater<UniOnCancellationCallProcessor, State> stateUpdater = AtomicReferenceFieldUpdater
+                .newUpdater(UniOnCancellationCallProcessor.class, State.class, "state");
+
+        public UniOnCancellationCallProcessor(Supplier<Uni<?>> supplier, UniSubscriber<? super I> downstream) {
             super(downstream);
+            this.supplier = supplier;
         }
-
-        private final AtomicReference<State> state = new AtomicReference<>(State.INIT);
 
         @Override
         public void onItem(I item) {
-            if (state.compareAndSet(State.INIT, State.DONE)) {
+            if (stateUpdater.compareAndSet(this, State.INIT, State.DONE)) {
                 downstream.onItem(item);
             }
         }
 
         @Override
         public void onFailure(Throwable failure) {
-            if (state.compareAndSet(State.INIT, State.DONE)) {
+            if (stateUpdater.compareAndSet(this, State.INIT, State.DONE)) {
                 downstream.onFailure(failure);
             }
         }
 
         @Override
         public void cancel() {
-            if (state.compareAndSet(State.INIT, State.CANCELLED)) {
+            if (stateUpdater.compareAndSet(this, State.INIT, State.CANCELLED)) {
                 UniSubscription sub = getAndSetUpstreamSubscription(CANCELLED);
                 execute().subscribe().with(
                         ignoredItem -> {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnFailureFlatMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnFailureFlatMap.java
@@ -41,7 +41,7 @@ public class UniOnFailureFlatMap<I> extends UniOperator<I, I> {
 
         @Override
         public void onSubscribe(UniSubscription subscription) {
-            if (upstream.get() == null) {
+            if (getCurrentUpstreamSubscription() == null) {
                 super.onSubscribe(subscription);
             } else if (innerSubscription == null) {
                 this.innerSubscription = subscription;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnItemOrFailureFlatMap.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnItemOrFailureFlatMap.java
@@ -37,7 +37,7 @@ public class UniOnItemOrFailureFlatMap<I, O> extends UniOperator<I, O> {
 
         @Override
         public void onSubscribe(UniSubscription subscription) {
-            if (upstream.get() == null) {
+            if (getCurrentUpstreamSubscription() == null) {
                 super.onSubscribe(subscription);
             } else if (innerSubscription == null) {
                 this.innerSubscription = subscription;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnItemTransformToUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnItemTransformToUni.java
@@ -37,7 +37,7 @@ public class UniOnItemTransformToUni<I, O> extends UniOperator<I, O> {
 
         @Override
         public void onSubscribe(UniSubscription subscription) {
-            if (upstream.get() == null) {
+            if (getCurrentUpstreamSubscription() == null) {
                 super.onSubscribe(subscription);
             } else if (innerSubscription == null) {
                 this.innerSubscription = subscription;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOperatorProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOperatorProcessor.java
@@ -14,9 +14,10 @@ public abstract class UniOperatorProcessor<I, O> implements UniSubscriber<I>, Un
 
     protected final UniSubscriber<? super O> downstream;
 
-    private static final AtomicReferenceFieldUpdater<UniOperatorProcessor,UniSubscription> updater = AtomicReferenceFieldUpdater.newUpdater(UniOperatorProcessor.class, UniSubscription.class, "upstream");
+    private static final AtomicReferenceFieldUpdater<UniOperatorProcessor, UniSubscription> updater = AtomicReferenceFieldUpdater
+            .newUpdater(UniOperatorProcessor.class, UniSubscription.class, "upstream");
 
-    protected volatile UniSubscription upstream;
+    private volatile UniSubscription upstream;
 
     public UniOperatorProcessor(UniSubscriber<? super O> downstream) {
         this.downstream = ParameterValidation.nonNull(downstream, "downstream");
@@ -61,4 +62,17 @@ public abstract class UniOperatorProcessor<I, O> implements UniSubscriber<I>, Un
     public boolean isCancelled() {
         return upstream == CANCELLED;
     }
+
+    protected final UniSubscription getCurrentUpstreamSubscription() {
+        return upstream;
+    }
+
+    protected final UniSubscription getAndSetUpstreamSubscription(UniSubscription newValue) {
+        return updater.getAndSet(this, newValue);
+    }
+
+    protected final boolean compareAndSetUpstreamSubscription(UniSubscription expect, UniSubscription update) {
+        return updater.compareAndSet(this, expect, update);
+    }
+
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOperatorProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOperatorProcessor.java
@@ -25,7 +25,7 @@ public abstract class UniOperatorProcessor<I, O> implements UniSubscriber<I>, Un
 
     @Override
     public void onSubscribe(UniSubscription subscription) {
-        if (updater.compareAndSet(this, null, subscription)) {
+        if (compareAndSetUpstreamSubscription(null, subscription)) {
             downstream.onSubscribe(this);
         } else {
             subscription.cancel();
@@ -35,7 +35,7 @@ public abstract class UniOperatorProcessor<I, O> implements UniSubscriber<I>, Un
     @Override
     @SuppressWarnings("unchecked")
     public void onItem(I item) {
-        UniSubscription subscription = updater.getAndSet(this, CANCELLED);
+        UniSubscription subscription = getAndSetUpstreamSubscription(CANCELLED);
         if (subscription != CANCELLED) {
             downstream.onItem((O) item);
         }
@@ -43,7 +43,7 @@ public abstract class UniOperatorProcessor<I, O> implements UniSubscriber<I>, Un
 
     @Override
     public void onFailure(Throwable failure) {
-        UniSubscription subscription = updater.getAndSet(this, CANCELLED);
+        UniSubscription subscription = getAndSetUpstreamSubscription(CANCELLED);
         if (subscription != CANCELLED) {
             downstream.onFailure(failure);
         } else {
@@ -53,7 +53,7 @@ public abstract class UniOperatorProcessor<I, O> implements UniSubscriber<I>, Un
 
     @Override
     public void cancel() {
-        UniSubscription subscription = updater.getAndSet(this, CANCELLED);
+        UniSubscription subscription = getAndSetUpstreamSubscription(CANCELLED);
         if (subscription != null && subscription != CANCELLED && subscription != DONE) {
             subscription.cancel();
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniRetryAtMost.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniRetryAtMost.java
@@ -3,7 +3,7 @@ package io.smallrye.mutiny.operators.uni;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Predicate;
 
 import io.smallrye.mutiny.Uni;
@@ -25,20 +25,25 @@ public class UniRetryAtMost<T> extends UniOperator<T, T> {
 
     @Override
     public void subscribe(UniSubscriber<? super T> subscriber) {
-        AbstractUni.subscribe(upstream(), new UniRetryAtMostProcessor(subscriber));
+        AbstractUni.subscribe(upstream(), new UniRetryAtMostProcessor<T>(this, subscriber));
     }
 
-    private class UniRetryAtMostProcessor extends UniOperatorProcessor<T, T> {
+    private static class UniRetryAtMostProcessor<T> extends UniOperatorProcessor<T, T> {
 
-        private final AtomicInteger counter = new AtomicInteger(0);
+        private final UniRetryAtMost<T> uniRetryAtMost;
 
-        public UniRetryAtMostProcessor(UniSubscriber<? super T> downstream) {
+        private volatile int counter = 0;
+        private static final AtomicIntegerFieldUpdater<UniRetryAtMostProcessor> counterUpdater = AtomicIntegerFieldUpdater
+                .newUpdater(UniRetryAtMostProcessor.class, "counter");
+
+        public UniRetryAtMostProcessor(UniRetryAtMost<T> uniRetryAtMost, UniSubscriber<? super T> downstream) {
             super(downstream);
+            this.uniRetryAtMost = uniRetryAtMost;
         }
 
         @Override
         public void onSubscribe(UniSubscription subscription) {
-            int count = counter.incrementAndGet();
+            int count = counterUpdater.incrementAndGet(this);
             if (compareAndSetUpstreamSubscription(null, subscription)) {
                 if (count == 1) {
                     downstream.onSubscribe(this);
@@ -57,7 +62,7 @@ public class UniRetryAtMost<T> extends UniOperator<T, T> {
             if (!testPredicate(failure)) {
                 return;
             }
-            if (counter.get() > maxAttempts) {
+            if (counter > uniRetryAtMost.maxAttempts) {
                 downstream.onFailure(failure);
                 return;
             }
@@ -65,13 +70,13 @@ public class UniRetryAtMost<T> extends UniOperator<T, T> {
             if (previousSubscription != null) {
                 previousSubscription.cancel();
             }
-            AbstractUni.subscribe(upstream(), this);
+            AbstractUni.subscribe(uniRetryAtMost.upstream(), this);
         }
 
         private boolean testPredicate(Throwable failure) {
             boolean passes;
             try {
-                passes = predicate.test(failure);
+                passes = uniRetryAtMost.predicate.test(failure);
             } catch (Throwable e) {
                 downstream.onFailure(e);
                 return false;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniRetryAtMost.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniRetryAtMost.java
@@ -39,7 +39,7 @@ public class UniRetryAtMost<T> extends UniOperator<T, T> {
         @Override
         public void onSubscribe(UniSubscription subscription) {
             int count = counter.incrementAndGet();
-            if (upstream.compareAndSet(null, subscription)) {
+            if (compareAndSetUpstreamSubscription(null, subscription)) {
                 if (count == 1) {
                     downstream.onSubscribe(this);
                 }
@@ -61,7 +61,7 @@ public class UniRetryAtMost<T> extends UniOperator<T, T> {
                 downstream.onFailure(failure);
                 return;
             }
-            UniSubscription previousSubscription = upstream.getAndSet(null);
+            UniSubscription previousSubscription = getAndSetUpstreamSubscription(null);
             if (previousSubscription != null) {
                 previousSubscription.cancel();
             }


### PR DESCRIPTION
- Avoid allocating excessive amounts of AtomicReference instances
- Improve abstraction over internal state of UniOperatorProcessor
- Use further atomic field updaters in selected places (Uni)
- Use CaS methods in UniOperatorProcessor
