### PR TITLE
Context support

### DIFF
--- a/documentation/src/main/jekyll/_data/categories.yml
+++ b/documentation/src/main/jekyll/_data/categories.yml
@@ -28,6 +28,7 @@
     - emission-threads
     - emit-subscription
     - logging
+    - context-passing
 
 - name: Integration
   guides:

--- a/documentation/src/main/jekyll/_data/guides.yml
+++ b/documentation/src/main/jekyll/_data/guides.yml
@@ -312,3 +312,10 @@ logging:
     - beginner
   related:
     - guide: infrastructure
+
+context-passing:
+  title: Context passing
+  text: Learn how to pass an implicit context between operators
+  labels:
+    - intermediate
+    - advanced

--- a/documentation/src/main/jekyll/guides/context-passing.adoc
+++ b/documentation/src/main/jekyll/guides/context-passing.adoc
@@ -1,0 +1,87 @@
+:page-layout: guides
+:page-guide-id: context-passing
+:page-show-toc: true
+:page-liquid:
+:include_dir: ../../../../src/test/java/guides
+
+== Context passing
+
+Mutiny reactive pipelines let data flow from publishers to subscribers.
+
+In the vast majority of cases a publisher shall have _all_ required data, and operators shall perform processing based on item values.
+For instance a network request shall be made with all request data known in advance, and response processing shall only depend on the response payload.
+
+That being said there are cases were this is not sufficient, and some data has to be carried along with items.
+For instance one intermediary operator in a pipeline may have to make another networked request from which we need to extract some correlation identifier which will be used by another operator down the pipeline.
+In such cases one will be tempted to forward tuples consisting of some item value plus some "extra" data.
+
+For such cases Mutiny offers a _subscriber-provided context_, so all operators involved in a subscription can share some form of _implicit data_.
+
+=== What's in a context?
+
+A context is a simple key / value, in-memory storage.
+Data can be queried, added and deleted from a context, as shown in the following snippet:
+
+[source,java,indent=0]
+----
+include::{include_dir}/ContextPassingTest.java[tags=contextManipulation]
+----
+
+`Context` objects are thread-safe, and can be created from sequences of key / value pairs (as shown above), from a Java `Map`, or they can be created empty.
+
+Note that an empty-created context defers its internal storage allocation until the first call to `put`.
+You can see `Context` as a glorified `ConcurrentHashMap` delegate, although this is an implementation detail and Mutiny might explore various internal storage strategies in the future.
+
+[TIP]
+====
+Contexts shall be primarily used to share transient data used for networked I/O processing such as correlation identifiers, tokens, etc.
+They should not be used as general-purpose data structures that are frequently updated and that hold large amounts of data.
+====
+
+=== How to access a context?
+
+Given a `Uni` or a `Multi`, a context can be accessed using the `withContext` operator, as in:
+
+[source,java,indent=0]
+----
+include::{include_dir}/ContextPassingTest.java[tags=contextSampleUsage]
+----
+
+This operator builds a sub-pipeline using 2 parameters: the current `Uni` or `Multi` and the context.
+
+[IMPORTANT]
+====
+The function passed to `withContext` is called at subscription time.
+This means that the context has not had a chance to be updated by upstream operators yet, so be careful with what you do in the body of that function.
+====
+
+There is another way to access the context by using the `attachContext` method:
+
+[source,java,indent=0]
+----
+include::{include_dir}/ContextPassingTest.java[tags=contextAttachedSampleUsage]
+----
+
+This method materializes the context in the regular pipeline items using the wrapper `ItemWithContext` class.
+The `get` method provides the item while the `context` method provides the context.
+
+=== How to access a context at the pipeline source?
+
+The `Uni` and `Multi` _builder_ methods like `Multi.createFrom()` provide publishers, not operators, so they don't have the `withContext` method.
+
+The first option is to use the `Uni.createFrom().context(...)` or `Multi.createFrom().context(...)` general purpose method to materialize the context:
+
+[source,java,indent=0]
+----
+include::{include_dir}/ContextPassingTest.java[tags=builderUsage]
+----
+
+The `context` method takes a function that accepts a `Context` and returns a pipeline.
+This is very similar to the `deferred` builder.
+
+If you use an `emitter` builder then for both `Uni` and `Multi` cases the emitter object offers a `context` method to access the context:
+
+[source,java,indent=0]
+----
+include::{include_dir}/ContextPassingTest.java[tags=emitterUsage]
+----

--- a/documentation/src/test/java/guides/ContextPassingTest.java
+++ b/documentation/src/test/java/guides/ContextPassingTest.java
@@ -1,0 +1,99 @@
+package guides;
+
+import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ContextPassingTest {
+
+    void contextManipulation() {
+
+        // tag::contextManipulation[]
+        // Create a context using key / value pairs
+        Context context = Context.of(
+                "X-CUSTOMER-ID", "1234",
+                "X-SPAN-ID", "foo-bar-baz"
+        );
+
+        // Get an entry
+        System.out.println(
+                context.<String>get("X-SPAN-ID"));
+
+        // Get an entry, use a supplier for a default value if the key is not present
+        System.out.println(
+                context.getOrElse("X-SPAN-ID", () -> "<no id>"));
+
+        // Add an entry
+        context.put("foo", "bar");
+
+        // Remove an entry
+        context.delete("foo");
+        // end::contextManipulation[]
+    }
+
+    @Test
+    void sampleUsage() {
+        Multi<Integer> pipeline = Multi.createFrom().range(1, 10);
+        String customerId = "1234";
+
+        // tag::contextSampleUsage[]
+        Context context = Context.of("X-CUSTOMER-ID", customerId);
+
+        pipeline.withContext((multi, ctx) -> multi.onItem().transformToUniAndMerge(item -> makeRequest(item, ctx.get("X-CUSTOMER-ID"))))
+                .subscribe().with(context, item -> handleResponse(item), err -> handleFailure(err));
+        // end::contextSampleUsage[]
+    }
+
+    @Test
+    void sampleUsageAttachedContext() {
+        Multi<Integer> pipeline = Multi.createFrom().range(1, 10);
+        String customerId = "1234";
+
+        // tag::contextAttachedSampleUsage[]
+        Context context = Context.of("X-CUSTOMER-ID", customerId);
+
+        pipeline.attachContext()
+                .onItem().transformToUniAndMerge(item -> makeRequest(item.get(), item.context().get("X-CUSTOMER-ID")))
+                .subscribe().with(context, item -> handleResponse(item), err -> handleFailure(err));
+        // end::contextAttachedSampleUsage[]
+    }
+
+    @Test
+    void builderUsage() {
+        Context context = Context.of("X-SPAN-ID", "1234");
+
+        // tag::builderUsage[]
+        Uni.createFrom().context(ctx -> makeRequest("db1", ctx.get("X-SPAN-ID")))
+                .subscribe().with(context, item -> handleResponse(item), err -> handleFailure(err));
+        // end::builderUsage[]
+    }
+
+    @Test
+    void emitterUsage() {
+        Context context = Context.of("X-SPAN-ID", "1234");
+
+        // tag::emitterUsage[]
+        Multi.createFrom().emitter(emitter -> {
+            String customerId = emitter.context().get("X-SPAN-ID");
+            for (int i = 0; i < 10; i++) {
+                emitter.emit("@" + i + " [" + customerId + "]");
+            }
+            emitter.complete();
+        });
+        // end::emitterUsage[]
+    }
+
+    private void handleFailure(Throwable err) {
+        Assertions.fail(err);
+    }
+
+    private void handleResponse(String item) {
+        Assertions.assertTrue(item.endsWith("::1234"));
+    }
+
+    private Uni<String> makeRequest(Object item, Object o) {
+        return Uni.createFrom().item(item + "::" + o);
+    }
+}

