### PR TITLE
Avoid `Uni.join().first(unis).toTerminate()` with a concurrency limit

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
@@ -188,14 +188,6 @@ public class UniJoin {
     public interface JoinFirstStrategyTerminal<T> {
 
         /**
-         * Forward the value or failure from the first {@link Uni} to terminate.
-         *
-         * @return a new {@link Uni}
-         */
-        @CheckReturnValue
-        Uni<T> toTerminate();
-
-        /**
          * Forward the value from the first {@link Uni} to terminate with a value.
          * <p>
          * When all {@link Uni} references fail then failures are collected into a {@link CompositeException},
@@ -239,7 +231,9 @@ public class UniJoin {
         }
 
         /**
-         * {@inheritDoc}
+         * Forward the value or failure from the first {@link Uni} to terminate.
+         *
+         * @return a new {@link Uni}
          */
         @CheckReturnValue
         public Uni<T> toTerminate() {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinAll.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniJoinAll.java
@@ -9,7 +9,6 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.AbstractUni;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
@@ -136,16 +135,12 @@ public class UniJoinAll<T> extends AbstractUni<List<T>> {
                     if (!cancelled.get()) {
                         failures.add(failure);
                         forwardSignalWhenCompleteOrSubscribeNext();
-                    } else {
-                        Infrastructure.handleDroppedException(failure);
                     }
                     break;
                 case FAIL_FAST:
                     if (cancelled.compareAndSet(false, true)) {
                         cancelSubscriptions();
                         subscriber.onFailure(failure);
-                    } else {
-                        Infrastructure.handleDroppedException(failure);
                     }
                     break;
             }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
@@ -469,22 +469,6 @@ class UniJoinTest {
             sub.assertCompleted().assertItem(Arrays.asList(1, 2, 3));
         }
 
-        @Test
-        void joinFirstWithItemSmokeTest() {
-            Uni<Integer> a = Uni.createFrom().failure(new IOException("boom"));
-            Uni<Integer> b = Uni.createFrom().failure(new IOException("bam"));
-            Uni<Integer> c = Uni.createFrom().item(3);
-
-            Uni<Integer> uni = Uni.join().first(a, b, c).usingConcurrencyOf(1).withItem();
-
-            UniAssertSubscriber<Integer> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
-            sub.assertCompleted().assertItem(3);
-
-            uni = Uni.join().first(a, b, c).usingConcurrencyOf(1).toTerminate();
-            sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
-            sub.assertFailedWith(IOException.class, "boom");
-        }
-
         @ParameterizedTest(name = "poolSize={0}, delays={1}, limit={2}, minTime={3}")
         @CsvSource(value = {
                 "4, 100, 1, 400",
@@ -584,34 +568,6 @@ class UniJoinTest {
             UniAssertSubscriber<String> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
 
             sub.awaitItem().assertCompleted().assertItem("b");
-            assertThat(System.currentTimeMillis() - start).isGreaterThanOrEqualTo(minTime);
-
-            pool.shutdownNow();
-        }
-
-        @ParameterizedTest(name = "poolSize={0}, delays={1}, limit={2}, minTime={3}, shallFail={4}")
-        @CsvSource(value = {
-                "4, 100, 1, 200, true",
-                "4, 100, 16, 100, false"
-        })
-        void joinFirstToSignalCheckConcurrency(int poolSize, int delays, int limit, int minTime, boolean shallFail) {
-            ScheduledExecutorService pool = Executors.newScheduledThreadPool(poolSize);
-
-            Uni<String> a = Uni.createFrom().future(() -> pool.schedule(() -> {
-                throw new RuntimeException("boom");
-            }, delays * 2L, TimeUnit.MILLISECONDS));
-            Uni<String> b = Uni.createFrom().future(() -> pool.schedule(() -> "b", delays, TimeUnit.MILLISECONDS));
-
-            Uni<String> uni = Uni.join().first(a, b).usingConcurrencyOf(limit).toTerminate();
-
-            long start = System.currentTimeMillis();
-            UniAssertSubscriber<String> sub = uni.subscribe().withSubscriber(UniAssertSubscriber.create());
-
-            if (shallFail) {
-                sub.awaitFailure().assertFailed();
-            } else {
-                sub.awaitItem().assertCompleted().assertItem("b");
-            }
             assertThat(System.currentTimeMillis() - start).isGreaterThanOrEqualTo(minTime);
 
             pool.shutdownNow();


### PR DESCRIPTION
Also removed dropped exception logging, cancellation on a join effectively means that failures shall be discarded.
