### PR TITLE
Fix UniToMultiPublisher race condition

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/converters/uni/UniToMultiPublisher.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/converters/uni/UniToMultiPublisher.java
@@ -1,9 +1,6 @@
 package io.smallrye.mutiny.converters.uni;
 
-import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -32,8 +29,17 @@ public final class UniToMultiPublisher<T> implements Publisher<T> {
         private final Uni<T> uni;
         private final Subscriber<? super T> downstream;
 
-        private final AtomicReference<UniSubscription> upstream = new AtomicReference<>();
-        private final AtomicBoolean uniSubscriptionRequested = new AtomicBoolean(false);
+        enum State {
+            INIT,
+            UNI_REQUESTED,
+            DONE
+        }
+
+        private volatile UniSubscription upstream;
+        private volatile State state = State.INIT;
+
+        private static final AtomicReferenceFieldUpdater<UniToMultiSubscription, State> STATE_UPDATER = AtomicReferenceFieldUpdater
+                .newUpdater(UniToMultiSubscription.class, State.class, "state");
 
         private UniToMultiSubscription(Uni<T> uni, Subscriber<? super T> downstream) {
             this.uni = uni;
@@ -42,9 +48,8 @@ public final class UniToMultiPublisher<T> implements Publisher<T> {
 
         @Override
         public void cancel() {
-            UniSubscription sub = upstream.getAndSet(CANCELLED);
-            if (sub != null) {
-                sub.cancel();
+            if (upstream != null) {
+                upstream.cancel();
             }
         }
 
@@ -54,17 +59,16 @@ public final class UniToMultiPublisher<T> implements Publisher<T> {
                 downstream.onError(new IllegalArgumentException("Invalid request"));
                 return;
             }
-            if (upstream.get() == CANCELLED) {
-                return;
-            }
-            if (uniSubscriptionRequested.compareAndSet(false, true)) {
+            if (STATE_UPDATER.compareAndSet(this, State.INIT, State.UNI_REQUESTED)) {
                 AbstractUni.subscribe(uni, this);
             }
         }
 
         @Override
         public void onSubscribe(UniSubscription subscription) {
-            if (!upstream.compareAndSet(null, subscription)) {
+            if (upstream == null) {
+                upstream = subscription;
+            } else {
                 subscription.cancel();
                 downstream.onError(new IllegalStateException(
                         "Invalid subscription state - already have a subscription for upstream"));
@@ -73,7 +77,7 @@ public final class UniToMultiPublisher<T> implements Publisher<T> {
 
         @Override
         public void onItem(T item) {
-            if (upstream.getAndSet(CANCELLED) != CANCELLED) {
+            if (STATE_UPDATER.compareAndSet(this, State.UNI_REQUESTED, State.DONE)) {
                 if (item != null) {
                     downstream.onNext(item);
                 }
@@ -83,7 +87,8 @@ public final class UniToMultiPublisher<T> implements Publisher<T> {
 
         @Override
         public void onFailure(Throwable failure) {
-            if (upstream.getAndSet(CANCELLED) != CANCELLED) {
+            if (STATE_UPDATER.compareAndSet(this, UniToMultiSubscription.State.UNI_REQUESTED,
+                    UniToMultiSubscription.State.DONE)) {
                 downstream.onError(failure);
             }
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/SwitchableSubscriptionSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/SwitchableSubscriptionSubscriber.java
@@ -149,12 +149,12 @@ public abstract class SwitchableSubscriptionSubscriber<O> implements MultiSubscr
                     unbounded = true;
                 }
             }
-            Subscription actual = currentUpstream.get();
 
             if (wip.decrementAndGet() != 0) {
                 drainLoop();
             }
 
+            Subscription actual = currentUpstream.get();
             if (actual != null) {
                 actual.request(n);
             }

--- a/implementation/src/test/java/io/smallrye/mutiny/BugReproducersTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/BugReproducersTest.java
@@ -1,0 +1,29 @@
+package io.smallrye.mutiny;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class BugReproducersTest {
+
+    @RepeatedTest(100)
+    public void reproducer_689() {
+        // Adapted from https://github.com/smallrye/smallrye-mutiny/issues/689
+        AtomicLong src = new AtomicLong();
+
+        AssertSubscriber<Long> sub = Multi.createBy().repeating()
+                .supplier(src::incrementAndGet)
+                .until(l -> l.equals(10_000L))
+                .flatMap(l -> Multi.createFrom().item(l * 2))
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+
+        sub.awaitCompletion();
+        assertThat(sub.getItems()).hasSize(9_999);
+    }
+}


### PR DESCRIPTION
- Protect UniToMultiPublisher from re-subscriptions when concurrent requests happen
- Refactor concurrency management in UniToMultiPublisher

Fixes #689
