### PR TITLE
Fix Issue #733: Not attaching to calling coroutine context anymore

### DIFF
--- a/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/UniAwaitSuspendingTest.kt
+++ b/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/UniAwaitSuspendingTest.kt
@@ -3,6 +3,7 @@ package io.smallrye.mutiny.coroutines
 import io.smallrye.mutiny.Uni
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -11,6 +12,7 @@ import org.assertj.core.api.Assertions.assertThat
 import java.time.Duration
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.Executors
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -125,5 +127,19 @@ class UniAwaitSuspendingTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun `verify that Uni emission is not blocked by the caller`() {
+        // Given
+        val uni = Uni.createFrom().item(23)
+
+        // When
+        val item = runBlocking(Executors.newSingleThreadExecutor().asCoroutineDispatcher()) {
+            uni.awaitSuspending()
+        }
+
+        // Then
+        assertThat(item).isEqualTo(23)
     }
 }


### PR DESCRIPTION
Solves https://github.com/smallrye/smallrye-mutiny/issues/733

Was able to clearly reproduce it with the example @pwlan had provided - thank you therefore.

There was a deadlock between the thread calling `Multi.onItem()` and the call to `Flow.collect()`.
I'm not deep enough in coroutine handling to explain it, but my best guess is, that with the attaching to the context, that calls `Multi.asFlow()` in `Multi.onItem()`, it tried to use the same thread for both.