### PR TITLE
Add item timeouts to Multi

### DIFF
--- a/implementation/revapi.json
+++ b/implementation/revapi.json
@@ -26,6 +26,11 @@
         "code": "java.annotation.added",
         "annotation": "@io.smallrye.common.annotation.CheckReturnValue",
         "justification": "This is a marker interface for static code analysis tools"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "classQualifiedName": "io.smallrye.mutiny.Multi",
+        "justification": "Addition of the `ifNoItem` group."
       }
     ]
   }

--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import io.smallrye.common.annotation.Experimental;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -176,6 +177,25 @@ public interface Multi<T> extends Publisher<T> {
      */
     @CheckReturnValue
     MultiOnFailure<T> onFailure(Class<? extends Throwable> typeOfFailure);
+
+    /**
+     * Produces a {@link Multi} reacting when no item event is fired by the upstream multi for the specified length
+     * of time.
+     * <p>
+     * This {@link Multi} detects if this {@link Multi} does not emit an item for the configured length of time.
+     * <p>
+     * Examples:
+     * <code>
+     * multi.ifNoItem().after(Duration.ofMillis(1000)).fail() // Propagate a TimeoutException
+     * multi.ifNoItem().after(Duration.ofMillis(1000)).recoverWithCompletion() // Complete the event on timeout
+     * multi.ifNoItem().after(Duration.ofMillis(1000)).on(myExecutor)... // Configure the executor calling on timeout actions
+     * </code>
+     *
+     * @return the on item timeout group
+     */
+    @Experimental("Multi timeouts are an experimental feature.")
+    @CheckReturnValue
+    MultiIfNoItem<T> ifNoItem();
 
     /**
      * Creates a new {@link Multi} that subscribes to this upstream and caches all of its events and replays them, to

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiIfNoItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiIfNoItem.java
@@ -1,0 +1,31 @@
+package io.smallrye.mutiny.groups;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.validate;
+
+import java.time.Duration;
+
+import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Multi;
+
+@Experimental("Multi timeouts are an experimental feature.")
+public class MultiIfNoItem<T> {
+
+    private final Multi<T> upstream;
+
+    public MultiIfNoItem(Multi<T> upstream) {
+        this.upstream = nonNull(upstream, "upstream");
+    }
+
+    /**
+     * Configures the timeout duration.
+     *
+     * @param timeout the timeout, must not be {@code null}, must be strictly positive.
+     * @return a new {@link MultiOnItemTimeout}
+     */
+    @CheckReturnValue
+    public MultiOnItemTimeout<T> after(Duration timeout) {
+        return new MultiOnItemTimeout<>(upstream, validate(timeout, "timeout"), null);
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItemTimeout.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItemTimeout.java
@@ -1,0 +1,93 @@
+package io.smallrye.mutiny.groups;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.validate;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+
+import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.TimeoutException;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.multi.MultiFailOnItemTimeout;
+
+@Experimental("Multi timeouts are an experimental feature.")
+public class MultiOnItemTimeout<T> {
+
+    private final Multi<T> failure;
+    private final Duration timeout;
+    private final ScheduledExecutorService executor;
+
+    public MultiOnItemTimeout(Multi<T> upstream, Duration timeout, ScheduledExecutorService executor) {
+        this.failure = nonNull(upstream, "upstream");
+        this.timeout = validate(timeout, "timeout");
+        this.executor = executor;
+    }
+
+    /**
+     * Configures on which executor the timeout is measured.
+     * Note that this executor is also going to be used to fire the {@code Timeout} failure event.
+     *
+     * @param executor the executor to use, must not be {@code null}
+     * @return a new {@link MultiOnItemTimeout}
+     */
+    public MultiOnItemTimeout<T> on(ScheduledExecutorService executor) {
+        return new MultiOnItemTimeout<>(failure, timeout, nonNull(executor, "executor"));
+    }
+
+    @CheckReturnValue
+    public Multi<T> fail() {
+        return Infrastructure.onMultiCreation(failWith(TimeoutException::new));
+    }
+
+    @CheckReturnValue
+    public Multi<T> failWith(Throwable failure) {
+        return failWith(() -> failure);
+    }
+
+    @CheckReturnValue
+    public Multi<T> failWith(Supplier<? extends Throwable> supplier) {
+        Supplier<? extends Throwable> actual = Infrastructure.decorate(nonNull(supplier, "supplier"));
+        return Infrastructure.onMultiCreation(new MultiFailOnItemTimeout<>(failure, timeout, actual, executor));
+    }
+
+    /**
+     * Produces a new {@link Multi} firing a completion when the current {@link Multi} does not
+     * emit an item before the timeout.
+     *
+     * @return the new {@link Multi}
+     */
+    @CheckReturnValue
+    public Multi<T> recoverWithCompletion() {
+        return fail().onFailure(TimeoutException.class).recoverWithCompletion();
+    }
+
+    /**
+     * Produces a new {@link Multi} providing a fallback {@link Multi} when the current {@link Multi} times out. The fallback
+     * is produced using the given supplier, and is called when the failure is caught. The produced {@link Multi} is used
+     * instead of the current {@link Multi}.
+     *
+     * @param supplier the fallback supplier, must not be {@code null}, must not produce {@code null}
+     * @return the new {@link Multi}
+     */
+    @CheckReturnValue
+    public Multi<T> recoverWithMulti(Supplier<Multi<? extends T>> supplier) {
+        // Decoration happens in `recoverWithMulti`
+        return fail().onFailure(TimeoutException.class).recoverWithMulti(supplier);
+    }
+
+    /**
+     * Produces a new {@link Multi} providing a fallback {@link Multi} when the current {@link Multi} times out. The fallback
+     * {@link Multi} is used instead of the current {@link Multi}.
+     *
+     * @param fallback the fallback {@link Multi}, must not be {@code null}
+     * @return the new {@link Multi}
+     */
+    @CheckReturnValue
+    public Multi<T> recoverWithMulti(Multi<? extends T> fallback) {
+        return fail().onFailure(TimeoutException.class).recoverWithMulti(fallback);
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
@@ -71,6 +71,11 @@ public abstract class AbstractMulti<T> implements Multi<T> {
     }
 
     @Override
+    public MultiIfNoItem<T> ifNoItem() {
+        return new MultiIfNoItem<>(this);
+    }
+
+    @Override
     public Multi<T> cache() {
         return Infrastructure.onMultiCreation(new MultiCacheOp<>(this));
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiFailOnItemTimeout.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiFailOnItemTimeout.java
@@ -1,0 +1,137 @@
+package io.smallrye.mutiny.operators.multi;
+
+import static io.smallrye.mutiny.helpers.Subscriptions.CANCELLED;
+
+import java.time.Duration;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import io.smallrye.common.annotation.Experimental;
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.EmptyUniSubscription;
+import io.smallrye.mutiny.helpers.ParameterValidation;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.MultiOperator;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+@Experimental("Multi timeouts are an experimental feature.")
+public class MultiFailOnItemTimeout<I> extends MultiOperator<I, I> {
+    private final Duration timeout;
+    private final Supplier<? extends Throwable> supplier;
+    private final ScheduledExecutorService executor;
+
+    public MultiFailOnItemTimeout(Multi<I> upstream, Duration timeout, Supplier<? extends Throwable> supplier,
+            ScheduledExecutorService executor) {
+        super(upstream);
+        this.timeout = timeout;
+        this.supplier = supplier;
+        this.executor = executor == null ? Infrastructure.getDefaultWorkerPool() : executor;
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super I> subscriber) {
+        upstream().subscribe().withSubscriber(new MultiFailOnItemTimeoutProcessor(subscriber));
+    }
+
+    public class MultiFailOnItemTimeoutProcessor extends MultiOperatorProcessor<I, I> {
+
+        private volatile ScheduledFuture<?> timeoutFuture;
+
+        public MultiFailOnItemTimeoutProcessor(MultiSubscriber<? super I> downstream) {
+            super(downstream);
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            if (!scheduleTimeout()) {
+                subscription.cancel();
+                downstream.onSubscribe(EmptyUniSubscription.DONE);
+            }
+            super.onSubscribe(subscription);
+        }
+
+        @Override
+        public void onItem(I item) {
+            Subscription sub = getUpstreamSubscription();
+            if (sub != CANCELLED) {
+                if (timeoutFuture != null) {
+                    timeoutFuture.cancel(false);
+                    if (!scheduleTimeout()) {
+                        //On failure is already called in scheduleTimeout
+                        return;
+                    }
+                }
+                downstream.onItem(item);
+            }
+        }
+
+        @Override
+        public void onFailure(Throwable failure) {
+            Subscription sub = getAndSetUpstreamSubscription(CANCELLED);
+            if (sub != CANCELLED) {
+                if (timeoutFuture != null) {
+                    timeoutFuture.cancel(false);
+                }
+                downstream.onFailure(failure);
+            } else {
+                Infrastructure.handleDroppedException(failure);
+            }
+        }
+
+        @Override
+        public void onCompletion() {
+            Subscription sub = getAndSetUpstreamSubscription(CANCELLED);
+            if (sub != CANCELLED) {
+                if (timeoutFuture != null) {
+                    timeoutFuture.cancel(false);
+                }
+                downstream.onCompletion();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (timeoutFuture != null) {
+                timeoutFuture.cancel(false);
+            }
+            super.cancel();
+        }
+
+        private void doTimeout() {
+            if (isCancelled()) {
+                return;
+            }
+            super.cancel();
+
+            Throwable throwable;
+            try {
+                throwable = supplier.get();
+            } catch (Throwable e) {
+                downstream.onFailure(e);
+                return;
+            }
+            if (throwable == null) {
+                downstream.onFailure(new NullPointerException(ParameterValidation.SUPPLIER_PRODUCED_NULL));
+            } else {
+                downstream.onFailure(throwable);
+            }
+        }
+
+        private boolean scheduleTimeout() {
+            try {
+                timeoutFuture = executor.schedule(this::doTimeout, timeout.toMillis(), TimeUnit.MILLISECONDS);
+                return true;
+            } catch (RejectedExecutionException e) {
+                // Executor out of service.
+                getAndSetUpstreamSubscription(CANCELLED);
+                downstream.onFailure(e);
+                return false;
+            }
+        }
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIfNoItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIfNoItemTest.java
@@ -1,0 +1,218 @@
+package io.smallrye.mutiny.operators;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.TestException;
+import io.smallrye.mutiny.TimeoutException;
+import io.smallrye.mutiny.helpers.ParameterValidation;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+
+public class MultiIfNoItemTest {
+
+    @Test
+    public void testResultWhenTimeoutIsNotReached() {
+        AssertSubscriber<Long> subscriber = AssertSubscriber.create(10);
+
+        Multi.createFrom().ticks().every(Duration.ofMillis(10))
+                .select().first(4)
+                .ifNoItem().after(Duration.ofMillis(20)).recoverWithCompletion()
+                .subscribe().withSubscriber(subscriber);
+
+        subscriber.awaitCompletion().assertItems(0L, 1L, 2L, 3L);
+    }
+
+    @Test
+    public void testTimeoutBeforeFirstItem() {
+        AssertSubscriber<Long> subscriber = AssertSubscriber.create(10);
+
+        Multi.createFrom().ticks().startingAfter(Duration.ofMillis(20)).every(Duration.ofMillis(20))
+                .ifNoItem().after(Duration.ofMillis(10)).fail()
+                .subscribe().withSubscriber(subscriber);
+
+        subscriber.awaitFailure(Duration.ofSeconds(2))
+                .assertHasNotReceivedAnyItem()
+                .assertFailedWith(TimeoutException.class);
+    }
+
+    @Test
+    public void testTimeoutAfterFirstItem() {
+        AssertSubscriber<Long> subscriber = AssertSubscriber.create(10);
+
+        Multi.createFrom().ticks().every(Duration.ofMillis(20))
+                .ifNoItem().after(Duration.ofMillis(10)).fail()
+                .subscribe().withSubscriber(subscriber);
+
+        subscriber.awaitFailure(Duration.ofSeconds(2))
+                .assertItems(0L)
+                .assertFailedWith(TimeoutException.class);
+    }
+
+    @Test
+    public void testTimeoutOnFailure() {
+        AssertSubscriber<Long> subscriber = AssertSubscriber.create();
+
+        Multi.createFrom().<Long> emitter(e -> new Thread(() -> {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException interruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            e.fail(new TestException("boom"));
+        }).start())
+                .ifNoItem().after(Duration.ofMillis(1)).fail()
+                .subscribe().withSubscriber(subscriber);
+
+        subscriber.awaitFailure()
+                .assertFailedWith(TimeoutException.class);
+    }
+
+    @Test
+    @Timeout(2)
+    public void testFailureBeforeTimeout() {
+        AtomicBoolean subscribed = new AtomicBoolean(false);
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
+
+        Multi.createFrom().<Integer> emitter(e -> new Thread(() -> {
+            await().untilTrue(subscribed);
+            e.fail(new TestException("boom"));
+        }).start())
+                .ifNoItem().after(Duration.ofMillis(10000)).fail()
+                .subscribe().withSubscriber(subscriber);
+
+        subscribed.set(true);
+        subscriber.awaitFailure()
+                .assertFailedWith(TestException.class);
+    }
+
+    @Test
+    public void testRecoverWithCompletion() {
+        AssertSubscriber<Object> subscriber = Multi.createFrom().nothing()
+                .ifNoItem().after(Duration.ofMillis(10)).recoverWithCompletion()
+                .subscribe().withSubscriber(AssertSubscriber.create());
+        subscriber.awaitCompletion();
+    }
+
+    @Test
+    public void testRecoverWithSwitchToMulti() {
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> nothing()
+                .ifNoItem().after(Duration.ofMillis(10)).recoverWithMulti(Multi.createFrom().item(15))
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
+        subscriber.awaitCompletion().assertItems(15);
+    }
+
+    @Test
+    public void testRecoverWithSwitchToMultiSupplier() {
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> nothing()
+                .ifNoItem().after(Duration.ofMillis(10)).recoverWithMulti(() -> Multi.createFrom().item(15))
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
+        subscriber.awaitCompletion().assertItems(15);
+    }
+
+    @Test
+    public void testFailingWithAnotherException() {
+        AssertSubscriber<Integer> subscriber = Multi.createFrom().<Integer> nothing()
+                .ifNoItem().after(Duration.ofMillis(10)).failWith(new IOException("boom"))
+                .subscribe().withSubscriber(AssertSubscriber.create());
+        subscriber.awaitFailure().assertFailedWith(IOException.class, "boom");
+    }
+
+    @Test
+    public void testDurationValidity() {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+                () -> Multi.createFrom().item(1).ifNoItem().after(null))
+                .withMessageContaining("timeout");
+
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+                () -> Multi.createFrom().item(1).ifNoItem().after(Duration.ofMillis(0)))
+                .withMessageContaining("timeout");
+
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+                () -> Multi.createFrom().item(1).ifNoItem().after(Duration.ofMillis(-1)))
+                .withMessageContaining("timeout");
+    }
+
+    @Test
+    public void testFailingOnTimeoutWithShutdownExecutor() {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        executor.shutdown();
+        AssertSubscriber<Object> subscriber = Multi.createFrom().nothing()
+                .ifNoItem().after(Duration.ofMillis(10)).on(executor).fail()
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        subscriber
+                .awaitFailure()
+                .assertFailedWith(RejectedExecutionException.class, "");
+    }
+
+    @Test
+    public void testFailingOnItemWithShutdownExecutor() {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        AssertSubscriber<Object> subscriber = Multi.createFrom().ticks().every(Duration.ofMillis(10))
+                .ifNoItem().after(Duration.ofMillis(20)).on(executor).fail()
+                .subscribe().withSubscriber(AssertSubscriber.create(10));
+
+        executor.shutdown();
+
+        subscriber
+                .awaitFailure()
+                .assertFailedWith(RejectedExecutionException.class, "");
+    }
+
+    @Test
+    public void testFailingOnTimeoutWithImmediateCancellation() {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        AssertSubscriber<Object> subscriber = Multi.createFrom().nothing()
+                .ifNoItem().after(Duration.ofMillis(10)).on(executor).fail()
+                .subscribe().withSubscriber(new AssertSubscriber<>(1, true));
+
+        subscriber.assertNotTerminated()
+                .assertSubscribed();
+    }
+
+    @Test
+    public void testFailingOnTimeoutWithCancellation() {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        AssertSubscriber<Object> subscriber = Multi.createFrom().nothing()
+                .ifNoItem().after(Duration.ofMillis(1000)).on(executor).fail()
+                .subscribe().withSubscriber(new AssertSubscriber<>(1, false));
+
+        subscriber.cancel();
+
+        subscriber.assertNotTerminated()
+                .assertSubscribed();
+    }
+
+    @Test
+    public void testTimeoutWithCustomSupplierFailing() {
+        AssertSubscriber<Object> subscriber = Multi.createFrom().nothing()
+                .ifNoItem().after(Duration.ofMillis(1)).failWith(() -> {
+                    throw new IllegalArgumentException("boom");
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        subscriber.awaitFailure()
+                .assertFailedWith(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testTimeoutWithCustomSupplierReturningNull() {
+        AssertSubscriber<Object> subscriber = Multi.createFrom().nothing()
+                .ifNoItem().after(Duration.ofMillis(1)).failWith(() -> null)
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        subscriber.awaitFailure()
+                .assertFailedWith(NullPointerException.class, ParameterValidation.SUPPLIER_PRODUCED_NULL);
+    }
+}


### PR DESCRIPTION
This PR adds `ifNoItem()` to Multi allowing for handling when a stream is slower than expected. The operator uses a timer to count down the time since the last item was emitted and will throw a TimeoutException if the threshold is exceeded. This PR does not address the overall time it takes a Multi to terminate, only the time between items.

Usage:
- multi.ifNoItem().after(Duration.ofMillis(1000)).fail() // Propagate a TimeoutException
- multi.ifNoItem().after(Duration.ofMillis(1000)).recoverWithCompletion() // Complete the event on timeout
- multi.ifNoItem().after(Duration.ofMillis(1000)).on(myExecutor)... // Configure the executor calling on timeout actions

The code in this PR is largely copied from the Uni equivalent. Key differences are: 
- Operator resets the timer rather than closing the stream after receiving an item
- The `recoverWithItem` equivalent is `recoverWithCompletion`
- Tests use `ticks()` rather than `delayIt()`

Relevant issue: #11 