### PR TITLE
Limit concurrency in Uni.combine().all()

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroupIterable.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroupIterable.java
@@ -10,6 +10,7 @@ import java.util.stream.StreamSupport;
 import io.smallrye.common.annotation.CheckReturnValue;
 import io.smallrye.common.annotation.Experimental;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.uni.UniAndCombination;
 
@@ -19,6 +20,7 @@ public class UniAndGroupIterable<T1> {
     private final List<? extends Uni<?>> unis;
 
     private boolean collectFailures;
+    private int concurrency = -1;
 
     public UniAndGroupIterable(Iterable<? extends Uni<?>> iterable) {
         this(null, iterable, false);
@@ -28,7 +30,7 @@ public class UniAndGroupIterable<T1> {
         this(source, iterable, false);
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public UniAndGroupIterable(Uni<? extends T1> source, Iterable<? extends Uni<?>> iterable, boolean collectFailures) {
         this.source = source;
         List<? extends Uni<?>> others;
@@ -48,18 +50,35 @@ public class UniAndGroupIterable<T1> {
     }
 
     /**
+     * Limit the number of concurrent upstream subscriptions.
+     * <p>
+     * When not specified all upstream {@link Uni} are being subscribed when the combining {@link Uni} is subscribed.
+     * <p>
+     * Setting a limit is useful when you have a large number of {@link Uni} to combine and their simultaneous
+     * subscriptions might overwhelm resources (e.g., database connections, etc).
+     *
+     * @param level the concurrency level, must be strictly positive
+     * @return an object to configure the combination logic
+     */
+    @CheckReturnValue
+    public UniAndGroupIterable<T1> usingConcurrencyOf(int level) {
+        this.concurrency = ParameterValidation.positive(level, "level");
+        return this;
+    }
+
+    /**
      * Combine the items emitted by the {@link Uni unis}, and emit the result when all {@link Uni unis} have
      * successfully completed. In case of failure, the failure is propagated.
-     * 
+     *
      * @param function the combination function
-     * @param <O> the combination value type
+     * @param <O>      the combination value type
      * @return the new {@link Uni}
      */
     @CheckReturnValue
     public <O> Uni<O> combinedWith(Function<List<?>, O> function) {
         Function<List<?>, O> actual = Infrastructure.decorate(nonNull(function, "function"));
         return Infrastructure
-                .onUniCreation(new UniAndCombination<>(source, unis, actual, collectFailures));
+                .onUniCreation(new UniAndCombination<>(source, unis, actual, collectFailures, concurrency));
     }
 
     /**
@@ -69,11 +88,11 @@ public class UniAndGroupIterable<T1> {
      * This method is a convenience wrapper for {@link #combinedWith(Function)} but with the assumption that all items
      * have {@code I} as a super type, which saves you a cast in the combination function.
      * If the cast fails then the returned {@link Uni} fails with a {@link ClassCastException}.
-     * 
+     *
      * @param superType the super type of all items
-     * @param function the combination function
-     * @param <O> the combination value type
-     * @param <I> the super type of all items
+     * @param function  the combination function
+     * @param <O>       the combination value type
+     * @param <I>       the super type of all items
      * @return the new {@link Uni}
      */
     @SuppressWarnings("unchecked")
@@ -88,12 +107,12 @@ public class UniAndGroupIterable<T1> {
      * {@link Uni unis} have successfully completed. In case of failure, the failure is propagated.
      *
      * @return the {@code Uni Uni<Void>} emitting {@code null} when all the {@link Uni unis} have completed, or propagating
-     *         the failure.
+     * the failure.
      */
     @CheckReturnValue
     public Uni<Void> discardItems() {
         return Infrastructure
-                .onUniCreation(new UniAndCombination<>(source, unis, x -> null, collectFailures));
+                .onUniCreation(new UniAndCombination<>(source, unis, x -> null, collectFailures, concurrency));
     }
 
 }


### PR DESCRIPTION
Note: `Uni.combine().any()` must not support concurrent limits, because the semantic is to forward the result of the fastest `Uni` (item or failure).