### PR TITLE
Rework the module-info declarations to be fully open modules

### DIFF
--- a/implementation/src/main/module/module-info.java
+++ b/implementation/src/main/module/module-info.java
@@ -1,32 +1,6 @@
-module io.smallrye.mutiny {
+open module io.smallrye.mutiny {
+
     requires org.reactivestreams;
-
-    exports io.smallrye.mutiny;
-
-    exports io.smallrye.mutiny.converters;
-    exports io.smallrye.mutiny.converters.multi;
-    exports io.smallrye.mutiny.converters.uni;
-
-    exports io.smallrye.mutiny.groups;
-
-    exports io.smallrye.mutiny.helpers;
-    exports io.smallrye.mutiny.helpers.queues;
-    exports io.smallrye.mutiny.helpers.spies;
-    exports io.smallrye.mutiny.helpers.test;
-
-    exports io.smallrye.mutiny.infrastructure;
-
-    exports io.smallrye.mutiny.operators;
-    exports io.smallrye.mutiny.operators.multi;
-    exports io.smallrye.mutiny.operators.multi.builders;
-    exports io.smallrye.mutiny.operators.multi.multicast;
-    exports io.smallrye.mutiny.operators.multi.overflow;
-    exports io.smallrye.mutiny.operators.multi.processors;
-    exports io.smallrye.mutiny.operators.uni.builders;
-
-    exports io.smallrye.mutiny.subscription;
-    exports io.smallrye.mutiny.tuples;
-    exports io.smallrye.mutiny.unchecked;
 
     uses io.smallrye.mutiny.infrastructure.MultiInterceptor;
     uses io.smallrye.mutiny.infrastructure.ExecutorConfiguration;

--- a/math/src/main/module/module-info.java
+++ b/math/src/main/module/module-info.java
@@ -1,6 +1,4 @@
-module io.smallrye.mutiny.math {
-    requires org.reactivestreams;
-    requires io.smallrye.mutiny;
+open module io.smallrye.mutiny.math {
 
-    exports io.smallrye.mutiny.math;
+    requires transitive io.smallrye.mutiny;
 }


### PR DESCRIPTION
There is little benefit from strong encapsulation at this stage.

Fixes #739
