### PR TITLE
Make UniRetry & MultiRetry propagate the original Exception (#724)

### DIFF
--- a/documentation/src/test/java/guides/RetryTest.java
+++ b/documentation/src/test/java/guides/RetryTest.java
@@ -38,7 +38,10 @@ public class RetryTest {
                 .withBackOff(Duration.ofMillis(100), Duration.ofSeconds(1))
                 .atMost(3);
         // end::retry-backoff[]
-        assertThatThrownBy(() -> u.await().indefinitely()).hasMessageContaining("3/3");
+        assertThatThrownBy(() -> u.await().indefinitely())
+                .getCause() // Expected exception is wrapped in a java.util.concurrent.CompletionException
+                .hasMessageContaining("boom")
+                .hasSuppressedException(new IllegalStateException("Retries exhausted: 3/3"));
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryWhenTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryWhenTest.java
@@ -299,7 +299,7 @@ public class MultiOnFailureRetryWhenTest {
                 .subscribe().withSubscriber(AssertSubscriber.create(100));
 
         subscriber
-                .await(Duration.ofSeconds(10))
+                .awaitCompletion(Duration.ofSeconds(10))
                 .assertItems("hey")
                 .assertCompleted();
     }
@@ -319,7 +319,14 @@ public class MultiOnFailureRetryWhenTest {
         await().until(() -> subscriber.getItems().size() >= 10);
         subscriber
                 .assertItems(0, 1, 0, 1, 0, 1, 0, 1, 0, 1) // Initial subscription + 4 retries
-                .assertFailedWith(IllegalStateException.class, "Retries exhausted");
+                .assertFailedWith(IOException.class, "boom retry")
+                .awaitFailure(t -> {
+                    // expecting an IllegalStateException with an info about the retries made
+                    Throwable[] suppressed = exception.getSuppressed();
+                    assertThat(suppressed.length).isEqualTo(1);
+                    assertThat(suppressed).anyMatch(s -> s instanceof IllegalStateException &&
+                            s.getMessage().equals("Retries exhausted: 4/4"));
+                });
 
     }
 
@@ -336,7 +343,14 @@ public class MultiOnFailureRetryWhenTest {
         await().until(() -> subscriber.getItems().size() >= 10);
         subscriber
                 .assertItems(0, 1, 0, 1, 0, 1, 0, 1, 0, 1) // Initial subscription + 4 retries
-                .assertFailedWith(IllegalStateException.class, "Retries exhausted: 4/4");
+                .assertFailedWith(IOException.class, "boom retry")
+                .awaitFailure(t -> {
+                    // expecting an IllegalStateException with an info about the retries made
+                    Throwable[] suppressed = exception.getSuppressed();
+                    assertThat(suppressed.length).isEqualTo(1);
+                    assertThat(suppressed).anyMatch(s -> s instanceof IllegalStateException &&
+                            s.getMessage().equals("Retries exhausted: 4/4"));
+                });
     }
 
     @Test
@@ -353,7 +367,14 @@ public class MultiOnFailureRetryWhenTest {
                 .until(() -> subscriber.getItems().size() >= 10);
         subscriber
                 .assertItems(0, 1, 0, 1, 0, 1, 0, 1, 0, 1) // Initial subscription + 4 retries
-                .assertFailedWith(IllegalStateException.class, "Retries exhausted: 4/4");
+                .assertFailedWith(IOException.class, "boom retry")
+                .awaitFailure(t -> {
+                    // expecting an IllegalStateException with an info about the retries made
+                    Throwable[] suppressed = exception.getSuppressed();
+                    assertThat(suppressed.length).isEqualTo(1);
+                    assertThat(suppressed).anyMatch(s -> s instanceof IllegalStateException &&
+                            s.getMessage().equals("Retries exhausted: 4/4"));
+                });
     }
 
 }


### PR DESCRIPTION
This changes the behavior of `ExponentialBackoff#randomExponentialBackoffFunction` so that the original Exception is propagated when the number of retries gets exhausted. An `IllegalStateException` with the number of retries made is added to the suppressed Exceptions in the original Exception.