### PR TITLE
Parallel tests execution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ We even accept pull requests just containing tests or documentation.
 If you have not done so on this machine, you need to:
  
 * Install Git and configure your GitHub access
-* Install Java SDK (OpenJDK recommended)
-* Install Apache Maven
+* Install Java SDK (OpenJDK recommended, see https://adoptium.net/)
+* Install Apache Maven (or use the `mvnw` wrapper scripts instead of `mvn`)
 
 ## Build
 
@@ -66,6 +66,21 @@ cd smallrye-mutiny
 mvn clean install
 # Wait... success!
 ```
+
+### Faster builds
+
+Tests account for the majority of the build time.
+
+There are 2 Maven profiles that you can activate to speed up the build of the Mutiny core library (in `implementation/`):
+
+- `-Pskip-rs-tck` to avoid running the Reactive Streams TCK
+- `-Pparallel-tests` to run the JUnit5 tests in parallel
+
+The 2 profiles can be activated at the same time if you want to benefit from parallel tests and skip the Reactive Streams TCK.
+This is mostly useful to have fast development feedback loops.
+
+Note that parallel tests are not activated by default (yet) because some tests may randomly fail if your system is under load, or if it has constrained resources.
+The Reactive Streams TCK is a good example as it uses some time-sensitive checks.
 
 ## The small print
 

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -175,5 +175,27 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>parallel-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <properties>
+                                <configurationParameters>
+                                    junit.jupiter.extensions.autodetection.enabled=true
+                                    junit.jupiter.testinstance.lifecycle.default = per_class
+                                    junit.jupiter.execution.parallel.enabled = true
+                                    junit.jupiter.execution.parallel.mode.default = same_thread
+                                    junit.jupiter.execution.parallel.mode.classes.default = concurrent
+                                </configurationParameters>
+                            </properties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiTimePeriod.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiTimePeriod.java
@@ -14,7 +14,7 @@ import io.smallrye.mutiny.operators.multi.builders.IntervalMulti;
 public class MultiTimePeriod {
 
     private Duration initialDelay;
-    private ScheduledExecutorService executor = Infrastructure.getDefaultWorkerPool();
+    private ScheduledExecutorService executor;
 
     @CheckReturnValue
     public MultiTimePeriod startingAfter(Duration duration) {
@@ -31,10 +31,14 @@ public class MultiTimePeriod {
     @CheckReturnValue
     public Multi<Long> every(Duration duration) {
         validate(duration, "duration");
+        ScheduledExecutorService executorService = this.executor;
+        if (executorService == null) {
+            executorService = Infrastructure.getDefaultWorkerPool();
+        }
         if (initialDelay != null) {
-            return Infrastructure.onMultiCreation(new IntervalMulti(initialDelay, duration, executor));
+            return Infrastructure.onMultiCreation(new IntervalMulti(initialDelay, duration, executorService));
         } else {
-            return Infrastructure.onMultiCreation(new IntervalMulti(duration, executor));
+            return Infrastructure.onMultiCreation(new IntervalMulti(duration, executorService));
         }
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/BugReproducersTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/BugReproducersTest.java
@@ -16,10 +16,14 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 class BugReproducersTest {
 
     @RepeatedTest(100)

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiBroadcastTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiBroadcastTest.java
@@ -8,11 +8,15 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.MultiEmitterProcessor;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiBroadcastTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiDisjointTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiDisjointTest.java
@@ -9,13 +9,17 @@ import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import junit5.support.InfrastructureResource;
 
 @SuppressWarnings("ConstantConditions")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiDisjointTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/UniMemoizeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/UniMemoizeTest.java
@@ -16,6 +16,8 @@ import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.reactivex.processors.UnicastProcessor;
 import io.smallrye.mutiny.Multi;
@@ -28,8 +30,10 @@ import io.smallrye.mutiny.operators.uni.UniMemoizeOp;
 import io.smallrye.mutiny.subscription.Cancellable;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
+import junit5.support.InfrastructureResource;
 
 @DisplayName("Tests for the uni.memoize() group")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 class UniMemoizeTest {
 
     private static void race(Runnable candidate1, Runnable candidate2, Executor s) {

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/UniOnFailureRetryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/UniOnFailureRetryTest.java
@@ -15,10 +15,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniOnFailureRetryTest {
     @Test
     public void testFailureWithPredicateException() {

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/UniSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/UniSubscriberTest.java
@@ -11,10 +11,14 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.Cancellable;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniSubscriberTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/BlockingIterableTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/BlockingIterableTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.Multi;
@@ -29,7 +31,9 @@ import io.smallrye.mutiny.helpers.queues.SpscArrayQueue;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.AbstractMulti;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class BlockingIterableTest {
 
     @Test
@@ -244,6 +248,7 @@ public class BlockingIterableTest {
     }
 
     @Nested
+    @ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
     class ThreadBlockingTest {
 
         @BeforeEach

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/test/AssertSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/test/AssertSubscriberTest.java
@@ -12,6 +12,8 @@ import java.util.function.Consumer;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Multi;
@@ -19,7 +21,9 @@ import io.smallrye.mutiny.TestException;
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class AssertSubscriberTest {
 
     private final Duration SMALL = Duration.ofMillis(200);

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/test/UniAssertSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/test/UniAssertSubscriberTest.java
@@ -10,12 +10,16 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.TestException;
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniEmitter;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 class UniAssertSubscriberTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/CallbackDecoratorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/CallbackDecoratorTest.java
@@ -7,9 +7,13 @@ import java.util.function.*;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.tuples.Functions;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
 public class CallbackDecoratorTest {
 
     Runnable runnable = () -> {

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/DroppedExceptionsTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/DroppedExceptionsTest.java
@@ -11,10 +11,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.Cancellable;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
 public class DroppedExceptionsTest {
 
     private static final PrintStream systemErr = System.err;

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/MutinySchedulerTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/MutinySchedulerTest.java
@@ -15,11 +15,15 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import junit5.support.InfrastructureResource;
 
 @SuppressWarnings("ConstantConditions")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
 public class MutinySchedulerTest {
 
     @BeforeAll

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/UniInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/UniInterceptorTest.java
@@ -4,13 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.AbstractUni;
 import io.smallrye.mutiny.subscription.UniDelegatingSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
 public class UniInterceptorTest {
 
     @AfterEach

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
@@ -12,11 +12,15 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiCreateFromTimePeriodTest {
 
     private ScheduledExecutorService executor;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiDistinctTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiDistinctTest.java
@@ -13,6 +13,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -22,8 +24,10 @@ import io.smallrye.mutiny.helpers.spies.MultiOnCancellationSpy;
 import io.smallrye.mutiny.helpers.spies.Spy;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.subscription.MultiEmitter;
+import junit5.support.InfrastructureResource;
 
 @SuppressWarnings("ConstantConditions")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiDistinctTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
@@ -18,6 +18,8 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -33,7 +35,9 @@ import io.smallrye.mutiny.subscription.BackPressureFailure;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 import io.smallrye.mutiny.test.Mocks;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
 public class MultiGroupTest {
 
     @AfterEach

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIfNoItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIfNoItemTest.java
@@ -12,13 +12,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.TestException;
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiIfNoItemTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureInvokeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureInvokeTest.java
@@ -15,13 +15,17 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import junit5.support.InfrastructureResource;
 
 @SuppressWarnings("ConstantConditions")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiOnFailureInvokeTest {
 
     public static final IOException BOOM = new IOException("boom");

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryTest.java
@@ -10,11 +10,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.groups.MultiRetry;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiOnFailureRetryTest {
 
     private AtomicInteger numberOfSubscriptions;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryWhenTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnFailureRetryWhenTest.java
@@ -12,13 +12,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.operators.multi.MultiRetryWhenOp;
 import io.smallrye.mutiny.tuples.Tuple2;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiOnFailureRetryWhenTest {
 
     private AtomicInteger numberOfSubscriptions;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnOverflowTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnOverflowTest.java
@@ -16,6 +16,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Multi;
@@ -27,7 +29,9 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiOnOverflowTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnSubscribeTest.java
@@ -15,6 +15,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Multi;
@@ -24,7 +26,9 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.multi.MultiOnSubscribeCall;
 import io.smallrye.mutiny.operators.multi.MultiOnSubscribeInvokeOp;
 import io.smallrye.mutiny.subscription.UniEmitter;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiOnSubscribeTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSelectFirstOrLastTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSelectFirstOrLastTest.java
@@ -16,6 +16,8 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -25,7 +27,9 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiSelectFirstOrLastTest {
 
     private AtomicInteger counter;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipTest.java
@@ -13,6 +13,8 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.TestException;
@@ -20,12 +22,15 @@ import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.multi.MultiSkipUntilOtherOp;
 import io.smallrye.mutiny.subscription.MultiEmitter;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
 public class MultiSkipTest {
 
     @AfterEach
     public void cleanup() {
         Infrastructure.clearInterceptors();
+        Infrastructure.resetDroppedExceptionHandler();
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSubscribeTest.java
@@ -12,11 +12,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.Cancellable;
 import io.smallrye.mutiny.subscription.MultiEmitter;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiSubscribeTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTakeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTakeTest.java
@@ -11,14 +11,18 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.TestException;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
+import junit5.support.InfrastructureResource;
 
 @SuppressWarnings("deprecation")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiTakeTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToMultiTest.java
@@ -20,6 +20,8 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.CompositeException;
@@ -31,7 +33,9 @@ import io.smallrye.mutiny.operators.multi.MultiFlatMapOp;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import io.smallrye.mutiny.test.Mocks;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiTransformToMultiTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
@@ -14,10 +14,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import junit5.support.InfrastructureResource;
 
 public class UniAwaitTest {
 
@@ -150,6 +153,7 @@ public class UniAwaitTest {
     }
 
     @Nested
+    @ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
     class ThreadBlockingTest {
 
         @BeforeEach

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromFutureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromFutureTest.java
@@ -12,11 +12,15 @@ import java.util.function.Supplier;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import junit5.support.InfrastructureResource;
 
 @SuppressWarnings("ConstantConditions")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniCreateFromFutureTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
@@ -11,12 +11,16 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.TestException;
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniIfNoItemTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnEventTest.java
@@ -12,13 +12,17 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import junit5.support.InfrastructureResource;
 
 @SuppressWarnings("ConstantConditions")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniOnEventTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRetryTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnFailureRetryTest.java
@@ -6,10 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniOnFailureRetryTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayTest.java
@@ -13,10 +13,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniOnItemDelayTest {
 
     private ScheduledExecutorService executor;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayUntilTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemDelayUntilTest.java
@@ -14,11 +14,15 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.smallrye.mutiny.subscription.UniEmitter;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniOnItemDelayUntilTest {
 
     private ScheduledExecutorService executor;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureFlatMapTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemOrFailureFlatMapTest.java
@@ -10,14 +10,18 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.smallrye.mutiny.subscription.UniEmitter;
 import io.smallrye.mutiny.tuples.Functions;
+import junit5.support.InfrastructureResource;
 
 @SuppressWarnings("ConstantConditions")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniOnItemOrFailureFlatMapTest {
 
     private final Uni<Integer> one = Uni.createFrom().item(1);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnSubscribeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnSubscribeTest.java
@@ -13,6 +13,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
@@ -20,7 +22,9 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.uni.UniOnSubscribeCall;
 import io.smallrye.mutiny.subscription.UniEmitter;
 import io.smallrye.mutiny.subscription.UniSubscription;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniOnSubscribeTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnTerminationTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnTerminationTest.java
@@ -8,14 +8,18 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.TestException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import junit5.support.InfrastructureResource;
 
 @SuppressWarnings("ConstantConditions")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniOnTerminationTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOrTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOrTest.java
@@ -14,10 +14,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
 public class UniOrTest {
 
     private ScheduledExecutorService executor;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRepeatTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRepeatTest.java
@@ -15,6 +15,8 @@ import java.util.function.Supplier;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.Multi;
@@ -22,7 +24,9 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.test.Mocks;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniRepeatTest {
 
     @RepeatedTest(10)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniRunSubscriptionOnTest.java
@@ -10,12 +10,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.UniSubscriber;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniRunSubscriptionOnTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniSerializedSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniSerializedSubscriberTest.java
@@ -16,6 +16,8 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
@@ -25,7 +27,9 @@ import io.smallrye.mutiny.subscription.UniEmitter;
 import io.smallrye.mutiny.subscription.UniSerializedSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
 public class UniSerializedSubscriberTest {
 
     @AfterEach

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniSubscribeAsCompletionStageTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniSubscribeAsCompletionStageTest.java
@@ -14,9 +14,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Uni;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class UniSubscribeAsCompletionStageTest {
 
     private ScheduledExecutorService executor;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiToHotStreamTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiToHotStreamTest.java
@@ -7,13 +7,17 @@ import java.time.Duration;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiToHotStreamTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromIterableTest.java
@@ -15,6 +15,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -24,7 +26,9 @@ import io.smallrye.mutiny.helpers.test.AbstractSubscriber;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.test.Mocks;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiFromIterableTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceFromUniTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceFromUniTest.java
@@ -16,6 +16,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.CompositeException;
@@ -24,8 +26,10 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.spies.Spy;
 import io.smallrye.mutiny.helpers.spies.UniOnCancellationSpy;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import junit5.support.InfrastructureResource;
 
 @SuppressWarnings("ConstantConditions")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiFromResourceFromUniTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/builders/MultiFromResourceTest.java
@@ -16,13 +16,17 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiFromResourceTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/multicast/MultiReferenceCountSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/multicast/MultiReferenceCountSubscriberTest.java
@@ -5,13 +5,17 @@ import static org.mockito.Mockito.mock;
 import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.operators.AbstractMulti;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 class MultiReferenceCountSubscriberTest {
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/BroadcastProcessorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/processors/BroadcastProcessorTest.java
@@ -15,11 +15,15 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class BroadcastProcessorTest {
 
     private ExecutorService executor;

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniAndMultiLoggerTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniAndMultiLoggerTest.java
@@ -9,13 +9,17 @@ import java.util.ArrayList;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
 class UniAndMultiLoggerTest {
 
     private static final PrintStream systemOut = System.out;

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/CallbackBasedSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/CallbackBasedSubscriberTest.java
@@ -8,13 +8,17 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import junit5.support.InfrastructureResource;
 
 @SuppressWarnings("ConstantConditions")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
 public class CallbackBasedSubscriberTest {
 
     @AfterEach

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/SafeSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/SafeSubscriberTest.java
@@ -10,6 +10,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.mockito.internal.stubbing.answers.ThrowsException;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -19,8 +21,10 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.test.Mocks;
+import junit5.support.InfrastructureResource;
 
 @SuppressWarnings("unchecked")
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
 public class SafeSubscriberTest {
 
     @AfterEach

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/SerializedSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/SerializedSubscriberTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -23,7 +25,9 @@ import io.smallrye.mutiny.TestException;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.test.Mocks;
+import junit5.support.InfrastructureResource;
 
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
 public class SerializedSubscriberTest {
 
     Subscriber<Integer> subscriber;

--- a/implementation/src/test/java/junit5/support/InfrastructureResource.java
+++ b/implementation/src/test/java/junit5/support/InfrastructureResource.java
@@ -1,0 +1,6 @@
+package junit5.support;
+
+public class InfrastructureResource {
+
+    public static final String NAME = "mutiny-infrastructure";
+}

--- a/implementation/src/test/java/tck/MultiLoggerTckTest.java
+++ b/implementation/src/test/java/tck/MultiLoggerTckTest.java
@@ -1,7 +1,12 @@
 package tck;
 
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Publisher;
 
+import junit5.support.InfrastructureResource;
+
+@ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ)
 public class MultiLoggerTckTest extends AbstractPublisherTck<Long> {
 
     @Override


### PR DESCRIPTION
Depends on #769, do not merge yet

Parallel builds (same JVM for the whole suite) work fine on my side but remain flaky in CI / constrained environments. Hence they must be activated with a Maven profile (`-Pparallel-tests`)