### PR TITLE
Update Coroutines to 1.6.0, Kotlin API to 1.5 and refactored tests

### DIFF
--- a/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/Multi.kt
+++ b/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/Multi.kt
@@ -3,18 +3,17 @@ package io.smallrye.mutiny.coroutines
 import io.smallrye.mutiny.Multi
 import io.smallrye.mutiny.subscription.MultiEmitter
 import io.smallrye.mutiny.subscription.MultiSubscriber
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import org.reactivestreams.Subscription
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.coroutines.coroutineContext
 
 /**
  * Subscribe to this [Multi] and provide the items as [Flow].

--- a/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/Uni.kt
+++ b/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/Uni.kt
@@ -2,11 +2,11 @@ package io.smallrye.mutiny.coroutines
 
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.subscription.UniEmitter
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 /**
  * Awaits the result of this [Uni] while suspending the surrounding coroutine.

--- a/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/TestUtil.kt
+++ b/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/TestUtil.kt
@@ -1,0 +1,19 @@
+package io.smallrye.mutiny.coroutines
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Utility method for typing gentle coroutine testing.
+ *
+ * Wrap the given [block] in coroutines [runBlocking] using the [Dispatchers.Default] as default [context].
+ */
+fun <T> testBlocking(context: CoroutineContext = Dispatchers.Default, block: suspend CoroutineScope.() -> T): T =
+    runBlocking(context, block)
+
+/**
+ * Produces a new embedded [CoroutineScope] to be used for isolating coroutines inside a coroutine test
+ */
+fun embeddedScope() = CoroutineScope(Dispatchers.Default)

--- a/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/UniAwaitSuspendingTest.kt
+++ b/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/UniAwaitSuspendingTest.kt
@@ -1,14 +1,6 @@
 package io.smallrye.mutiny.coroutines
 
 import io.smallrye.mutiny.Uni
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
-import org.assertj.core.api.Assertions.assertThat
 import java.time.Duration
 import java.time.Instant
 import java.util.UUID
@@ -19,12 +11,19 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import org.assertj.core.api.Assertions.assertThat
 
 class UniAwaitSuspendingTest {
 
     @Test
     fun `test immediate onItem event`() {
-        runBlocking {
+        testBlocking {
             // Given
             val item = UUID.randomUUID()
             val uni = Uni.createFrom().item(item)
@@ -39,7 +38,7 @@ class UniAwaitSuspendingTest {
 
     @Test
     fun `test delayed onItem event`() {
-        runBlocking {
+        testBlocking {
             // Given
             val item = UUID.randomUUID()
             val delayed = Duration.ofMillis(250)
@@ -58,7 +57,7 @@ class UniAwaitSuspendingTest {
 
     @Test
     fun `test null item`() {
-        runBlocking {
+        testBlocking {
             // Given
             val uni = Uni.createFrom().nullItem<Any>()
 
@@ -76,7 +75,7 @@ class UniAwaitSuspendingTest {
         val uni = Uni.createFrom().failure<Any>(RuntimeException("boom"))
 
         // When & Then
-        assertFailsWith<RuntimeException>("boom") { runBlocking { uni.awaitSuspending() } }
+        assertFailsWith<RuntimeException>("boom") { testBlocking { uni.awaitSuspending() } }
     }
 
     @Test
@@ -85,7 +84,7 @@ class UniAwaitSuspendingTest {
         val uni = Uni.createFrom().failure<Any>(Exception("kaboom"))
 
         // When & Then
-        assertFailsWith<Exception>("kaboom") { runBlocking { uni.awaitSuspending() } }
+        assertFailsWith<Exception>("kaboom") { testBlocking { uni.awaitSuspending() } }
     }
 
     @Test
@@ -95,7 +94,7 @@ class UniAwaitSuspendingTest {
 
         // When
         var retrieveError: Throwable? = null
-        runBlocking {
+        testBlocking {
             val job = launch {
                 try {
                     uni.awaitSuspending()
@@ -120,7 +119,7 @@ class UniAwaitSuspendingTest {
 
         // When & Then
         assertFailsWith<TimeoutCancellationException> {
-            runBlocking {
+            testBlocking {
                 withTimeout(50) {
                     uni.awaitSuspending()
                     fail()
@@ -135,7 +134,7 @@ class UniAwaitSuspendingTest {
         val uni = Uni.createFrom().item(23)
 
         // When
-        val item = runBlocking(Executors.newSingleThreadExecutor().asCoroutineDispatcher()) {
+        val item = testBlocking(Executors.newSingleThreadExecutor().asCoroutineDispatcher()) {
             uni.awaitSuspending()
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,9 +105,9 @@
 
         <!-- Configuration of mutiny-kotlin module -->
         <kotlin.version>1.6.10</kotlin.version>
-        <kotlin.compiler.apiVersion>1.4</kotlin.compiler.apiVersion>
-        <kotlin.compiler.languageVersion>1.4</kotlin.compiler.languageVersion>
-        <coroutines.version>1.5.2</coroutines.version>
+        <kotlin.compiler.apiVersion>1.5</kotlin.compiler.apiVersion>
+        <kotlin.compiler.languageVersion>1.5</kotlin.compiler.languageVersion>
+        <coroutines.version>1.6.0</coroutines.version>
         <kotlin.compiler.jvmTarget>${maven.compiler.target}</kotlin.compiler.jvmTarget>
         <dokka.version>1.6.0</dokka.version>
 


### PR DESCRIPTION
*  Refactored and cleaned up tests.
* Update Coroutines to 1.6
* Needed to increase language/api version to 1.5 because of method signature changes in `Flow` that are only supported from 1.5 onwards (causing the test failures of https://github.com/smallrye/smallrye-mutiny/pull/788)