### PR TITLE
Use the SR-CP call that uses the context settings or MP-config settings

### DIFF
--- a/context-propagation/src/main/java/io/smallrye/mutiny/context/DefaultContextPropagationInterceptor.java
+++ b/context-propagation/src/main/java/io/smallrye/mutiny/context/DefaultContextPropagationInterceptor.java
@@ -9,6 +9,6 @@ public class DefaultContextPropagationInterceptor extends BaseContextPropagation
 
     @Override
     protected SmallRyeThreadContext getThreadContext() {
-        return SmallRyeThreadContext.getCurrentThreadContextOrPropagatedContexts();
+        return SmallRyeThreadContext.getCurrentThreadContextOrDefaultContexts();
     }
 }

--- a/context-propagation/src/main/java/io/smallrye/mutiny/context/MutinyContextManagerExtension.java
+++ b/context-propagation/src/main/java/io/smallrye/mutiny/context/MutinyContextManagerExtension.java
@@ -17,7 +17,7 @@ public class MutinyContextManagerExtension implements ContextManagerExtension {
         Infrastructure.setCompletableFutureWrapper(new UnaryOperator<CompletableFuture<?>>() {
             @Override
             public CompletableFuture<?> apply(CompletableFuture<?> t) {
-                ThreadContext threadContext = SmallRyeThreadContext.getCurrentThreadContextOrPropagatedContexts();
+                ThreadContext threadContext = SmallRyeThreadContext.getCurrentThreadContextOrDefaultContexts();
                 return threadContext.withContextCapture(t);
             }
         });


### PR DESCRIPTION
This is the equivalent of https://github.com/quarkusio/quarkus/pull/19869 which we did for Quarkus.

It allows the user to get either scope-local context settings, or default to MP-config settings instead of the "all propagation" that was the case before. This allows users to override the context settings globally.