--- a/implementation/revapi.json
+++ b/implementation/revapi.json
@@ -21,7 +21,50 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.mutiny.groups.UniAwait<T>::<init>(io.smallrye.mutiny.Uni<T>)",
+        "new": "method void io.smallrye.mutiny.groups.UniAwait<T>::<init>(io.smallrye.mutiny.Uni<T>, io.smallrye.mutiny.Context)",
+        "justification": "Private API impacted by the new Mutiny context support"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.mutiny.groups.UniAwaitOptional<T>::<init>(io.smallrye.mutiny.Uni<T>)",
+        "new": "method void io.smallrye.mutiny.groups.UniAwaitOptional<T>::<init>(io.smallrye.mutiny.Uni<T>, io.smallrye.mutiny.Context)",
+        "justification": "Private API impacted by the new Mutiny context support"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.mutiny.helpers.BlockingIterable<T>::<init>(org.reactivestreams.Publisher<? extends T>, int, java.util.function.Supplier<java.util.Queue<T>>)",
+        "new": "method void io.smallrye.mutiny.helpers.BlockingIterable<T>::<init>(io.smallrye.mutiny.Multi<? extends T>, int, java.util.function.Supplier<java.util.Queue<T>>, java.util.function.Supplier<io.smallrye.mutiny.Context>)",
+        "justification": "Private API impacted by the new Mutiny context support"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.mutiny.helpers.UniCallbackSubscriber<T>::<init>(java.util.function.Consumer<? super T>, java.util.function.Consumer<? super java.lang.Throwable>)",
+        "new": "method void io.smallrye.mutiny.helpers.UniCallbackSubscriber<T>::<init>(java.util.function.Consumer<? super T>, java.util.function.Consumer<? super java.lang.Throwable>, io.smallrye.mutiny.Context)",
+        "justification": "Private API impacted by the new Mutiny context support"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.mutiny.subscription.Subscribers.CallbackBasedSubscriber<T>::<init>(java.util.function.Consumer<? super T>, java.util.function.Consumer<? super java.lang.Throwable>, java.lang.Runnable, java.util.function.Consumer<? super org.reactivestreams.Subscription>)",
+        "new": "method void io.smallrye.mutiny.subscription.Subscribers.CallbackBasedSubscriber<T>::<init>(io.smallrye.mutiny.Context, java.util.function.Consumer<? super T>, java.util.function.Consumer<? super java.lang.Throwable>, java.lang.Runnable, java.util.function.Consumer<? super org.reactivestreams.Subscription>)",
+        "justification": "Private API impacted by the new Mutiny context support"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method <T> io.smallrye.mutiny.subscription.CancellableSubscriber<T> io.smallrye.mutiny.subscription.Subscribers::from(java.util.function.Consumer<? super T>, java.util.function.Consumer<? super java.lang.Throwable>, java.lang.Runnable, java.util.function.Consumer<? super org.reactivestreams.Subscription>)",
+        "new": "method <T> io.smallrye.mutiny.subscription.CancellableSubscriber<T> io.smallrye.mutiny.subscription.Subscribers::from(io.smallrye.mutiny.Context, java.util.function.Consumer<? super T>, java.util.function.Consumer<? super java.lang.Throwable>, java.lang.Runnable, java.util.function.Consumer<? super org.reactivestreams.Subscription>)",
+        "justification": "Private API impacted by the new Mutiny context support"
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/implementation/src/main/java/io/smallrye/mutiny/Context.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Context.java
@@ -1,0 +1,228 @@
+package io.smallrye.mutiny;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+import static java.util.Objects.requireNonNull;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * A context allows sharing key / value entries along with a subscriber in a Mutiny pipeline, so all operators can
+ * share implicit data for a given subscription.
+ * <p>
+ * A context is provided by a {@link io.smallrye.mutiny.subscription.UniSubscriber} or {@link org.reactivestreams.Subscriber}
+ * that implements {@link io.smallrye.mutiny.subscription.ContextSupport}.
+ * <p>
+ * Context keys are represented as {@link String} while values can be from heterogeneous types.
+ * <p>
+ * {@link Context} instances are thread-safe.
+ * Internal storage is not allocated until the first entry is being added.
+ * <p>
+ * Contexts shall be primarily used to share transient data used for networked I/O processing such as correlation
+ * identifiers, tokens, etc.
+ * They should not be used as general-purpose data structures that are frequently updated and that hold large amounts of
+ * data.
+ *
+ * @see Uni#withContext(BiFunction)
+ * @see Uni#attachContext()
+ * @see io.smallrye.mutiny.groups.UniSubscribe
+ * @see Multi#withContext(BiFunction)
+ * @see Multi#attachContext()
+ * @see io.smallrye.mutiny.groups.MultiSubscribe
+ */
+@Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+public final class Context {
+
+    /**
+     * Creates a new empty context.
+     *
+     * @return the context
+     */
+    public static Context empty() {
+        return new Context();
+    }
+
+    /**
+     * Creates a context from key / value pairs.
+     *
+     * @param entries a sequence of key / value pairs, as in {@code key1, value1, key2, value2}
+     * @return the new context
+     * @throws IllegalArgumentException when {@code entries} is not balanced
+     * @throws NullPointerException when {@code entries} is {@code null}
+     */
+    public static Context of(Object... entries) {
+        requireNonNull(entries, "The entries array cannot be null");
+        if (entries.length % 2 != 0) {
+            throw new IllegalArgumentException("Arguments must be balanced to form (key, value) pairs");
+        }
+        HashMap<String, Object> map = new HashMap<>();
+        for (int i = 0; i < entries.length; i = i + 2) {
+            String key = nonNull(entries[i], "key").toString();
+            Object value = nonNull(entries[i + 1], "value");
+            map.put(key, value);
+        }
+        return new Context(map);
+    }
+
+    /**
+     * Creates a context by copying the entries from a {@link Map}.
+     *
+     * @param entries the map, cannot be {@code null}
+     * @return the new context
+     * @throws NullPointerException when {@code entries} is null
+     */
+    public static Context from(Map<String, ?> entries) {
+        return new Context(requireNonNull(entries, "The entries map cannot be null"));
+    }
+
+    private volatile ConcurrentHashMap<String, Object> entries;
+
+    private Context() {
+        this.entries = null;
+    }
+
+    private Context(Map<String, ?> initialEntries) {
+        this.entries = new ConcurrentHashMap<>(initialEntries);
+    }
+
+    /**
+     * Checks whether the context has an entry for a given key.
+     *
+     * @param key the key
+     * @return {@code true} when there is an entry for {@code key}, {@code false} otherwise
+     */
+    public boolean contains(String key) {
+        if (entries == null) {
+            return false;
+        } else {
+            return entries.containsKey(key);
+        }
+    }
+
+    /**
+     * Get a value for a key.
+     *
+     * @param key the key
+     * @param <T> the value type
+     * @return the value
+     * @throws NoSuchElementException when there is no entry for {@code key}
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T get(String key) throws NoSuchElementException {
+        if (entries == null) {
+            throw new NoSuchElementException("The context is empty");
+        }
+        T value = (T) entries.get(key);
+        if (value == null) {
+            throw new NoSuchElementException("The context does not have a value for key " + key);
+        }
+        return value;
+    }
+
+    /**
+     * Get a value for a key, or provide an alternative value when not present.
+     *
+     * @param key the key
+     * @param alternativeSupplier the alternative value supplier when there is no entry for {@code key}
+     * @param <T> the value type
+     * @return the value
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getOrElse(String key, Supplier<? extends T> alternativeSupplier) {
+        if (entries != null) {
+            T value = (T) entries.get(key);
+            if (value != null) {
+                return value;
+            }
+        }
+        return alternativeSupplier.get();
+    }
+
+    /**
+     * Stores a value for a given key.
+     *
+     * @param key the key
+     * @param value the value, cannot be {@code null}
+     * @return this context
+     */
+    public Context put(String key, Object value) {
+        if (entries == null) {
+            synchronized (this) {
+                if (entries == null) {
+                    this.entries = new ConcurrentHashMap<>(8);
+                }
+            }
+        }
+        entries.put(key, value);
+        return this;
+    }
+
+    /**
+     * Delete an entry for a given key, if present.
+     *
+     * @param key the key
+     * @return this context
+     */
+    public Context delete(String key) {
+        if (entries != null) {
+            entries.remove(key);
+        }
+        return this;
+    }
+
+    /**
+     * Test whether the context is empty.
+     *
+     * @return {@code true} if the context is empty, {@code false} otherwise
+     */
+    public boolean isEmpty() {
+        return (this.entries == null) || (entries.isEmpty());
+    }
+
+    /**
+     * Gives the set of keys present in the context at the time the method is being called.
+     * <p>
+     * Note that each call to this method produces a copy.
+     *
+     * @return the set of keys
+     */
+    public Set<String> keys() {
+        if (this.entries == null) {
+            return Collections.emptySet();
+        }
+        HashSet<String> set = new HashSet<>();
+        Enumeration<String> enumeration = entries.keys();
+        while (enumeration.hasMoreElements()) {
+            set.add(enumeration.nextElement());
+        }
+        return set;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        Context context = (Context) other;
+        return Objects.equals(entries, context.entries);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entries);
+    }
+
+    @Override
+    public String toString() {
+        return "Context{" +
+                "entries=" + entries +
+                '}';
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/ItemWithContext.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/ItemWithContext.java
@@ -1,0 +1,76 @@
+package io.smallrye.mutiny;
+
+import java.util.Objects;
+
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * Models an item flowing along a Mutiny pipeline with its subscriber context attached.
+ *
+ * @param <T> the iten type
+ * @see Uni#attachContext()
+ * @see Multi#attachContext()
+ */
+@Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+public final class ItemWithContext<T> {
+
+    private final Context context;
+    private final T item;
+
+    /**
+     * Creates a new item with a context.
+     * <p>
+     * Since instances are being created by Mutiny operators there is no {@code null} check on parameters
+     * for performance reasons.
+     *
+     * @param context the context
+     * @param item the item
+     */
+    public ItemWithContext(Context context, T item) {
+        this.context = context;
+        this.item = item;
+    }
+
+    /**
+     * Gives the context.
+     *
+     * @return the context
+     */
+    public Context context() {
+        return context;
+    }
+
+    /**
+     * Gives the item.
+     *
+     * @return the item
+     */
+    public T get() {
+        return item;
+    }
+
+    @Override
+    public String toString() {
+        return "ItemWithContext{" +
+                "context=" + context +
+                ", item=" + item +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ItemWithContext<?> that = (ItemWithContext<?>) o;
+        return Objects.equals(context, that.context) && Objects.equals(item, that.item);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(context, item);
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/converters/uni/UniToMultiPublisher.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/converters/uni/UniToMultiPublisher.java
@@ -6,8 +6,10 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.AbstractUni;
+import io.smallrye.mutiny.subscription.ContextSupport;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
 
@@ -24,7 +26,7 @@ public final class UniToMultiPublisher<T> implements Publisher<T> {
         downstream.onSubscribe(new UniToMultiSubscription<>(uni, downstream));
     }
 
-    private static class UniToMultiSubscription<T> implements UniSubscription, Subscription, UniSubscriber<T> {
+    private static class UniToMultiSubscription<T> implements UniSubscription, Subscription, UniSubscriber<T>, ContextSupport {
 
         private final Uni<T> uni;
         private final Subscriber<? super T> downstream;
@@ -44,6 +46,15 @@ public final class UniToMultiPublisher<T> implements Publisher<T> {
         private UniToMultiSubscription(Uni<T> uni, Subscriber<? super T> downstream) {
             this.uni = uni;
             this.downstream = downstream;
+        }
+
+        @Override
+        public Context context() {
+            if (downstream instanceof ContextSupport) {
+                return ((ContextSupport) downstream).context();
+            } else {
+                return Context.empty();
+            }
         }
 
         @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
@@ -18,6 +18,8 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
 import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.converters.MultiConverter;
@@ -467,6 +469,23 @@ public class MultiCreate {
     public <T> Multi<T> deferred(Supplier<Multi<? extends T>> supplier) {
         Supplier<Multi<? extends T>> actual = Infrastructure.decorate(nonNull(supplier, "supplier"));
         return Infrastructure.onMultiCreation(new DeferredMulti<>(actual));
+    }
+
+    /**
+     * Creates a {@link Multi} using {@link Function#apply(Object)} on the subscription-bound {@link Context}
+     * (the mapper is called at subscription time).
+     * <p>
+     * This method is semantically equivalent to {@link #deferred(Supplier)}, except that it passes a context.
+     *
+     * @param mapper the mapper, must not be {@code null}, must not produce {@code null}
+     * @param <T> the type of the item
+     * @return the produced {@link Multi}
+     */
+    @Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+    @CheckReturnValue
+    public <T> Multi<T> context(Function<Context, Multi<? extends T>> mapper) {
+        Function<Context, Multi<? extends T>> actual = Infrastructure.decorate(nonNull(mapper, "mapper"));
+        return Infrastructure.onMultiCreation(new DeferredMultiWithContext<>(actual));
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiSubscribe.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiSubscribe.java
@@ -13,6 +13,8 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.BlockingIterable;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
@@ -90,7 +92,6 @@ public class MultiSubscribe<T> {
      * Each {@link Subscription} will work for only a single {@link Subscriber}. A {@link Subscriber} should
      * only subscribe once to a single {@link Multi}.
      *
-     *
      * @param onSubscription the callback receiving the subscription, must not be {@code null}
      * @param onItem the callback receiving the items, must not be {@code null}
      * @param onFailure the callback receiving the failure, must not be {@code null}
@@ -102,7 +103,44 @@ public class MultiSubscribe<T> {
             Consumer<? super T> onItem,
             Consumer<? super Throwable> onFailure,
             Runnable onComplete) {
+        return with(Context.empty(), onSubscription, onItem, onFailure, onComplete);
+    }
+
+    /**
+     * Subscribes to the {@link Multi} to start receiving the items.
+     * <p>
+     * This method accepts the following callbacks:
+     * <ol>
+     * <li>{@code onSubscription} receives the {@link Subscription}, you <strong>must</strong> request items using
+     * the {@link Subscription#request(long)} method</li>
+     * <li>{@code onItem} receives the requested items if any</li>
+     * <li>{@code onFailure} receives the failure if any</li>
+     * <li>{@code onComplete} receives the completion event</li>
+     * </ol>
+     * <p>
+     * This method returns a {@link Cancellable} to cancel the subscription.
+     *
+     * <p>
+     * This is a "factory method" and can be called multiple times, each time starting a new {@link Subscription}.
+     * Each {@link Subscription} will work for only a single {@link Subscriber}. A {@link Subscriber} should
+     * only subscribe once to a single {@link Multi}.
+     *
+     * @param context the context, must not be {@code null}
+     * @param onSubscription the callback receiving the subscription, must not be {@code null}
+     * @param onItem the callback receiving the items, must not be {@code null}
+     * @param onFailure the callback receiving the failure, must not be {@code null}
+     * @param onComplete the callback receiving the completion event, must not be {@code null}
+     * @return the cancellable object to cancel the subscription
+     */
+    @Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+    public Cancellable with(
+            Context context,
+            Consumer<? super Subscription> onSubscription,
+            Consumer<? super T> onItem,
+            Consumer<? super Throwable> onFailure,
+            Runnable onComplete) {
         CancellableSubscriber<? super T> subscriber = Subscribers.from(
+                nonNull(context, "context"),
                 nonNull(onItem, "onItem"),
                 nonNull(onFailure, "onFailure"),
                 nonNull(onComplete, "onComplete"),
@@ -138,10 +176,45 @@ public class MultiSubscribe<T> {
             Consumer<? super T> onItem,
             Consumer<? super Throwable> onFailure,
             Runnable onComplete) {
+        return with(Context.empty(), onItem, onFailure, onComplete);
+    }
+
+    /**
+     * Subscribes to the {@link Multi} to start receiving the items.
+     * <p>
+     * This method accepts the following callbacks:
+     * <ol>
+     * <li>{@code onItem} receives the requested items if any</li>
+     * <li>{@code onFailure} receives the failure if any</li>
+     * <li>{@code onComplete} receives the completion event</li>
+     * </ol>
+     * <p>
+     * This method returns a {@link Cancellable} to cancel the subscription.
+     *
+     * <strong>Important:</strong> This method request {@link Long#MAX_VALUE} items.
+     *
+     * <p>
+     * This is a "factory method" and can be called multiple times, each time starting a new {@link Subscription}.
+     * Each {@link Subscription} will work for only a single {@link Subscriber}. A {@link Subscriber} should
+     * only subscribe once to a single {@link Multi}.
+     *
+     * @param context the context, must not be {@code null}
+     * @param onItem the callback receiving the items, must not be {@code null}
+     * @param onFailure the callback receiving the failure, must not be {@code null}
+     * @param onComplete the callback receiving the completion event, must not be {@code null}
+     * @return the cancellable object to cancel the subscription
+     */
+    @Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+    public Cancellable with(
+            Context context,
+            Consumer<? super T> onItem,
+            Consumer<? super Throwable> onFailure,
+            Runnable onComplete) {
         nonNull(onItem, "onItem");
         nonNull(onFailure, "onFailure");
         nonNull(onComplete, "onComplete");
         CancellableSubscriber<? super T> subscriber = Subscribers.from(
+                nonNull(context, "context"),
                 nonNull(onItem, "onItem"),
                 nonNull(onFailure, "onFailure"),
                 nonNull(onComplete, "onComplete"),
@@ -178,9 +251,45 @@ public class MultiSubscribe<T> {
     public Cancellable with(
             Consumer<? super T> onItem,
             Consumer<? super Throwable> onFailure) {
+        return with(Context.empty(), onItem, onFailure);
+    }
+
+    /**
+     * Subscribes to the {@link Multi} to start receiving the items.
+     * <p>
+     * This method accepts the following callbacks:
+     * <ol>
+     * <li>{@code onItem} receives the requested items if any</li>
+     * <li>{@code onFailure} receives the failure if any</li>
+     * </ol>
+     * <p>
+     * So, you won't be notified on stream completion.
+     * <p>
+     * This method returns a {@link Cancellable} to cancel the subscription.
+     *
+     * <strong>Important:</strong> This method request {@link Long#MAX_VALUE} items.
+     *
+     * <p>
+     * This is a "factory method" and can be called multiple times, each time starting a new {@link Subscription}.
+     * Each {@link Subscription} will work for only a single {@link Subscriber}. A {@link Subscriber} should
+     * only subscribe once to a single {@link Multi}.
+     * *
+     * <p>
+     *
+     * @param context the context, must not be {@code null}
+     * @param onItem the callback receiving the items, must not be {@code null}
+     * @param onFailure the callback receiving the failure, must not be {@code null}
+     * @return the cancellable object to cancel the subscription
+     */
+    @Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+    public Cancellable with(
+            Context context,
+            Consumer<? super T> onItem,
+            Consumer<? super Throwable> onFailure) {
         nonNull(onItem, "onItem");
         nonNull(onFailure, "onFailure");
         CancellableSubscriber<? super T> subscriber = Subscribers.from(
+                nonNull(context, "context"),
                 nonNull(onItem, "onItem"),
                 nonNull(onFailure, "onFailure"),
                 null,
@@ -209,8 +318,35 @@ public class MultiSubscribe<T> {
      * @return the cancellable object to cancel the subscription
      */
     public Cancellable with(Consumer<? super T> onItem) {
+        return with(Context.empty(), onItem);
+    }
+
+    /**
+     * Subscribes to the {@link Multi} to start receiving the items.
+     * <p>
+     * This method receives only the {@code onItem} callback, invoked on each item.
+     * So, you won't be notified on stream completion, and on failure the default failure handler is used.
+     * <p>
+     * This method returns a {@link Cancellable} to cancel the subscription.
+     *
+     * <strong>Important:</strong> This method request {@link Long#MAX_VALUE} items.
+     *
+     * <p>
+     * This is a "factory method" and can be called multiple times, each time starting a new {@link Subscription}.
+     * Each {@link Subscription} will work for only a single {@link Subscriber}. A {@link Subscriber} should
+     * only subscribe once to a single {@link Multi}.
+     * *
+     * <p>
+     *
+     * @param context the context, must not be {@code null}
+     * @param onItem the callback receiving the items, must not be {@code null}
+     * @return the cancellable object to cancel the subscription
+     */
+    @Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+    public Cancellable with(Context context, Consumer<? super T> onItem) {
         Consumer<? super T> actual = Infrastructure.decorate(nonNull(onItem, "onItem"));
         CancellableSubscriber<? super T> subscriber = Subscribers.from(
+                nonNull(context, "context"),
                 actual,
                 NO_ON_FAILURE,
                 null,
@@ -228,7 +364,7 @@ public class MultiSubscribe<T> {
      * </ol>
      * <p>
      * So, you won't be notified on failure.
-     *
+     * <p>
      * This method returns a {@link Cancellable} to cancel the subscription.
      *
      * <strong>Important:</strong> This method request {@link Long#MAX_VALUE} items.
@@ -245,9 +381,43 @@ public class MultiSubscribe<T> {
     public Cancellable with(
             Consumer<? super T> onItem,
             Runnable onComplete) {
+        return with(Context.empty(), onItem, onComplete);
+    }
+
+    /**
+     * Subscribes to the {@link Multi} to start receiving the items.
+     * <p>
+     * This method accepts the following callbacks:
+     * <ol>
+     * <li>{@code onItem} receives the requested items if any</li>
+     * <li>{@code onComplete} receives the completion event</li>
+     * </ol>
+     * <p>
+     * So, you won't be notified on failure.
+     * <p>
+     * This method returns a {@link Cancellable} to cancel the subscription.
+     *
+     * <strong>Important:</strong> This method request {@link Long#MAX_VALUE} items.
+     *
+     * <p>
+     * This is a "factory method" and can be called multiple times, each time starting a new {@link Subscription}.
+     * Each {@link Subscription} will work for only a single {@link Subscriber}. A {@link Subscriber} should
+     * only subscribe once to a single {@link Multi}.
+     *
+     * @param context the context, must not be {@code null}
+     * @param onItem the callback receiving the items, must not be {@code null}
+     * @param onComplete the callback receiving the completion event, must not be {@code null}
+     * @return the cancellable object to cancel the subscription
+     */
+    @Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+    public Cancellable with(
+            Context context,
+            Consumer<? super T> onItem,
+            Runnable onComplete) {
         nonNull(onItem, "onItem");
         nonNull(onComplete, "onComplete");
         CancellableSubscriber<? super T> subscriber = Subscribers.from(
+                nonNull(context, "context"),
                 nonNull(onItem, "onItem"),
                 null,
                 onComplete,
@@ -264,6 +434,16 @@ public class MultiSubscribe<T> {
     }
 
     /**
+     * @param contextSupplier the context supplier, must not be {@code null}, must not return {@code null}
+     * @return a blocking iterable used to consume the items emitted by the upstream {@link Multi}.
+     */
+    @CheckReturnValue
+    @Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+    public BlockingIterable<T> asIterable(Supplier<Context> contextSupplier) {
+        return asIterable(contextSupplier, 256, () -> new ArrayBlockingQueue<>(256));
+    }
+
+    /**
      * Consumes the upstream {@link Multi} as an iterable.
      *
      * @param batchSize the number of elements stored in the queue
@@ -272,8 +452,22 @@ public class MultiSubscribe<T> {
      */
     @CheckReturnValue
     public BlockingIterable<T> asIterable(int batchSize, Supplier<Queue<T>> supplier) {
+        return asIterable(Context::empty, batchSize, supplier);
+    }
+
+    /**
+     * Consumes the upstream {@link Multi} as an iterable.
+     *
+     * @param contextSupplier the context supplier, must not be {@code null}, must not return {@code null}
+     * @param batchSize the number of elements stored in the queue
+     * @param queueSupplier the supplier of queue used internally, must not be {@code null}, must not return {@code null}
+     * @return a blocking iterable used to consume the items emitted by the upstream {@link Multi}.
+     */
+    @CheckReturnValue
+    @Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+    public BlockingIterable<T> asIterable(Supplier<Context> contextSupplier, int batchSize, Supplier<Queue<T>> queueSupplier) {
         // No interception of the queue supplier.
-        return new BlockingIterable<>(upstream, batchSize, supplier);
+        return new BlockingIterable<>(upstream, batchSize, queueSupplier, contextSupplier);
     }
 
     /**
@@ -282,6 +476,16 @@ public class MultiSubscribe<T> {
     @CheckReturnValue
     public Stream<T> asStream() {
         return asStream(256, () -> new ArrayBlockingQueue<>(256));
+    }
+
+    /**
+     * @param contextSupplier the context supplier, must not be {@code null}, must not return {@code null}
+     * @return a <strong>blocking</strong> stream to consume the items from the upstream {@link Multi}.
+     */
+    @CheckReturnValue
+    @Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+    public Stream<T> asStream(Supplier<Context> contextSupplier) {
+        return asStream(contextSupplier, 256, () -> new ArrayBlockingQueue<>(256));
     }
 
     /**
@@ -295,6 +499,21 @@ public class MultiSubscribe<T> {
     public Stream<T> asStream(int batchSize, Supplier<Queue<T>> supplier) {
         // No interception of the queue supplier.
         return asIterable(batchSize, supplier).stream();
+    }
+
+    /**
+     * Consumes the items from the upstream {@link Multi} as a blocking stream.
+     *
+     * @param contextSupplier the context supplier, must not be {@code null}, must not return {@code null}
+     * @param batchSize the number of element stored in the queue
+     * @param queueSupplier the supplier of queue used internally, must not be {@code null}, must not return {@code null}
+     * @return a blocking stream used to consume the items from {@link Multi}
+     */
+    @CheckReturnValue
+    @Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+    public Stream<T> asStream(Supplier<Context> contextSupplier, int batchSize, Supplier<Queue<T>> queueSupplier) {
+        // No interception of the queue supplier.
+        return asIterable(contextSupplier, batchSize, queueSupplier).stream();
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAwait.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAwait.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.util.Optional;
 
 import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.uni.UniBlockingAwait;
@@ -21,9 +22,11 @@ import io.smallrye.mutiny.operators.uni.UniBlockingAwait;
 public class UniAwait<T> {
 
     private final Uni<T> upstream;
+    private final Context context;
 
-    public UniAwait(Uni<T> upstream) {
+    public UniAwait(Uni<T> upstream, Context context) {
         this.upstream = nonNull(upstream, "upstream");
+        this.context = context;
     }
 
     /**
@@ -59,7 +62,7 @@ public class UniAwait<T> {
      * @return the item from the {@link Uni}, potentially {@code null}
      */
     public T atMost(Duration duration) {
-        return UniBlockingAwait.await(upstream, duration);
+        return UniBlockingAwait.await(upstream, duration, context);
     }
 
     /**
@@ -70,7 +73,7 @@ public class UniAwait<T> {
      */
     @CheckReturnValue
     public UniAwaitOptional<T> asOptional() {
-        return new UniAwaitOptional<>(upstream);
+        return new UniAwaitOptional<>(upstream, context);
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAwaitOptional.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAwaitOptional.java
@@ -5,6 +5,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import java.time.Duration;
 import java.util.Optional;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.uni.UniBlockingAwait;
@@ -19,9 +20,11 @@ import io.smallrye.mutiny.operators.uni.UniBlockingAwait;
 public class UniAwaitOptional<T> {
 
     private final Uni<T> upstream;
+    private final Context context;
 
-    public UniAwaitOptional(Uni<T> upstream) {
+    public UniAwaitOptional(Uni<T> upstream, Context context) {
         this.upstream = nonNull(upstream, "upstream");
+        this.context = context;
     }
 
     /**
@@ -58,7 +61,7 @@ public class UniAwaitOptional<T> {
      * @return the item from the {@link Uni}, potentially {@code null}
      */
     public Optional<T> atMost(Duration duration) {
-        return Optional.ofNullable(UniBlockingAwait.await(upstream, duration));
+        return Optional.ofNullable(UniBlockingAwait.await(upstream, duration, context));
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniCreate.java
@@ -14,6 +14,8 @@ import java.util.function.Supplier;
 import org.reactivestreams.Publisher;
 
 import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.converters.UniConverter;
@@ -418,6 +420,23 @@ public class UniCreate {
     public <T> Uni<T> deferred(Supplier<Uni<? extends T>> supplier) {
         Supplier<Uni<? extends T>> actual = Infrastructure.decorate(ParameterValidation.nonNull(supplier, "supplier"));
         return Infrastructure.onUniCreation(new UniCreateFromDeferredSupplier<>(actual));
+    }
+
+    /**
+     * Creates a {@link Uni} using {@link Function#apply(Object)} on the subscription-bound {@link Context}
+     * (the mapper is called at subscription time).
+     * <p>
+     * This method is semantically equivalent to {@link #deferred(Supplier)}, except that it passes a context.
+     *
+     * @param mapper the mapper, must not be {@code null}, must not produce {@code null}
+     * @param <T> the type of the item
+     * @return the produced {@link Uni}
+     */
+    @Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+    @CheckReturnValue
+    public <T> Uni<T> context(Function<Context, Uni<? extends T>> mapper) {
+        Function<Context, Uni<? extends T>> actual = Infrastructure.decorate(nonNull(mapper, "mapper"));
+        return Infrastructure.onUniCreation(new DeferredUniWithContext<>(actual));
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/BlockingIterable.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/BlockingIterable.java
@@ -1,14 +1,8 @@
 package io.smallrye.mutiny.helpers;
 
-import static io.smallrye.mutiny.helpers.ParameterValidation.SUPPLIER_PRODUCED_NULL;
-import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
-import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
+import static io.smallrye.mutiny.helpers.ParameterValidation.*;
 
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.util.Queue;
-import java.util.Spliterator;
-import java.util.Spliterators;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
@@ -18,23 +12,28 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.BackPressureFailure;
+import io.smallrye.mutiny.subscription.ContextSupport;
 
 public class BlockingIterable<T> implements Iterable<T> {
 
-    private final Publisher<? extends T> upstream;
+    private final Multi<? extends T> upstream;
     private final Supplier<Queue<T>> supplier;
     private final int batchSize;
+    private final Supplier<Context> contextSupplier;
 
-    public BlockingIterable(Publisher<? extends T> upstream, int batchSize, Supplier<Queue<T>> supplier) {
+    public BlockingIterable(Multi<? extends T> upstream, int batchSize, Supplier<Queue<T>> queueSupplier,
+            Supplier<Context> contextSupplier) {
         this.upstream = nonNull(upstream, "upstream");
         this.batchSize = positive(batchSize, "batchSize");
-        this.supplier = nonNull(supplier, "supplier");
+        this.supplier = nonNull(queueSupplier, "queueSupplier");
+        this.contextSupplier = nonNull(contextSupplier, "contextSupplier");
     }
 
     @Override
@@ -75,7 +74,18 @@ public class BlockingIterable<T> implements Iterable<T> {
             throw new IllegalStateException(SUPPLIER_PRODUCED_NULL);
         }
 
-        return new SubscriberIterator<>(queue, batchSize);
+        Context context = null;
+        try {
+            context = contextSupplier.get();
+        } catch (Throwable e) {
+            propagateFailure(e);
+        }
+
+        if (context == null) {
+            throw new IllegalStateException(SUPPLIER_PRODUCED_NULL);
+        }
+
+        return new SubscriberIterator<>(queue, batchSize, context);
     }
 
     private static void propagateFailure(Throwable e) {
@@ -87,7 +97,7 @@ public class BlockingIterable<T> implements Iterable<T> {
     }
 
     @SuppressWarnings("ReactiveStreamsSubscriberImplementation")
-    private static final class SubscriberIterator<T> implements Subscriber<T>, Iterator<T> {
+    private static final class SubscriberIterator<T> implements Subscriber<T>, Iterator<T>, ContextSupport {
 
         private final Queue<T> queue;
 
@@ -99,6 +109,8 @@ public class BlockingIterable<T> implements Iterable<T> {
 
         private final Condition condition;
 
+        private final Context context;
+
         long produced;
 
         AtomicReference<Subscription> subscription = new AtomicReference<>();
@@ -107,10 +119,11 @@ public class BlockingIterable<T> implements Iterable<T> {
 
         Throwable failure;
 
-        SubscriberIterator(Queue<T> queue, int batchSize) {
+        SubscriberIterator(Queue<T> queue, int batchSize, Context context) {
             this.queue = queue;
             this.batchSize = batchSize;
             this.limit = batchSize;
+            this.context = context;
             this.lock = new ReentrantLock();
             this.condition = lock.newCondition();
         }
@@ -201,6 +214,11 @@ public class BlockingIterable<T> implements Iterable<T> {
             if (s != null) {
                 s.cancel();
             }
+        }
+
+        @Override
+        public Context context() {
+            return this.context;
         }
 
         @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/MultiEmitterProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/MultiEmitterProcessor.java
@@ -8,6 +8,7 @@ import org.reactivestreams.Processor;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import io.smallrye.mutiny.subscription.MultiEmitter;
@@ -131,5 +132,10 @@ public class MultiEmitterProcessor<T> implements Processor<T, T>, MultiEmitter<T
 
     public Multi<T> toMulti() {
         return Multi.createFrom().publisher(this);
+    }
+
+    @Override
+    public Context context() {
+        throw new UnsupportedOperationException("This class is used in tests");
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/StrictMultiSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/StrictMultiSubscriber.java
@@ -9,6 +9,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.subscription.ContextSupport;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 
 /**
@@ -24,7 +26,7 @@ import io.smallrye.mutiny.subscription.MultiSubscriber;
  * @param <T> the type of item
  */
 public class StrictMultiSubscriber<T>
-        implements MultiSubscriber<T>, Subscription {
+        implements MultiSubscriber<T>, Subscription, ContextSupport {
 
     private final AtomicInteger wip = new AtomicInteger();
 
@@ -93,5 +95,14 @@ public class StrictMultiSubscriber<T>
     public void onCompletion() {
         done = true;
         HalfSerializer.onComplete(downstream, wip, failure);
+    }
+
+    @Override
+    public Context context() {
+        if (downstream instanceof ContextSupport) {
+            return ((ContextSupport) downstream).context();
+        } else {
+            return Context.empty();
+        }
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/UniCallbackSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/UniCallbackSubscriber.java
@@ -8,6 +8,7 @@ import java.util.function.Consumer;
 
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.UniSubscriber;
@@ -27,6 +28,7 @@ public class UniCallbackSubscriber<T> implements UniSubscriber<T>, UniSubscripti
 
     private final Consumer<? super T> onResultCallback;
     private final Consumer<? super Throwable> onFailureCallback;
+    private final Context context;
 
     /**
      * Creates a {@link UniSubscriber} consuming the item and failure of a
@@ -34,11 +36,14 @@ public class UniCallbackSubscriber<T> implements UniSubscriber<T>, UniSubscripti
      *
      * @param onResultCallback callback invoked on item event, must not be {@code null}
      * @param onFailureCallback callback invoked on failure event, must not be {@code null}
+     * @param context
      */
     public UniCallbackSubscriber(Consumer<? super T> onResultCallback,
-            Consumer<? super Throwable> onFailureCallback) {
+            Consumer<? super Throwable> onFailureCallback,
+            Context context) {
         this.onResultCallback = nonNull(onResultCallback, "onResultCallback");
         this.onFailureCallback = nonNull(onFailureCallback, "onFailureCallback");
+        this.context = context;
     }
 
     @Override
@@ -81,5 +86,10 @@ public class UniCallbackSubscriber<T> implements UniSubscriber<T>, UniSubscripti
         if (sub != null) {
             sub.cancel();
         }
+    }
+
+    @Override
+    public Context context() {
+        return context;
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertSubscriber.java
@@ -15,13 +15,16 @@ import java.util.function.Consumer;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.subscription.ContextSupport;
+
 /**
  * A {@link io.smallrye.mutiny.Multi} {@link Subscriber} for testing purposes that comes with useful assertion helpers.
  *
  * @param <T> the type of the items
  */
 @SuppressWarnings({ "ReactiveStreamsSubscriberImplementation" })
-public class AssertSubscriber<T> implements Subscriber<T> {
+public class AssertSubscriber<T> implements Subscriber<T>, ContextSupport {
 
     /**
      * The default timeout used by {@code await} method.
@@ -82,21 +85,38 @@ public class AssertSubscriber<T> implements Subscriber<T> {
     private boolean cancelled;
 
     /**
+     * The subscription context.
+     */
+    private final Context context;
+
+    /**
+     * Creates a new {@link AssertSubscriber}.
+     *
+     * @param context the context
+     * @param requested the number of initially requested items
+     * @param cancelled {@code true} if the subscription is immediately cancelled, {@code false} otherwise
+     */
+    public AssertSubscriber(Context context, long requested, boolean cancelled) {
+        this.context = context;
+        this.requested.set(requested);
+        this.upfrontCancellation = cancelled;
+    }
+
+    /**
      * Creates a new {@link AssertSubscriber}.
      *
      * @param requested the number of initially requested items
      * @param cancelled {@code true} if the subscription is immediately cancelled, {@code false} otherwise
      */
     public AssertSubscriber(long requested, boolean cancelled) {
-        this.requested.set(requested);
-        this.upfrontCancellation = cancelled;
+        this(Context.empty(), requested, cancelled);
     }
 
     /**
      * Creates a new {@link AssertSubscriber} with 0 requested items and no upfront cancellation.
      */
     public AssertSubscriber() {
-        this(0, false);
+        this(Context.empty(), 0, false);
     }
 
     /**
@@ -105,7 +125,7 @@ public class AssertSubscriber<T> implements Subscriber<T> {
      * @param requested the number of initially requested items
      */
     public AssertSubscriber(long requested) {
-        this(requested, false);
+        this(Context.empty(), requested, false);
     }
 
     /**
@@ -127,6 +147,34 @@ public class AssertSubscriber<T> implements Subscriber<T> {
      */
     public static <T> AssertSubscriber<T> create(long requested) {
         return new AssertSubscriber<>(requested);
+    }
+
+    /**
+     * Creates a new {@link AssertSubscriber} with 0 requested items and no upfront cancellation.
+     *
+     * @param context the context
+     * @param <T> the items type
+     * @return a new subscriber
+     */
+    public static <T> AssertSubscriber<T> create(Context context) {
+        return new AssertSubscriber<>(context, 0, false);
+    }
+
+    /**
+     * Creates a new {@link AssertSubscriber} with no upfront cancellation.
+     *
+     * @param context the context
+     * @param requested the number of initially requested items
+     * @param <T> the items type
+     * @return a new subscriber
+     */
+    public static <T> AssertSubscriber<T> create(Context context, long requested) {
+        return new AssertSubscriber<>(context, requested, false);
+    }
+
+    @Override
+    public Context context() {
+        return context;
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
@@ -4,19 +4,18 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
 import java.util.Objects;
 import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
 import org.reactivestreams.Subscriber;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.*;
 import io.smallrye.mutiny.helpers.StrictMultiSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
-import io.smallrye.mutiny.operators.multi.MultiCacheOp;
-import io.smallrye.mutiny.operators.multi.MultiEmitOnOp;
-import io.smallrye.mutiny.operators.multi.MultiLogger;
-import io.smallrye.mutiny.operators.multi.MultiSubscribeOnOp;
+import io.smallrye.mutiny.operators.multi.*;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 
@@ -168,7 +167,7 @@ public abstract class AbstractMulti<T> implements Multi<T> {
 
     @Override
     public Multi<T> log(String identifier) {
-        return new MultiLogger<>(this, identifier);
+        return Infrastructure.onMultiCreation(new MultiLogger<>(this, identifier));
     }
 
     @Override
@@ -176,4 +175,8 @@ public abstract class AbstractMulti<T> implements Multi<T> {
         return log("Multi." + this.getClass().getSimpleName());
     }
 
+    @Override
+    public <R> Multi<R> withContext(BiFunction<Multi<T>, Context, Multi<R>> builder) {
+        return Infrastructure.onMultiCreation(new MultiWithContext<>(this, nonNull(builder, "builder")));
+    }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOperatorProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOperatorProcessor.java
@@ -7,11 +7,13 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.subscription.ContextSupport;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 
-public abstract class MultiOperatorProcessor<I, O> implements MultiSubscriber<I>, Subscription {
+public abstract class MultiOperatorProcessor<I, O> implements MultiSubscriber<I>, Subscription, ContextSupport {
 
     /*
      * We used to have an interpretation of the RS TCK that it had to be null on cancellation to release the subscriber.
@@ -59,6 +61,15 @@ public abstract class MultiOperatorProcessor<I, O> implements MultiSubscriber<I>
 
     protected boolean isCancelled() {
         return cancellationRequested == 1;
+    }
+
+    @Override
+    public Context context() {
+        if (downstream instanceof ContextSupport) {
+            return ((ContextSupport) downstream).context();
+        } else {
+            return Context.empty();
+        }
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSelectFirstUntilOtherOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSelectFirstUntilOtherOp.java
@@ -7,10 +7,12 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.subscription.ContextSupport;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 import io.smallrye.mutiny.subscription.SerializedSubscriber;
 
@@ -38,7 +40,7 @@ public final class MultiSelectFirstUntilOtherOp<T, U> extends AbstractMultiOpera
         upstream.subscribe(Infrastructure.onMultiSubscription(upstream, mainSubscriber));
     }
 
-    public static final class TakeUntilOtherSubscriber<U> implements MultiSubscriber<U> {
+    public static final class TakeUntilOtherSubscriber<U> implements MultiSubscriber<U>, ContextSupport {
         final TakeUntilMainProcessor<?> main;
         boolean once;
 
@@ -74,6 +76,11 @@ public final class MultiSelectFirstUntilOtherOp<T, U> extends AbstractMultiOpera
             }
             once = true;
             main.onOtherCompletion();
+        }
+
+        @Override
+        public Context context() {
+            return main.context();
         }
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipUntilOtherOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipUntilOtherOp.java
@@ -7,10 +7,12 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.subscription.ContextSupport;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 import io.smallrye.mutiny.subscription.SerializedSubscriber;
 
@@ -38,7 +40,7 @@ public final class MultiSkipUntilOtherOp<T, U> extends AbstractMultiOperator<T, 
     }
 
     @SuppressWarnings("SubscriberImplementation")
-    static final class OtherStreamTracker<U> implements MultiSubscriber<U> {
+    static final class OtherStreamTracker<U> implements MultiSubscriber<U>, ContextSupport {
 
         private final SkipUntilMainProcessor<?> main;
 
@@ -68,6 +70,10 @@ public final class MultiSkipUntilOtherOp<T, U> extends AbstractMultiOperator<T, 
             main.open();
         }
 
+        @Override
+        public Context context() {
+            return main.context();
+        }
     }
 
     static final class SkipUntilMainProcessor<T> extends MultiOperatorProcessor<T, T> {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWithContext.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWithContext.java
@@ -1,0 +1,51 @@
+package io.smallrye.mutiny.operators.multi;
+
+import java.util.function.BiFunction;
+
+import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.ParameterValidation;
+import io.smallrye.mutiny.helpers.Subscriptions;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.subscription.ContextSupport;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+public class MultiWithContext<I, O> extends AbstractMultiOperator<I, O> {
+
+    private final BiFunction<Multi<I>, Context, Multi<O>> builder;
+
+    public MultiWithContext(Multi<? extends I> upstream, BiFunction<Multi<I>, Context, Multi<O>> builder) {
+        super(upstream);
+        this.builder = builder;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void subscribe(MultiSubscriber<? super O> downstream) {
+        ParameterValidation.nonNull(downstream, "downstream");
+
+        Context context;
+        if (downstream instanceof ContextSupport) {
+            context = ((ContextSupport) downstream).context();
+        } else {
+            context = Context.empty();
+        }
+
+        Multi<O> multi;
+        try {
+            multi = builder.apply((Multi<I>) upstream, context);
+            if (multi == null) {
+                downstream.onSubscribe(Subscriptions.CANCELLED);
+                downstream.onFailure(new NullPointerException("The builder function returned null"));
+                return;
+            }
+        } catch (Throwable err) {
+            downstream.onSubscribe(Subscriptions.CANCELLED);
+            downstream.onFailure(err);
+            return;
+        }
+
+        Multi<O> pipelineWithContext = Infrastructure.onMultiCreation(multi);
+        pipelineWithContext.subscribe().withSubscriber(downstream);
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BaseMultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BaseMultiEmitter.java
@@ -6,13 +6,15 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.helpers.Subscriptions;
+import io.smallrye.mutiny.subscription.ContextSupport;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 
 abstract class BaseMultiEmitter<T>
-        implements MultiEmitter<T>, Subscription {
+        implements MultiEmitter<T>, Subscription, ContextSupport {
 
     protected final AtomicLong requested = new AtomicLong();
     protected final MultiSubscriber<? super T> downstream;
@@ -26,6 +28,15 @@ abstract class BaseMultiEmitter<T>
     BaseMultiEmitter(MultiSubscriber<? super T> downstream) {
         this.downstream = downstream;
         this.onTermination = new AtomicReference<>();
+    }
+
+    @Override
+    public Context context() {
+        if (downstream instanceof ContextSupport) {
+            return ((ContextSupport) downstream).context();
+        } else {
+            return Context.empty();
+        }
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/DeferredMultiWithContext.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/DeferredMultiWithContext.java
@@ -1,0 +1,44 @@
+package io.smallrye.mutiny.operators.multi.builders;
+
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.ParameterValidation;
+import io.smallrye.mutiny.helpers.Subscriptions;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.subscription.ContextSupport;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+public class DeferredMultiWithContext<T> extends AbstractMulti<T> {
+
+    private final Function<Context, Multi<? extends T>> mapper;
+
+    public DeferredMultiWithContext(Function<Context, Multi<? extends T>> mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super T> downstream) {
+        Context context;
+        if (downstream instanceof ContextSupport) {
+            context = ((ContextSupport) downstream).context();
+        } else {
+            context = Context.empty();
+        }
+
+        Multi<? extends T> multi;
+        try {
+            multi = mapper.apply(context);
+            if (multi == null) {
+                throw new NullPointerException(ParameterValidation.MAPPER_RETURNED_NULL);
+            }
+        } catch (Throwable failure) {
+            Subscriptions.fail(downstream, failure);
+            return;
+        }
+
+        multi.subscribe(Infrastructure.onMultiSubscription(multi, downstream));
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/ResourceMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/ResourceMulti.java
@@ -10,11 +10,13 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.CompositeException;
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.subscription.ContextSupport;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 
 public class ResourceMulti<R, I> extends AbstractMulti<I> {
@@ -80,7 +82,7 @@ public class ResourceMulti<R, I> extends AbstractMulti<I> {
         stream.subscribe(us);
     }
 
-    private static class ResourceSubscriber<I, R> implements Subscription, MultiSubscriber<I> {
+    private static class ResourceSubscriber<I, R> implements Subscription, MultiSubscriber<I>, ContextSupport {
 
         private final MultiSubscriber<? super I> downstream;
         private final R resource;
@@ -195,6 +197,15 @@ public class ResourceMulti<R, I> extends AbstractMulti<I> {
                         },
                         Infrastructure::handleDroppedException // ignore the failure, we have cancelled anyway.
                 );
+            }
+        }
+
+        @Override
+        public Context context() {
+            if (downstream instanceof ContextSupport) {
+                return ((ContextSupport) downstream).context();
+            } else {
+                return Context.empty();
             }
         }
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/SerializedMultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/SerializedMultiEmitter.java
@@ -8,8 +8,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.helpers.queues.Queues;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.subscription.ContextSupport;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 
@@ -18,7 +20,7 @@ import io.smallrye.mutiny.subscription.MultiSubscriber;
  *
  * @param <T> the type of item
  */
-public class SerializedMultiEmitter<T> implements MultiEmitter<T>, MultiSubscriber<T> {
+public class SerializedMultiEmitter<T> implements MultiEmitter<T>, MultiSubscriber<T>, ContextSupport {
 
     private final AtomicInteger wip = new AtomicInteger();
     private final BaseMultiEmitter<T> downstream;
@@ -167,5 +169,14 @@ public class SerializedMultiEmitter<T> implements MultiEmitter<T>, MultiSubscrib
     @Override
     public long requested() {
         return downstream.requested();
+    }
+
+    @Override
+    public Context context() {
+        if (downstream instanceof ContextSupport) {
+            return ((ContextSupport) downstream).context();
+        } else {
+            return Context.empty();
+        }
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/ConnectableMultiConnection.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/ConnectableMultiConnection.java
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
 
 public class ConnectableMultiConnection implements Runnable, Consumer<Cancellable> {
 
@@ -12,14 +13,16 @@ public class ConnectableMultiConnection implements Runnable, Consumer<Cancellabl
     };
 
     private final MultiReferenceCount<?> parent;
+    private final MultiSubscriber<?> subscriber;
     private final AtomicReference<Cancellable> onCancellation = new AtomicReference<>();
 
     private Cancellable timer;
     private long subscriberCount;
     private boolean connected;
 
-    ConnectableMultiConnection(MultiReferenceCount<?> parent) {
+    ConnectableMultiConnection(MultiReferenceCount<?> parent, MultiSubscriber<?> subscriber) {
         this.parent = parent;
+        this.subscriber = subscriber;
     }
 
     @Override
@@ -97,5 +100,9 @@ public class ConnectableMultiConnection implements Runnable, Consumer<Cancellabl
             timer.cancel();
         }
         this.timer = cancellable;
+    }
+
+    public MultiSubscriber<?> getSubscriber() {
+        return subscriber;
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiReferenceCount.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiReferenceCount.java
@@ -37,13 +37,13 @@ public class MultiReferenceCount<T> extends AbstractMulti<T> implements Multi<T>
     }
 
     @Override
-    public void subscribe(MultiSubscriber<? super T> s) {
+    public void subscribe(MultiSubscriber<? super T> subscriber) {
         ConnectableMultiConnection conn;
         boolean connect;
         synchronized (this) {
             conn = connection;
             if (conn == null) {
-                conn = new ConnectableMultiConnection(this);
+                conn = new ConnectableMultiConnection(this, subscriber);
                 connection = conn;
             }
 
@@ -51,7 +51,7 @@ public class MultiReferenceCount<T> extends AbstractMulti<T> implements Multi<T>
             connect = conn.shouldConnectAfterIncrement(numberOfSubscribers);
         }
 
-        upstream.subscribe().withSubscriber(new MultiReferenceCountSubscriber<>(s, this, conn));
+        upstream.subscribe().withSubscriber(new MultiReferenceCountSubscriber<>(subscriber, this, conn));
 
         if (connect) {
             upstream.connect(conn);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniBlockingAwait.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniBlockingAwait.java
@@ -1,7 +1,6 @@
 package io.smallrye.mutiny.operators.uni;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
-import static io.smallrye.mutiny.helpers.ParameterValidation.validate;
 
 import java.time.Duration;
 import java.util.concurrent.CompletionException;
@@ -9,6 +8,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
@@ -22,7 +22,7 @@ public class UniBlockingAwait {
         // Avoid direct instantiation.
     }
 
-    public static <T> T await(Uni<T> upstream, Duration duration) {
+    public static <T> T await(Uni<T> upstream, Duration duration, Context context) {
         nonNull(upstream, "upstream");
         validate(duration);
 
@@ -34,6 +34,12 @@ public class UniBlockingAwait {
         AtomicReference<T> reference = new AtomicReference<>();
         AtomicReference<Throwable> referenceToFailure = new AtomicReference<>();
         UniSubscriber<T> subscriber = new UniSubscriber<T>() {
+
+            @Override
+            public Context context() {
+                return (context != null) ? context : Context.empty();
+            }
+
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 // Do nothing.

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnItemTransformToMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnItemTransformToMulti.java
@@ -10,11 +10,13 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.EmptyUniSubscription;
 import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.operators.AbstractMulti;
 import io.smallrye.mutiny.operators.AbstractUni;
+import io.smallrye.mutiny.subscription.ContextSupport;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
@@ -38,7 +40,8 @@ public class UniOnItemTransformToMulti<I, O> extends AbstractMulti<O> {
     }
 
     @SuppressWarnings("SubscriberImplementation")
-    static final class FlatMapPublisherSubscriber<I, O> implements Subscriber<O>, UniSubscriber<I>, Subscription {
+    static final class FlatMapPublisherSubscriber<I, O>
+            implements Subscriber<O>, UniSubscriber<I>, Subscription, ContextSupport {
 
         private final AtomicReference<Subscription> secondUpstream;
         private final AtomicReference<UniSubscription> firstUpstream;
@@ -81,6 +84,15 @@ public class UniOnItemTransformToMulti<I, O> extends AbstractMulti<O> {
                 subscription.cancel();
             }
             Subscriptions.cancel(secondUpstream);
+        }
+
+        @Override
+        public Context context() {
+            if (downstream instanceof ContextSupport) {
+                return ((ContextSupport) downstream).context();
+            } else {
+                return Context.empty();
+            }
         }
 
         /**

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOperatorProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOperatorProcessor.java
@@ -5,6 +5,7 @@ import static io.smallrye.mutiny.helpers.EmptyUniSubscription.DONE;
 
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.UniSubscriber;
@@ -21,6 +22,11 @@ public abstract class UniOperatorProcessor<I, O> implements UniSubscriber<I>, Un
 
     public UniOperatorProcessor(UniSubscriber<? super O> downstream) {
         this.downstream = ParameterValidation.nonNull(downstream, "downstream");
+    }
+
+    @Override
+    public Context context() {
+        return this.downstream.context();
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOrCombination.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOrCombination.java
@@ -24,15 +24,6 @@ public class UniOrCombination<T> extends UniOperator<Void, T> {
                 .forEach(u -> challengers.add(nonNull(u, "iterable` must not contain a `null` value")));
     }
 
-    public UniOrCombination(Uni<? super T>[] array) {
-        super(null);
-        nonNull(array, "array");
-        this.challengers = new ArrayList<>();
-        for (Uni<? super T> u : array) {
-            challengers.add(nonNull(u, "array` must not contain a `null` value"));
-        }
-    }
-
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public void subscribe(UniSubscriber<? super T> subscriber) {
@@ -54,7 +45,7 @@ public class UniOrCombination<T> extends UniOperator<Void, T> {
 
         List<CompletableFuture<? super T>> futures = new ArrayList<>();
         challengers.forEach(uni -> {
-            CompletableFuture<? super T> future = uni.subscribe().asCompletionStage();
+            CompletableFuture<? super T> future = uni.subscribe().asCompletionStage(subscriber.context());
             futures.add(future);
         });
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniSubscribeToCompletionStage.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniSubscribeToCompletionStage.java
@@ -3,13 +3,14 @@ package io.smallrye.mutiny.operators.uni;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.Cancellable;
 
 public class UniSubscribeToCompletionStage {
 
-    public static <T> CompletableFuture<T> subscribe(Uni<T> uni) {
+    public static <T> CompletableFuture<T> subscribe(Uni<T> uni, Context context) {
         final AtomicReference<Cancellable> cancellable = new AtomicReference<>();
 
         CompletableFuture<T> future = new CompletableFuture<T>() {
@@ -26,7 +27,7 @@ public class UniSubscribeToCompletionStage {
             }
         };
 
-        cancellable.set(uni.subscribe().with(future::complete, future::completeExceptionally));
+        cancellable.set(uni.subscribe().with(context, future::complete, future::completeExceptionally));
         return Infrastructure.wrapCompletableFuture(future);
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniWithContext.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniWithContext.java
@@ -1,0 +1,43 @@
+package io.smallrye.mutiny.operators.uni;
+
+import java.util.function.BiFunction;
+
+import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.EmptyUniSubscription;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.AbstractUni;
+import io.smallrye.mutiny.operators.UniOperator;
+import io.smallrye.mutiny.subscription.UniSubscriber;
+
+public class UniWithContext<I, O> extends UniOperator<I, O> {
+
+    private final Uni<I> upstream;
+    private final BiFunction<Uni<I>, Context, Uni<O>> builder;
+
+    public UniWithContext(Uni<I> upstream, BiFunction<Uni<I>, Context, Uni<O>> builder) {
+        super(upstream);
+        this.upstream = upstream;
+        this.builder = builder;
+    }
+
+    @Override
+    public void subscribe(UniSubscriber<? super O> downstream) {
+        Context context = downstream.context();
+        Uni<O> uni;
+        try {
+            uni = builder.apply(upstream, context);
+            if (uni == null) {
+                downstream.onSubscribe(EmptyUniSubscription.DONE);
+                downstream.onFailure(new NullPointerException("The builder function returned null"));
+                return;
+            }
+        } catch (Throwable err) {
+            downstream.onSubscribe(EmptyUniSubscription.DONE);
+            downstream.onFailure(err);
+            return;
+        }
+        Uni<O> pipelineWithContext = Infrastructure.onUniCreation(uni);
+        AbstractUni.subscribe(pipelineWithContext, downstream);
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/DefaultUniEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/DefaultUniEmitter.java
@@ -5,6 +5,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.subscription.UniEmitter;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
@@ -78,5 +79,10 @@ public class DefaultUniEmitter<T> implements UniEmitter<T>, UniSubscription {
 
     public boolean isTerminated() {
         return disposed.get();
+    }
+
+    @Override
+    public Context context() {
+        return downstream.context();
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/DeferredUniWithContext.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/DeferredUniWithContext.java
@@ -1,0 +1,39 @@
+package io.smallrye.mutiny.operators.uni.builders;
+
+import static io.smallrye.mutiny.helpers.EmptyUniSubscription.DONE;
+
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.ParameterValidation;
+import io.smallrye.mutiny.operators.AbstractUni;
+import io.smallrye.mutiny.subscription.UniSubscriber;
+
+public class DeferredUniWithContext<T> extends AbstractUni<T> {
+
+    private final Function<Context, Uni<? extends T>> mapper;
+
+    public DeferredUniWithContext(Function<Context, Uni<? extends T>> mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void subscribe(UniSubscriber<? super T> subscriber) {
+        Uni<? extends T> uni;
+        try {
+            uni = mapper.apply(subscriber.context());
+            if (uni == null) {
+                subscriber.onSubscribe(DONE);
+                subscriber.onFailure(new NullPointerException(ParameterValidation.MAPPER_RETURNED_NULL));
+                return;
+            }
+        } catch (Throwable failure) {
+            subscriber.onSubscribe(DONE);
+            subscriber.onFailure(failure);
+            return;
+        }
+
+        AbstractUni.subscribe(uni, subscriber);
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromPublisher.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromPublisher.java
@@ -9,8 +9,10 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.AbstractUni;
+import io.smallrye.mutiny.subscription.ContextSupport;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
 
@@ -27,7 +29,7 @@ public class UniCreateFromPublisher<T> extends AbstractUni<T> {
     }
 
     @SuppressWarnings("ReactiveStreamsSubscriberImplementation")
-    private class PublisherSubscriber implements UniSubscription, Subscriber<T> {
+    private class PublisherSubscriber implements UniSubscription, Subscriber<T>, ContextSupport {
 
         private final UniSubscriber<? super T> subscriber;
         AtomicReference<Subscription> subscription = new AtomicReference<>();
@@ -86,6 +88,11 @@ public class UniCreateFromPublisher<T> extends AbstractUni<T> {
             if (sub != CANCELLED) {
                 subscriber.onItem(null);
             }
+        }
+
+        @Override
+        public Context context() {
+            return subscriber.context();
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinAll.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinAll.java
@@ -57,7 +57,7 @@ public class UniJoinAll<T> extends AbstractUni<List<T>> {
                 Uni<? extends T> uni = unis.get(i);
                 uni.onSubscription()
                         .invoke(subscription -> subscriptions.set(index, subscription))
-                        .subscribe().with(item -> this.onItem(index, item), this::onFailure);
+                        .subscribe().with(subscriber.context(), item -> this.onItem(index, item), this::onFailure);
             }
         }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinFirst.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinFirst.java
@@ -52,7 +52,7 @@ public class UniJoinFirst<T> extends AbstractUni<T> {
                 Uni<? extends T> uni = unis.get(i);
                 uni.onSubscription()
                         .invoke(subscription -> subscriptions.set(index, subscription))
-                        .subscribe().with(this::onItem, this::onFailure);
+                        .subscribe().with(subscriber.context(), this::onItem, this::onFailure);
             }
         }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/ContextSupport.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/ContextSupport.java
@@ -1,0 +1,26 @@
+package io.smallrye.mutiny.subscription;
+
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Context;
+
+/**
+ * Interface for subscribers and types that provide a {@link Context}.
+ */
+@Experimental("Context support is a new experimental API introduced in Mutiny 1.3.0")
+public interface ContextSupport {
+
+    /**
+     * Provide a context.
+     * <p>
+     * Since calls to this method shall only be triggered when a Mutiny pipeline uses a {@code withContext} operator,
+     * there is no need in general for caching the context value in a field of the implementing class.
+     * Exceptions include operators that have cross-subscriber semantics such as memoizers or broadcasters.
+     * <p>
+     * This method is expected to be called once per {@code withContext} operator.
+     *
+     * @return the context, must not be {@code null}.
+     */
+    default Context context() {
+        return Context.empty();
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/MultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/MultiEmitter.java
@@ -13,7 +13,7 @@ import io.smallrye.mutiny.Multi;
  *
  * @param <T> the expected type of items.
  */
-public interface MultiEmitter<T> {
+public interface MultiEmitter<T> extends ContextSupport {
 
     /**
      * Emits an {@code item} event downstream.

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/SafeSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/SafeSubscriber.java
@@ -7,6 +7,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.CompositeException;
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 
@@ -17,7 +18,7 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
  * @param <T> the value type
  */
 @SuppressWarnings({ "ReactiveStreamsSubscriberImplementation" })
-public final class SafeSubscriber<T> implements Subscriber<T>, Subscription {
+public final class SafeSubscriber<T> implements Subscriber<T>, Subscription, ContextSupport {
 
     /**
      * The actual Subscriber.
@@ -214,6 +215,15 @@ public final class SafeSubscriber<T> implements Subscriber<T>, Subscription {
         } catch (Throwable e) {
             // nothing we can do.
             Infrastructure.handleDroppedException(e);
+        }
+    }
+
+    @Override
+    public Context context() {
+        if (downstream instanceof ContextSupport) {
+            return ((ContextSupport) downstream).context();
+        } else {
+            return Context.empty();
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/SerializedSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/SerializedSubscriber.java
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 
 /**
@@ -16,7 +17,7 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
  *
  * @param <T> the type of items
  */
-public final class SerializedSubscriber<T> implements Subscription, MultiSubscriber<T> {
+public final class SerializedSubscriber<T> implements Subscription, MultiSubscriber<T>, ContextSupport {
 
     private final Subscriber<? super T> downstream;
 
@@ -213,6 +214,15 @@ public final class SerializedSubscriber<T> implements Subscription, MultiSubscri
                 actual.onComplete();
                 return;
             }
+        }
+    }
+
+    @Override
+    public Context context() {
+        if (downstream instanceof ContextSupport) {
+            return ((ContextSupport) downstream).context();
+        } else {
+            return Context.empty();
         }
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/SwitchableSubscriptionSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/SwitchableSubscriptionSubscriber.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.helpers.Subscriptions;
 
@@ -18,7 +19,7 @@ import io.smallrye.mutiny.helpers.Subscriptions;
  *
  * @param <O> outgoing item type
  */
-public abstract class SwitchableSubscriptionSubscriber<O> implements MultiSubscriber<O>, Subscription {
+public abstract class SwitchableSubscriptionSubscriber<O> implements MultiSubscriber<O>, Subscription, ContextSupport {
 
     /**
      * The downstream subscriber
@@ -70,6 +71,15 @@ public abstract class SwitchableSubscriptionSubscriber<O> implements MultiSubscr
 
     public SwitchableSubscriptionSubscriber(MultiSubscriber<? super O> downstream) {
         this.downstream = downstream;
+    }
+
+    @Override
+    public Context context() {
+        if (downstream instanceof ContextSupport) {
+            return ((ContextSupport) downstream).context();
+        } else {
+            return Context.empty();
+        }
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/UniDelegatingSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/UniDelegatingSubscriber.java
@@ -2,12 +2,19 @@ package io.smallrye.mutiny.subscription;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import io.smallrye.mutiny.Context;
+
 public class UniDelegatingSubscriber<I, O> implements UniSubscriber<I> {
 
     private final UniSubscriber<? super O> delegate;
 
     public UniDelegatingSubscriber(UniSubscriber<? super O> subscriber) {
         this.delegate = nonNull(subscriber, "delegate");
+    }
+
+    @Override
+    public Context context() {
+        return delegate.context();
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/UniEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/UniEmitter.java
@@ -8,7 +8,7 @@ import io.smallrye.mutiny.Uni;
  *
  * @param <T> the expected type of item.
  */
-public interface UniEmitter<T> {
+public interface UniEmitter<T> extends ContextSupport {
 
     /**
      * Emits the {@code item} event downstream with the given (potentially {@code null}) item.

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/UniSerializedSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/UniSerializedSubscriber.java
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.smallrye.mutiny.CompositeException;
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.helpers.EmptyUniSubscription;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
@@ -52,6 +53,11 @@ public class UniSerializedSubscriber<T> implements UniSubscriber<T>, UniSubscrip
         if (state.compareAndSet(INIT, SUBSCRIBED)) {
             upstream.subscribe(this);
         }
+    }
+
+    @Override
+    public Context context() {
+        return downstream.context();
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/UniSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/UniSubscriber.java
@@ -22,7 +22,7 @@ import io.smallrye.mutiny.groups.UniSubscribe;
  *
  * @param <T> the expected type of item
  */
-public interface UniSubscriber<T> {
+public interface UniSubscriber<T> extends ContextSupport {
 
     /**
      * Event handler called once the subscribed {@link Uni} has taken into account the subscription. The {@link Uni}

--- a/implementation/src/test/java/io/smallrye/mutiny/ContextTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/ContextTest.java
@@ -1,0 +1,1161 @@
+package io.smallrye.mutiny;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.helpers.BlockingIterable;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.smallrye.mutiny.subscription.UniDelegatingSubscriber;
+
+class ContextTest {
+
+    @Nested
+    @DisplayName("Context factory methods")
+    class ContextFactoryMethods {
+
+        @Test
+        void empty() {
+            Context context = Context.empty();
+            assertThat(context.keys()).isEmpty();
+        }
+
+        @Test
+        void balancedOf() {
+            Context context = Context.of("foo", "bar", "abc", "def");
+            assertThat(context.keys())
+                    .hasSize(2)
+                    .contains("foo", "abc");
+        }
+
+        @Test
+        void emptyOf() {
+            Context context = Context.of();
+            assertThat(context.keys()).isEmpty();
+        }
+
+        @Test
+        void nullOf() {
+            assertThatThrownBy(() -> Context.of((Object[]) null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("The entries array cannot be null");
+        }
+
+        @Test
+        void unbalancedOf() {
+            assertThatThrownBy(() -> Context.of("foo", "bar", "baz"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Arguments must be balanced to form (key, value) pairs");
+        }
+
+        @Test
+        void from() {
+            HashMap<String, String> map = new HashMap<String, String>() {
+                {
+                    put("foo", "bar");
+                    put("abc", "def");
+                }
+            };
+
+            Context context = Context.from(map);
+            assertThat(context.keys())
+                    .hasSize(2)
+                    .contains("foo", "abc");
+
+            map.put("123", "456");
+            assertThat(map).hasSize(3);
+            assertThat(context.keys()).hasSize(2);
+        }
+
+        @Test
+        void fromNull() {
+            assertThatThrownBy(() -> Context.from(null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("The entries map cannot be null");
+        }
+
+        @Test
+        // This will please CodeCov
+        void toStringAndEquals() {
+            Context ctx1 = Context.of("foo", "bar");
+            Context ctx2 = Context.of("foo", "bar");
+            Context ctx3 = Context.of("foo", "bar", "abc", "def");
+            Context ctx4 = Context.empty();
+            Context ctx5 = Context.empty();
+
+            assertThat(ctx1).isEqualTo(ctx2);
+            assertThat(ctx2).isNotEqualTo(ctx3);
+            assertThat(ctx2).isNotEqualTo(ctx4);
+            assertThat(ctx5).isEqualTo(ctx5);
+
+            assertThat(ctx1.toString()).isEqualTo("Context{entries={foo=bar}}");
+            assertThat(ctx4.toString()).isEqualTo("Context{entries=null}");
+        }
+    }
+
+    @Nested
+    @DisplayName("Context methods")
+    class ContextMethods {
+
+        @Test
+        void sanityChecks() {
+            Context context = Context.of("foo", "bar", "123", 456);
+
+            assertThat(context.keys())
+                    .hasSize(2)
+                    .contains("foo", "123");
+
+            assertThat(context.contains("foo")).isTrue();
+            assertThat(context.contains("bar")).isFalse();
+            assertThat(context.isEmpty()).isFalse();
+
+            assertThat(context.<String> get("foo")).isEqualTo("bar");
+            assertThat(context.getOrElse("bar", () -> "666")).isEqualTo("666");
+
+            context.put("bar", 123);
+            assertThat(context.keys()).hasSize(3);
+            assertThat(context.getOrElse("bar", () -> 666)).isEqualTo(123);
+
+            context.delete("foo").delete("123").delete("bar");
+            assertThat(context.contains("foo")).isFalse();
+            assertThat(context.isEmpty()).isTrue();
+            assertThat(context.keys()).isEmpty();
+        }
+
+        @Test
+        void containsOnEmptyContext() {
+            assertThat(Context.empty().contains("foo")).isFalse();
+        }
+
+        @Test
+        void getOnEmptyContext() {
+            assertThatThrownBy(() -> Context.empty().get("foo"))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessage("The context is empty");
+
+            assertThat(Context.empty().getOrElse("foo", () -> "bar")).isEqualTo("bar");
+        }
+
+        @Test
+        void getOnMissingKey() {
+            assertThatThrownBy(() -> Context.of("foo", "bar").get("yolo"))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessage("The context does not have a value for key yolo");
+        }
+
+        @Test
+        void keysetIsACopy() {
+            Context context = Context.of("foo", "bar", "123", 456);
+            Set<String> k1 = context.keys();
+            context.put("bar", "baz");
+            Set<String> k2 = context.keys();
+            assertThat(k1).isNotSameAs(k2);
+        }
+    }
+
+    @Nested
+    @DisplayName("Uni with context")
+    class UniAndContext {
+
+        @Test
+        void noContextShallBeEmpty() {
+            UniAssertSubscriber<String> sub = Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.assertCompleted().assertItem("63::yolo");
+        }
+
+        @Test
+        void transformWithContext() {
+            Context context = Context.of("foo", "bar");
+
+            UniAssertSubscriber<String> sub = Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().withSubscriber(UniAssertSubscriber.create(context));
+
+            sub.assertCompleted().assertItem("63::bar");
+        }
+
+        @Test
+        void withContextRejectsNullBuilder() {
+            assertThatThrownBy(() -> Uni.createFrom().item(1).withContext(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("`builder` must not be `null`");
+        }
+
+        @Test
+        void withContextRejectsNullReturningBuilder() {
+            UniAssertSubscriber<Object> sub = Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> null)
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.assertFailedWith(NullPointerException.class, "The builder function returned null");
+        }
+
+        @Test
+        void withContextRejectsThrowingBuilder() {
+            UniAssertSubscriber<Object> sub = Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> {
+                        throw new RuntimeException("boom");
+                    })
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.assertFailedWith(RuntimeException.class, "boom");
+        }
+
+        @Test
+        void callbacksPropagateContext() {
+            Context context = Context.of("foo", "bar");
+            AtomicReference<String> result = new AtomicReference<>();
+
+            Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().with(context, result::set);
+
+            assertThat(result.get())
+                    .isNotNull()
+                    .isEqualTo("63::bar");
+        }
+
+        @Test
+        void asCompletableStagePropagateContext() {
+            Context context = Context.of("foo", "bar");
+
+            Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().asCompletionStage(context)
+                    .whenComplete((str, err) -> {
+                        assertThat(err).isNull();
+                        assertThat(str).isEqualTo("63::bar");
+                    });
+        }
+
+        @Test
+        void serializedSubscriberDoesPropagateContext() {
+            Context context = Context.of("foo", "bar");
+
+            UniAssertSubscriber<String> sub = Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().withSerializedSubscriber(UniAssertSubscriber.create(context));
+
+            sub.assertCompleted().assertItem("63::bar");
+        }
+
+        @Test
+        void callbacksWithoutContextPropagateEmptyContext() {
+            AtomicReference<String> result = new AtomicReference<>();
+
+            Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().with(result::set);
+
+            assertThat(result.get())
+                    .isNotNull()
+                    .isEqualTo("63::yolo");
+        }
+
+        @Test
+        void contextDoesPropagate() {
+            Context context = Context.of("foo", "bar");
+
+            UniAssertSubscriber<String> sub = Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(() -> ctx.put("counter", ctx.<Integer> get("counter") + 1)))
+                    .withContext((uni, ctx) -> uni
+                            .onItem().invoke(() -> ctx.put("counter", ctx.<Integer> get("counter") + 1)))
+                    .withContext((uni, ctx) -> uni
+                            .onItem().invoke(() -> ctx.put("counter", ctx.<Integer> get("counter") + 1)))
+                    .withContext((uni, ctx) -> uni
+                            .onItem().transform(Object::toString)
+                            .onItem().transform(s -> s + "::" + ctx.get("counter")))
+                    .withContext((uni, ctx) -> {
+                        ctx.put("counter", 0);
+                        return uni;
+                    })
+                    .subscribe().withSubscriber(UniAssertSubscriber.create(context));
+
+            sub.assertCompleted().assertItem("63::3");
+            assertThat(context.<Integer> get("counter")).isEqualTo(3);
+        }
+
+        @Test
+        void uniOperatorSubclassesPropagateContext() {
+            Context context = Context.of("foo", "bar");
+
+            UniAssertSubscriber<String> sub = Uni.createFrom().failure(new IOException("boom"))
+                    .withContext((uni, ctx) -> uni
+                            .onItem().transformToUni(obj -> Uni.createFrom().item("Yolo"))
+                            .onFailure().recoverWithItem(ctx.<String> get("foo")))
+                    .subscribe().withSubscriber(UniAssertSubscriber.create(context));
+
+            sub.assertCompleted().assertItem("bar");
+        }
+
+        @Test
+        void joinAllAndAttachContext() {
+            Context context = Context.of("foo", "bar", "baz", "baz");
+
+            Uni<Integer> a = Uni.createFrom().item(58)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(n -> ctx.put(n.toString(), n)));
+
+            Uni<Integer> b = Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(n -> ctx.put(n.toString(), n)));
+
+            Uni<Integer> c = Uni.createFrom().item(69)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(n -> ctx.put(n.toString(), n)));
+
+            UniAssertSubscriber<String> sub = Uni.join().all(a, b, c).andFailFast()
+                    .attachContext()
+                    .onItem().transform(itemsWithContext -> {
+                        Context ctx = itemsWithContext.context();
+                        return itemsWithContext.get().toString() + "::" + ctx.get("58") + "::" + ctx.get("63") + "::"
+                                + ctx.get("69");
+                    })
+                    .subscribe().withSubscriber(UniAssertSubscriber.create(context));
+
+            sub.assertCompleted().assertItem("[58, 63, 69]::58::63::69");
+        }
+
+        @Test
+        void joinFirstAndAttachContext() {
+            Context context = Context.of("foo", "bar", "baz", "baz");
+
+            Uni<Integer> a = Uni.createFrom().item(58)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(n -> ctx.put(n.toString(), n)));
+
+            Uni<Integer> b = Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(n -> ctx.put(n.toString(), n)));
+
+            Uni<Integer> c = Uni.createFrom().item(69)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(n -> ctx.put(n.toString(), n)));
+
+            UniAssertSubscriber<String> sub = Uni.join().first(a, b, c).withItem()
+                    .attachContext()
+                    .onItem().transform(item -> {
+                        Context ctx = item.context();
+                        return item.get().toString() + "::" + ctx.get("58");
+                    })
+                    .subscribe().withSubscriber(UniAssertSubscriber.create(context));
+
+            sub.assertCompleted().assertItem("58::58");
+        }
+
+        @Test
+        void combineAllAndAttachContext() {
+            Context context = Context.of("foo", "bar", "baz", "baz");
+
+            Uni<Integer> a = Uni.createFrom().item(58)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(n -> ctx.put(n.toString(), n)));
+
+            Uni<Integer> b = Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(n -> ctx.put(n.toString(), n)));
+
+            Uni<Integer> c = Uni.createFrom().item(69)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(n -> ctx.put(n.toString(), n)));
+
+            UniAssertSubscriber<String> sub = Uni.combine().all().unis(a, b, c).asTuple()
+                    .attachContext()
+                    .onItem().transform(itemsWithContext -> {
+                        Context ctx = itemsWithContext.context();
+                        return itemsWithContext.get().toString() + "::" + ctx.get("58") + "::" + ctx.get("63") + "::"
+                                + ctx.get("69");
+                    })
+                    .subscribe().withSubscriber(UniAssertSubscriber.create(context));
+
+            sub.assertCompleted().assertItem("Tuple{item1=58,item2=63,item3=69}::58::63::69");
+        }
+
+        @Test
+        void combineAnyAndAttachContext() {
+            Context context = Context.of("foo", "bar", "baz", "baz");
+
+            Uni<Integer> a = Uni.createFrom().item(58)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(n -> ctx.put(n.toString(), n)));
+
+            Uni<Integer> b = Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(n -> ctx.put(n.toString(), n)));
+
+            Uni<Integer> c = Uni.createFrom().item(69)
+                    .withContext((uni, ctx) -> uni.onItem().invoke(n -> ctx.put(n.toString(), n)));
+
+            UniAssertSubscriber<String> sub = Uni.combine().any().of(a, b, c)
+                    .attachContext()
+                    .onItem().transform(item -> {
+                        Context ctx = item.context();
+                        return item.get().toString() + "::" + ctx.get("58");
+                    })
+                    .subscribe().withSubscriber(UniAssertSubscriber.create(context));
+
+            sub.assertCompleted().assertItem("58::58");
+        }
+
+        @Test
+        void memoization() {
+            AtomicBoolean invalidator = new AtomicBoolean(false);
+
+            Context firstContext = Context.of("foo", "bar", "baz", "baz");
+
+            Uni<String> pipeline = Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> {
+                        ctx.put("abc", 123);
+                        return uni;
+                    })
+                    .onItem().transform(Object::toString)
+                    .memoize().until(invalidator::get);
+
+            UniAssertSubscriber<String> sub = pipeline.subscribe().withSubscriber(UniAssertSubscriber.create(firstContext));
+
+            assertThat(firstContext.contains("abc")).isTrue();
+            assertThat(firstContext.contains("foo")).isTrue();
+            assertThat(firstContext.<Integer> get("abc")).isEqualTo(123);
+            assertThat(firstContext.<String> get("foo")).isEqualTo("bar");
+            sub.assertCompleted().assertItem("63");
+
+            Context secondContext = Context.empty();
+            sub = pipeline.subscribe().withSubscriber(UniAssertSubscriber.create(secondContext));
+
+            sub.assertCompleted().assertItem("63");
+            assertThat(secondContext.isEmpty()).isTrue();
+
+            invalidator.set(true);
+
+            Context thirdContext = Context.empty();
+            sub = pipeline.subscribe().withSubscriber(UniAssertSubscriber.create(thirdContext));
+
+            sub.assertCompleted().assertItem("63");
+            assertThat(thirdContext.<Integer> get("abc")).isEqualTo(123);
+            assertThat(thirdContext.contains("foo")).isFalse();
+        }
+
+        @Test
+        void numberOfCallsToContextMethod() {
+            Context context = Context.of("foo", "bar", "baz", "baz");
+            AtomicInteger counter = new AtomicInteger();
+
+            UniAssertSubscriber<Integer> sub = Uni.createFrom().item(1)
+                    .withContext((uni, ctx) -> uni
+                            .onItem().transform(n -> n + "!")
+                            .onItem().transform(s -> "[" + s + "]"))
+                    .onItem().transform(String::toUpperCase)
+                    .onItem().transform(String::length)
+                    .withContext((uni, ctx) -> uni)
+                    .subscribe().withSubscriber(new UniAssertSubscriber<Integer>() {
+                        @Override
+                        public Context context() {
+                            counter.incrementAndGet();
+                            return context;
+                        }
+                    });
+
+            sub.assertCompleted().assertItem(4);
+            assertThat(counter.get()).isEqualTo(2);
+        }
+
+        @Test
+        void blockingAwait() {
+            Context context = Context.of("foo", "bar", "baz", "baz");
+
+            String res = Uni.createFrom().item(63)
+                    .attachContext()
+                    .onItem().transform(item -> item.get() + "::" + item.context().get("foo"))
+                    .awaitUsing(context).indefinitely();
+
+            assertThat(res).isEqualTo("63::bar");
+        }
+
+        @Test
+        void blockingAwaitOptional() {
+            Context context = Context.of("foo", "bar", "baz", "baz");
+
+            Optional<String> res = Uni.createFrom().item(63)
+                    .attachContext()
+                    .onItem().transform(item -> item.get() + "::" + item.context().get("foo"))
+                    .awaitUsing(context).asOptional().indefinitely();
+
+            assertThat(res)
+                    .isPresent()
+                    .hasValue("63::bar");
+        }
+
+        @Test
+        void uniDelegatingSubscriber() {
+            Context context = Context.of("foo", "bar");
+            AtomicReference<String> box = new AtomicReference<>();
+
+            Uni.createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .onItem().invoke(box::set)
+                    .subscribe().withSubscriber(new UniDelegatingSubscriber<>(UniAssertSubscriber.create(context)));
+
+            assertThat(box.get())
+                    .isNotNull()
+                    .isEqualTo("63::bar");
+        }
+
+        @Test
+        void plugAndFlatMap() {
+            UniAssertSubscriber<ItemWithContext<String>> sub = Uni.createFrom().item("63")
+                    .withContext((uni, ctx) -> {
+                        ctx.put("foo", "bar");
+                        return uni;
+                    })
+                    .plug(uni -> uni.flatMap(s -> Uni.createFrom().item("yolo")))
+                    .attachContext()
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.assertCompleted();
+            ItemWithContext<String> item = sub.getItem();
+            assertThat(item.get()).isEqualTo("yolo");
+            assertThat(item.context().keys()).hasSize(1).contains("foo");
+            assertThat(item.context().<String> get("foo")).isEqualTo("bar");
+        }
+    }
+
+    @Nested
+    @DisplayName("{Uni,Multi} <-> {Multi,Uni} bridges")
+    class UniMultiBridges {
+
+        @Test
+        void uniToUni() {
+            Context context = Context.of("foo", "bar");
+
+            UniAssertSubscriber<String> sub = Uni.createFrom().item("abc")
+                    .withContext((uni, ctx) -> uni
+                            .onItem().transformToUni(s -> Uni.createFrom().item(s + "::" + ctx.get("foo"))))
+                    .onFailure().recoverWithItem(() -> "woops")
+                    .subscribe().withSubscriber(UniAssertSubscriber.create(context));
+
+            sub.assertCompleted().assertItem("abc::bar");
+        }
+
+        @Test
+        void multiToMulti() {
+            Context context = Context.of("foo", "bar");
+
+            AssertSubscriber<String> sub = Multi.createFrom().items(1, 2, 3)
+                    .withContext((multi, ctx) -> multi
+                            .onItem().transformToMultiAndMerge(n -> Multi.createFrom().item(n + "@" + ctx.get("foo"))))
+                    .onFailure().recoverWithItem(() -> "woops")
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, 10));
+
+            List<String> items = sub.assertCompleted().getItems();
+            assertThat(items).hasSize(3)
+                    .contains("1@bar", "2@bar", "3@bar");
+        }
+
+        @Test
+        void uniToMulti() {
+            Context context = Context.of("foo", "bar");
+
+            AssertSubscriber<String> sub = Uni.createFrom().item("abc")
+                    .withContext((uni, ctx) -> uni.onItem().transform(s -> s + "@" + ctx.get("foo")))
+                    .onItem().transformToMulti(s -> Multi.createFrom().item(s))
+                    .withContext((multi, ctx) -> multi
+                            .onItem().transformToMultiAndConcatenate(s -> Multi.createFrom().items(s, ctx.get("foo"))))
+                    .onFailure().recoverWithItem(() -> "woops")
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, 10));
+
+            List<String> items = sub.assertCompleted().getItems();
+            assertThat(items)
+                    .hasSize(2)
+                    .contains("abc@bar", "bar");
+        }
+
+        @Test
+        void multiToUni() {
+            Context context = Context.of("foo", "bar");
+
+            UniAssertSubscriber<Object> sub = Multi.createFrom().items(1, 2, 3)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "@" + ctx.get("foo")))
+                    .toUni()
+                    .withContext((uni, ctx) -> uni
+                            .onItem().transformToUni(s -> Uni.createFrom().item(s + "::" + ctx.get("foo"))))
+                    .onFailure().recoverWithItem(() -> "woops")
+                    .subscribe().withSubscriber(UniAssertSubscriber.create(context));
+
+            sub.assertCompleted().assertItem("1@bar::bar");
+        }
+    }
+
+    @Nested
+    @DisplayName("Uni with context")
+    class MultiAndContext {
+
+        @Test
+        void noContextShallBeEmpty() {
+            AssertSubscriber<String> sub = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().withSubscriber(AssertSubscriber.create(10L));
+
+            sub.assertCompleted();
+            assertThat(sub.getItems())
+                    .hasSize(3)
+                    .containsExactly("58::yolo", "63::yolo", "69::yolo");
+        }
+
+        @Test
+        void transformWithContext() {
+            Context context = Context.of("foo", "bar");
+
+            AssertSubscriber<String> sub = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, 10L));
+
+            sub.assertCompleted();
+            assertThat(sub.getItems())
+                    .hasSize(3)
+                    .containsExactly("58::bar", "63::bar", "69::bar");
+        }
+
+        @Test
+        void withContextRejectsNullBuilder() {
+            assertThatThrownBy(() -> Multi.createFrom().item(1).withContext(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("`builder` must not be `null`");
+        }
+
+        @Test
+        void withContextRejectsNullReturningBuilder() {
+            AssertSubscriber<Object> sub = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> null)
+                    .subscribe().withSubscriber(AssertSubscriber.create(10L));
+
+            sub.assertFailedWith(NullPointerException.class, "The builder function returned null");
+        }
+
+        @Test
+        void withContextRejectsThrowingBuilder() {
+            AssertSubscriber<Object> sub = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> {
+                        throw new RuntimeException("boom");
+                    })
+                    .subscribe().withSubscriber(AssertSubscriber.create(10L));
+
+            sub.assertFailedWith(RuntimeException.class, "boom");
+        }
+
+        @Test
+        void callbacksPropagateContext() {
+            Context context = Context.of("foo", "bar");
+            ArrayList<String> list = new ArrayList<>();
+
+            Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().with(context, list::add);
+
+            assertThat(list)
+                    .hasSize(3)
+                    .containsExactly("58::bar", "63::bar", "69::bar");
+        }
+
+        @Test
+        void callbacksWithoutContextPropagateEmptyContext() {
+            ArrayList<String> list = new ArrayList<>();
+
+            Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().with(list::add);
+
+            assertThat(list)
+                    .hasSize(3)
+                    .containsExactly("58::yolo", "63::yolo", "69::yolo");
+        }
+
+        @Test
+        void asIterableWithoutContext() {
+            BlockingIterable<String> iter = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().asIterable();
+
+            assertThat(iter).containsExactly("58::yolo", "63::yolo", "69::yolo");
+        }
+
+        @Test
+        void asIterableWithContext() {
+            BlockingIterable<String> iter = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().asIterable(() -> Context.of("foo", "bar"));
+
+            assertThat(iter).containsExactly("58::bar", "63::bar", "69::bar");
+        }
+
+        @Test
+        void asStreamWithoutContext() {
+            Stream<String> stream = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().asStream();
+
+            assertThat(stream).containsExactly("58::yolo", "63::yolo", "69::yolo");
+        }
+
+        @Test
+        void asStreamWithContext() {
+            Stream<String> stream = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().asStream(() -> Context.of("foo", "bar"));
+
+            assertThat(stream).containsExactly("58::bar", "63::bar", "69::bar");
+        }
+
+        @Test
+        void mergeStreamsAndManipulateContext() {
+            Context context = Context.of("foo", "bar", "counter", 0);
+
+            Multi<String> s1 = Multi.createFrom().range(0, 5)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")));
+
+            Multi<String> s2 = Multi.createFrom().range(0, 5)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")));
+
+            AssertSubscriber<String> sub = Multi.createBy().combining().streams(s1, s2).asTuple()
+                    .withContext((multi, ctx) -> multi.onItem().transform(t -> t.getItem1() + "|" + t.getItem2()))
+                    .withContext(
+                            (multi, ctx) -> multi.onItem().invoke(() -> ctx.put("counter", ctx.<Integer> get("counter") + 1)))
+                    .withContext((multi, ctx) -> multi.onItem().transformToUniAndConcatenate(s -> Uni
+                            .createFrom().item(s + "@" + ctx.get("counter"))
+                            .withContext((uni, nestedCtx) -> uni.onItem()
+                                    .transform(str -> "[" + ctx.get("counter") + " -> " + str + "]"))))
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, Long.MAX_VALUE));
+
+            sub.assertCompleted();
+            assertThat(sub.getItems())
+                    .hasSize(5)
+                    .startsWith("[1 -> 0::bar|0::bar@1]")
+                    .endsWith("[5 -> 4::bar|4::bar@5]");
+        }
+
+        @Test
+        void multiByRepeating() {
+            Context context = Context.of("foo", "bar", "counter", 0);
+
+            AssertSubscriber<String> sub = Multi.createBy().repeating().uni(() -> Uni
+                    .createFrom().item(63)
+                    .withContext((uni, ctx) -> uni.onItem().transform(n -> {
+                        ctx.put("counter", ctx.<Integer> get("counter") + 1);
+                        return n + "::" + ctx.get("foo") + "@" + ctx.get("counter");
+                    })))
+                    .atMost(5)
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, Long.MAX_VALUE));
+
+            sub.assertCompleted();
+            assertThat(sub.getItems())
+                    .hasSize(5)
+                    .containsExactly("63::bar@1", "63::bar@2", "63::bar@3", "63::bar@4", "63::bar@5");
+        }
+
+        @Test
+        void multiRetry() {
+            Context context = Context.of("foo", "bar", "counter", 0);
+
+            AssertSubscriber<String> sub = Multi.createFrom().item("foo=")
+                    .withContext((multi, ctx) -> multi.onItem().transform(s -> {
+                        ctx.put("counter", ctx.<Integer> get("counter") + 1);
+                        return s + ctx.get("foo") + "@" + ctx.get("counter");
+                    }))
+                    .onItem().failWith(s -> new IOException(s))
+                    .onFailure().retry().atMost(5)
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, Long.MAX_VALUE));
+
+            sub.assertFailedWith(IOException.class, "foo=bar@6");
+        }
+
+        @Test
+        void safeSubscriber() {
+            Context context = Context.of("foo", "bar");
+
+            Multi<String> someMulti = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")));
+
+            AssertSubscriber<String> sub = Multi.createFrom().publisher(Multi.createFrom().publisher(someMulti))
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, Long.MAX_VALUE));
+
+            sub.assertCompleted();
+            assertThat(sub.getItems())
+                    .hasSize(3)
+                    .containsExactly("58::bar", "63::bar", "69::bar");
+        }
+
+        @Test
+        void broadcast() {
+            Multi<String> someMulti = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .broadcast().toAllSubscribers();
+
+            AssertSubscriber<String> sub1 = someMulti.subscribe()
+                    .withSubscriber(AssertSubscriber.create(Context.of("foo", "bar")));
+            AssertSubscriber<String> sub2 = someMulti.subscribe().withSubscriber(AssertSubscriber.create());
+
+            sub1.request(1L);
+            sub2.request(1L);
+            sub2.request(1L);
+            sub2.request(1L);
+            sub1.request(1L);
+            sub1.request(1L);
+            sub2.request(1L);
+
+            sub1.assertCompleted();
+            sub2.assertCompleted();
+
+            assertThat(sub1.getItems())
+                    .hasSize(3)
+                    .containsExactly("58::bar", "63::bar", "69::bar");
+
+            assertThat(sub2.getItems())
+                    .hasSize(3)
+                    .containsExactly("58::bar", "63::bar", "69::bar");
+        }
+
+        @Test
+        void cache() {
+            Multi<String> someMulti = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .cache();
+
+            AssertSubscriber<String> sub1 = someMulti.subscribe()
+                    .withSubscriber(AssertSubscriber.create(Context.of("foo", "bar"), Long.MAX_VALUE));
+            sub1.assertCompleted();
+            assertThat(sub1.getItems())
+                    .hasSize(3)
+                    .containsExactly("58::bar", "63::bar", "69::bar");
+
+            AssertSubscriber<String> sub2 = someMulti.subscribe()
+                    .withSubscriber(AssertSubscriber.create(Context.of("foo", "baz"), Long.MAX_VALUE));
+            sub2.assertCompleted();
+            assertThat(sub2.getItems())
+                    .hasSize(3)
+                    .containsExactly("58::bar", "63::bar", "69::bar");
+        }
+
+        @Test
+        void attachContext() {
+            Context context = Context.of("foo", "bar");
+
+            AssertSubscriber<String> sub = Multi.createFrom().items(58, 63, 69)
+                    .attachContext()
+                    .onItem().transform(n -> n.get() + "::" + n.context().getOrElse("foo", () -> "yolo"))
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, Long.MAX_VALUE));
+
+            sub.assertCompleted();
+            assertThat(sub.getItems())
+                    .hasSize(3)
+                    .containsExactly("58::bar", "63::bar", "69::bar");
+        }
+
+        @Test
+        void emitAndSubscribeOn() {
+            Context context = Context.empty();
+            ExecutorService pool = Executors.newFixedThreadPool(4);
+
+            AssertSubscriber<String> sub = Multi.createFrom().range(1, 100)
+                    .withContext((multi, ctx) -> {
+                        ctx.put("foo", "bar");
+                        return multi.onItem().transform(n -> {
+                            String key = n.toString();
+                            context.put(key, n + "::" + ctx.get("foo"));
+                            return key;
+                        });
+                    })
+                    .emitOn(pool)
+                    .runSubscriptionOn(pool)
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, Long.MAX_VALUE));
+
+            sub.awaitCompletion(Duration.ofSeconds(5));
+
+            assertThat(sub.getItems())
+                    .hasSize(99)
+                    .contains("63", "99", "58", "69");
+
+            assertThat(context.keys()).contains("63", "99", "58", "69");
+            assertThat(context.<String> get("63")).isEqualTo("63::bar");
+
+            pool.shutdown();
+        }
+
+        @Test
+        void collectToList() {
+            Context context = Context.of("foo", "bar");
+
+            AssertSubscriber<List<String>> sub = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .select().where(s -> !s.startsWith("69"))
+                    .collect().asList()
+                    .toMulti()
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, Long.MAX_VALUE));
+
+            assertThat(sub.getItems().get(0))
+                    .hasSize(2)
+                    .contains("63::bar", "58::bar");
+        }
+
+        @Test
+        void groupBy() {
+            Context context = Context.of("foo", "bar");
+
+            AssertSubscriber<GroupedMulti<String, String>> sub = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .group().by(str -> str.substring(0, 2))
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, Long.MAX_VALUE));
+
+            sub.assertCompleted();
+            assertThat(sub.getItems().get(0).key()).isEqualTo("58");
+            assertThat(sub.getItems().get(0).collect().asList().await().indefinitely())
+                    .hasSize(1)
+                    .contains("58::bar");
+        }
+
+        @Test
+        void plugAndFlatMap() {
+            AssertSubscriber<ItemWithContext<String>> sub = Multi.createFrom().items(58, 63, 69)
+                    .withContext((multi, ctx) -> multi.onItem().invoke(() -> ctx.put("foo", "bar")))
+                    .plug(multi -> multi.flatMap(n -> Multi.createFrom().items(n.toString())))
+                    .attachContext()
+                    .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+
+            sub.assertCompleted();
+            List<ItemWithContext<String>> items = sub.getItems();
+            assertThat(items)
+                    .hasSize(3)
+                    .anyMatch(item -> item.get().equals("63"))
+                    .allMatch(item -> item.context().get("foo").equals("bar"));
+        }
+
+        @Test
+        void alienSubscriber() {
+            AtomicBoolean completed = new AtomicBoolean(false);
+            AtomicReference<Throwable> error = new AtomicReference<>();
+            ArrayList<String> items = new ArrayList<>();
+
+            Multi.createFrom().items(58, 63, 69)
+                    .attachContext()
+                    .onItem().transform(n -> n.get() + "::" + n.context().getOrElse("foo", () -> "yolo"))
+                    .subscribe().withSubscriber(new AlienSubscriber<>(items, error, completed));
+
+            assertThat(completed).isTrue();
+            assertThat(error).hasValue(null);
+            assertThat(items)
+                    .hasSize(3)
+                    .containsExactly("58::yolo", "63::yolo", "69::yolo");
+        }
+
+        @Test
+        void timeGrouping() {
+            Context context = Context.of("foo", "bar");
+
+            AssertSubscriber<List<String>> sub = Multi.createFrom().items(58, 63, 69)
+                    .attachContext()
+                    .onItem().transform(n -> n.get() + "::" + n.context().getOrElse("foo", () -> "yolo"))
+                    .group().intoLists().every(Duration.ofSeconds(5L))
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, Long.MAX_VALUE));
+
+            sub.awaitCompletion();
+            assertThat(sub.getItems()).hasSize(1);
+            assertThat(sub.getItems().get(0))
+                    .hasSize(3)
+                    .containsExactly("58::bar", "63::bar", "69::bar");
+        }
+    }
+
+    @Nested
+    @DisplayName("Uni and Multi context-aware builders")
+    class Builders {
+
+        @Test
+        void uniEmitter() {
+            Context context = Context.of("foo", "bar");
+
+            UniAssertSubscriber<Object> sub = Uni.createFrom().emitter(em -> {
+                em.complete(em.context().getOrElse("foo", () -> "yolo"));
+            })
+                    .subscribe().withSubscriber(UniAssertSubscriber.create(context));
+
+            sub.assertCompleted().assertItem("bar");
+        }
+
+        @Test
+        void multiEmitter() {
+            Context context = Context.of("foo", "bar");
+
+            AssertSubscriber<Object> sub = Multi.createFrom().emitter(em -> {
+                em.emit(em.context().getOrElse("foo", () -> "yolo"));
+                em.complete();
+            })
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, 10L));
+
+            sub.assertCompleted().assertItems("bar");
+        }
+
+        @Test
+        void multiCreateWithContext() {
+            Context context = Context.of("foo", "bar");
+
+            AssertSubscriber<String> sub = Multi
+                    .createFrom().context(ctx -> Multi.createFrom().item(ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, 10L));
+
+            sub.assertCompleted().assertItems("bar");
+        }
+
+        @Test
+        void multiCreateWithContextAndAlienSubscriber() {
+            ArrayList<String> items = new ArrayList<>();
+            AtomicReference<Throwable> error = new AtomicReference<>(null);
+            AtomicBoolean completed = new AtomicBoolean(false);
+
+            Multi.createFrom().context(ctx -> Multi.createFrom().item(ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().withSubscriber(new AlienSubscriber<>(items, error, completed));
+
+            assertThat(completed).isTrue();
+            assertThat(error.get()).isNull();
+            assertThat(items)
+                    .hasSize(1)
+                    .contains("yolo");
+        }
+
+        @Test
+        void multiCreateWithContextMapperIsNull() {
+            assertThatThrownBy(() -> Multi.createFrom().context(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("`mapper` must not be `null`");
+        }
+
+        @Test
+        void multiCreateWithContextMapperReturnsNull() {
+            AssertSubscriber<Object> sub = Multi.createFrom().context(ctx -> null)
+                    .subscribe().withSubscriber(AssertSubscriber.create(10L));
+
+            sub.assertFailedWith(NullPointerException.class, "The mapper returned `null`");
+        }
+
+        @Test
+        void multiCreateWithContextMapperThrows() {
+            AssertSubscriber<Object> sub = Multi.createFrom().context(ctx -> {
+                throw new RuntimeException("Yolo!");
+            })
+                    .subscribe().withSubscriber(AssertSubscriber.create(10L));
+
+            sub.assertFailedWith(RuntimeException.class, "Yolo!");
+        }
+
+        @Test
+        void uniCreateWithContext() {
+            Context context = Context.of("foo", "bar");
+
+            UniAssertSubscriber<String> sub = Uni.createFrom()
+                    .context(ctx -> Uni.createFrom().item(ctx.getOrElse("foo", () -> "yolo")))
+                    .subscribe().withSubscriber(UniAssertSubscriber.create(context));
+
+            sub.assertCompleted().assertItem("bar");
+        }
+
+        @Test
+        void uniCreateWithContextMapperIsNull() {
+            assertThatThrownBy(() -> Uni.createFrom().context(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("`mapper` must not be `null`");
+        }
+
+        @Test
+        void uniCreateWithContextMapperReturnsNull() {
+            UniAssertSubscriber<Object> sub = Uni.createFrom().context(ctx -> null)
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.assertFailedWith(NullPointerException.class, "The mapper returned `null`");
+        }
+
+        @Test
+        void uniCreateWithContextMapperThrows() {
+            UniAssertSubscriber<Object> sub = Uni.createFrom().context(ctx -> {
+                throw new RuntimeException("Yolo!");
+            })
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.assertFailedWith(RuntimeException.class, "Yolo!");
+        }
+
+        @Test
+        void multiRepeat() {
+            Context context = Context.of("foo", "bar");
+
+            AssertSubscriber<String> sub = Multi.createFrom().context(ctx -> Multi.createBy()
+                    .repeating().uni(
+                            AtomicInteger::new,
+                            counter -> Uni.createFrom()
+                                    .item(counter.incrementAndGet() + "::" + ctx.getOrElse("foo", () -> "yolo")))
+                    .atMost(5))
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, Long.MAX_VALUE));
+
+            sub.assertCompleted();
+            assertThat(sub.getItems())
+                    .hasSize(5)
+                    .contains("1::bar", "5::bar");
+        }
+
+        @Test
+        void multiCombine() {
+            Context context = Context.of("foo", "bar");
+
+            Multi<String> a = Multi.createFrom()
+                    .context(ctx -> Multi.createFrom().items("a", ctx.getOrElse("foo", () -> "yolo")));
+            Multi<String> b = Multi.createFrom()
+                    .context(ctx -> Multi.createFrom().items("b", ctx.getOrElse("foo", () -> "yolo")));
+            Multi<String> c = Multi.createFrom()
+                    .context(ctx -> Multi.createFrom().items("c", ctx.getOrElse("foo", () -> "yolo")));
+
+            AssertSubscriber<String> sub = Multi.createBy().merging().streams(a, b, c)
+                    .subscribe().withSubscriber(AssertSubscriber.create(context, Long.MAX_VALUE));
+
+            sub.assertCompleted();
+            assertThat(sub.getItems())
+                    .hasSize(6)
+                    .containsExactly("a", "bar", "b", "bar", "c", "bar");
+        }
+    }
+}
+
+class AlienSubscriber<T> implements Subscriber<T> {
+    private final ArrayList<T> items;
+    private final AtomicReference<Throwable> error;
+    private final AtomicBoolean completed;
+
+    public AlienSubscriber(ArrayList<T> items, AtomicReference<Throwable> error, AtomicBoolean completed) {
+        this.items = items;
+        this.error = error;
+        this.completed = completed;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        s.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(T item) {
+        items.add(item);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        error.set(t);
+    }
+
+    @Override
+    public void onComplete() {
+        completed.set(true);
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/ItemWithContextTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/ItemWithContextTest.java
@@ -1,0 +1,27 @@
+package io.smallrye.mutiny;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ItemWithContextTest {
+
+    @Test
+    void sanityCheck() {
+        ItemWithContext<Integer> itemWithContext = new ItemWithContext<>(Context.of("foo", "bar"), 123);
+
+        assertThat(itemWithContext.context().<String> get("foo")).isEqualTo("bar");
+        assertThat(itemWithContext.get()).isEqualTo(123);
+
+        ItemWithContext<Integer> copy = new ItemWithContext<>(Context.of("foo", "bar"), 123);
+        ItemWithContext<Integer> diff1 = new ItemWithContext<>(Context.of("foo", "baz"), 123);
+        ItemWithContext<Integer> diff2 = new ItemWithContext<>(Context.of("foo", "bar"), 456);
+
+        assertThat(copy).isEqualTo(itemWithContext);
+        assertThat(diff1).isNotEqualTo(itemWithContext);
+        assertThat(diff2).isNotEqualTo(itemWithContext);
+
+        assertThat(copy.toString()).isEqualTo("ItemWithContext{context=Context{entries={foo=bar}}, item=123}");
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/UniMemoizeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/UniMemoizeTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.reactivex.processors.UnicastProcessor;
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
@@ -365,6 +366,11 @@ class UniMemoizeTest {
             @Override
             public void onFailure(Throwable ignored) {
 
+            }
+
+            @Override
+            public Context context() {
+                return Context.empty();
             }
         };
         uni.subscribe().withSubscriber(subscriber);

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/MultiSubscribers.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/MultiSubscribers.java
@@ -3,6 +3,8 @@ package io.smallrye.mutiny.helpers;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.subscription.ContextSupport;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 
 public class MultiSubscribers {
@@ -15,12 +17,21 @@ public class MultiSubscribers {
         return new MultiSubscriberWrapper<>(subscriber);
     }
 
-    private static class MultiSubscriberWrapper<T> implements MultiSubscriber<T> {
+    private static class MultiSubscriberWrapper<T> implements MultiSubscriber<T>, ContextSupport {
 
         private final Subscriber<T> delegate;
 
         private MultiSubscriberWrapper(Subscriber<T> delegate) {
             this.delegate = delegate;
+        }
+
+        @Override
+        public Context context() {
+            if (delegate instanceof ContextSupport) {
+                return ((ContextSupport) delegate).context();
+            } else {
+                return Context.empty();
+            }
         }
 
         @Override

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/UniInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/UniInterceptorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.AbstractUni;
 import io.smallrye.mutiny.subscription.UniDelegatingSubscriber;
@@ -113,6 +114,11 @@ public class UniInterceptorTest {
             public <T> UniSubscriber<? super T> onSubscription(Uni<T> instance,
                     UniSubscriber<? super T> subscriber) {
                 return new UniSubscriber<T>() {
+                    @Override
+                    public Context context() {
+                        return Context.empty();
+                    }
+
                     @Override
                     public void onSubscribe(UniSubscription subscription) {
                         subscriber.onSubscribe(subscription);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromEmitterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromEmitterTest.java
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.smallrye.mutiny.operators.uni.builders.DefaultUniEmitter;
@@ -166,6 +167,11 @@ public class UniCreateFromEmitterTest {
                 .subscribe().withSubscriber(new UniSubscriber<Integer>() {
 
                     @Override
+                    public Context context() {
+                        return Context.empty();
+                    }
+
+                    @Override
                     public void onSubscribe(UniSubscription subscription) {
 
                     }
@@ -198,6 +204,10 @@ public class UniCreateFromEmitterTest {
             }
         })
                 .subscribe().withSubscriber(new UniSubscriber<Integer>() {
+                    @Override
+                    public Context context() {
+                        return Context.empty();
+                    }
 
                     @Override
                     public void onSubscribe(UniSubscription subscription) {

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniSerializedSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniSerializedSubscriberTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.smallrye.mutiny.CompositeException;
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
@@ -459,6 +460,12 @@ public class UniSerializedSubscriberTest {
                 reference::set);
 
         UniSerializedSubscriber.subscribe(uni, new UniSubscriber<Integer>() {
+
+            @Override
+            public Context context() {
+                return Context.empty();
+            }
+
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 // Do nothing
@@ -496,6 +503,11 @@ public class UniSerializedSubscriberTest {
                 reference::set);
 
         UniSerializedSubscriber.subscribe(uni, new UniSubscriber<Integer>() {
+            @Override
+            public Context context() {
+                return Context.empty();
+            }
+
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 // Do nothing
@@ -539,6 +551,11 @@ public class UniSerializedSubscriberTest {
 
         UniSerializedSubscriber.subscribe(uni, new UniSubscriber<Integer>() {
             @Override
+            public Context context() {
+                return Context.empty();
+            }
+
+            @Override
             public void onSubscribe(UniSubscription subscription) {
                 // Do nothing
             }
@@ -581,6 +598,11 @@ public class UniSerializedSubscriberTest {
 
         UniSerializedSubscriber.subscribe(uni, new UniSubscriber<Integer>() {
             @Override
+            public Context context() {
+                return Context.empty();
+            }
+
+            @Override
             public void onSubscribe(UniSubscription subscription) {
                 // Do nothing
             }
@@ -619,6 +641,11 @@ public class UniSerializedSubscriberTest {
         };
 
         UniSerializedSubscriber.subscribe(uni, new UniSubscriber<Integer>() {
+            @Override
+            public Context context() {
+                return Context.empty();
+            }
+
             @Override
             public void onSubscribe(UniSubscription subscription) {
                 subscription.cancel();

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/CallbackBasedSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/CallbackBasedSubscriberTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.CompositeException;
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import junit5.support.InfrastructureResource;
@@ -125,7 +126,7 @@ public class CallbackBasedSubscriberTest {
         Infrastructure.setDroppedExceptionHandler(captured::set);
         Multi.createFrom().failure(new IOException("I/O"))
                 .onCancellation().invoke(() -> cancelled.set(true))
-                .subscribe().withSubscriber(new Subscribers.CallbackBasedSubscriber<>(i -> {
+                .subscribe().withSubscriber(new Subscribers.CallbackBasedSubscriber<>(Context.empty(), i -> {
                 },
                         null, null, s -> {
                         }));

--- a/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/CallbackBasedSubscriberTckTest.java
+++ b/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/CallbackBasedSubscriberTckTest.java
@@ -2,12 +2,15 @@ package io.smallrye.mutiny.tcktests;
 
 import org.reactivestreams.Subscriber;
 
+import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.subscription.Subscribers;
 
 public class CallbackBasedSubscriberTckTest extends AbstractWhiteBoxSubscriberTck {
+
     @Override
     public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
         return new Subscribers.CallbackBasedSubscriber<>(
+                Context.empty(),
                 probe::registerOnNext,
                 probe::registerOnError,
                 probe::registerOnComplete,


### PR DESCRIPTION
This brings subscriber-provided contexts to `Uni` and `Multi`.

Context can be materialized using the `withContext` and `attachContext` operators.

See #757

This is a squashed commit based on explorations in https://github.com/jponge/smallrye-mutiny/tree/feature/context
