### PR TITLE
Allow disabling all Callback decorators via environment properties

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/infrastructure/Infrastructure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/infrastructure/Infrastructure.java
@@ -21,6 +21,9 @@ import io.smallrye.mutiny.tuples.Functions;
 
 public class Infrastructure {
 
+    private static final String DISABLE_CALLBACK_DECORATORS_PROP_NAME = "mutiny.disableCallBackDecorators";
+    private static final boolean DISABLE_CALLBACK_DECORATORS = Boolean.getBoolean(DISABLE_CALLBACK_DECORATORS_PROP_NAME);
+
     static {
         ServiceLoader<ExecutorConfiguration> executorLoader = ServiceLoader.load(ExecutorConfiguration.class);
         Iterator<ExecutorConfiguration> iterator = executorLoader.iterator();
@@ -313,11 +316,13 @@ public class Infrastructure {
     }
 
     public static void reloadCallbackDecorators() {
-        ServiceLoader<CallbackDecorator> loader = ServiceLoader.load(CallbackDecorator.class);
-        ArrayList<CallbackDecorator> interceptors = new ArrayList<>();
-        loader.forEach(interceptors::add);
-        interceptors.sort(Comparator.comparingInt(MutinyInterceptor::ordinal));
-        CALLBACK_DECORATORS = interceptors.toArray(CALLBACK_DECORATORS);
+        if (!DISABLE_CALLBACK_DECORATORS) {
+            ServiceLoader<CallbackDecorator> loader = ServiceLoader.load(CallbackDecorator.class);
+            ArrayList<CallbackDecorator> interceptors = new ArrayList<>();
+            loader.forEach(interceptors::add);
+            interceptors.sort(Comparator.comparingInt(MutinyInterceptor::ordinal));
+            CALLBACK_DECORATORS = interceptors.toArray(CALLBACK_DECORATORS);
+        }
     }
 
     public static void clearInterceptors() {


### PR DESCRIPTION
The `CallbackDecorator` provided by Contex Propagation has a strong impact on performance, and in some contexts unnecessary.

It's rather tricky to remove it from classpath, so it would be very handy to have a different option to disable it.

cc/ @jponge @FroMage 