### PR TITLE
No need to release downstream subscriber references

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOp.java
@@ -162,7 +162,7 @@ public class MultiWindowOp<T> extends AbstractMultiOperator<T, Multi<T>> {
 
         @Override
         public void cancel() {
-            if (atomicallyFlipDownstreamHasCancelled()) {
+            if (compareAndSwapDownstreamCancellationRequest()) {
                 if (count.decrementAndGet() == 0) {
                     getUpstreamSubscription().cancel();
                 }
@@ -276,7 +276,7 @@ public class MultiWindowOp<T> extends AbstractMultiOperator<T, Multi<T>> {
 
         @Override
         public void cancel() {
-            if (atomicallyFlipDownstreamHasCancelled()) {
+            if (compareAndSwapDownstreamCancellationRequest()) {
                 if (count.decrementAndGet() == 0) {
                     getUpstreamSubscription().cancel();
                 }
@@ -467,7 +467,7 @@ public class MultiWindowOp<T> extends AbstractMultiOperator<T, Multi<T>> {
 
         @Override
         public void cancel() {
-            if (atomicallyFlipDownstreamHasCancelled()) {
+            if (compareAndSwapDownstreamCancellationRequest()) {
                 run();
             }
         }

--- a/implementation/src/test/java/io/smallrye/mutiny/BugReproducersTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/BugReproducersTest.java
@@ -1,18 +1,28 @@
 package io.smallrye.mutiny;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 
-public class BugReproducersTest {
+class BugReproducersTest {
 
     @RepeatedTest(100)
-    public void reproducer_689() {
+    void reproducer_689() {
         // Adapted from https://github.com/smallrye/smallrye-mutiny/issues/689
         AtomicLong src = new AtomicLong();
 
@@ -25,5 +35,44 @@ public class BugReproducersTest {
 
         sub.awaitCompletion();
         assertThat(sub.getItems()).hasSize(9_999);
+    }
+
+    @Test
+    void reproducer_705() {
+        // Adapted from https://github.com/smallrye/smallrye-mutiny/issues/705
+        // The issue was an over-interpretation of one of the RS TCK rule regarding releasing subscriber references.
+        AssertSubscriber<List<Integer>> sub = AssertSubscriber.create();
+        AtomicInteger counter = new AtomicInteger();
+        AtomicReference<Throwable> threadFailure = new AtomicReference<>();
+
+        ExecutorService threadPool = Executors.newFixedThreadPool(4, new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable task) {
+                Thread thread = Executors.defaultThreadFactory().newThread(task);
+                thread.setUncaughtExceptionHandler((t, e) -> {
+                    e.printStackTrace();
+                    threadFailure.set(e);
+                });
+                return thread;
+            }
+        });
+
+        Multi.createFrom().range(0, 1000)
+                .emitOn(threadPool)
+                .group().intoLists().of(100)
+                .onItem().invoke(() -> {
+                    if (counter.incrementAndGet() == 3) {
+                        sub.cancel();
+                    }
+                })
+                .runSubscriptionOn(threadPool)
+                .subscribe().withSubscriber(sub);
+
+        sub.request(Long.MAX_VALUE);
+        await().atMost(5, TimeUnit.SECONDS).untilAtomic(counter, greaterThanOrEqualTo(3));
+
+        assertThat(threadFailure.get()).isNull();
+        sub.assertNotTerminated();
+        threadPool.shutdownNow();
     }
 }


### PR DESCRIPTION
We used to have an over interpretation of the RS TCK that downstream subscriber references had to be null on cancellation.

It's actually not necessary (and NPE-prone) since operators are instantiated per-subscription, so the *publisher* does not actually keep references on cancelled subscribers.

Fixes #705
