### PR TITLE
JPMS open modules do not export packages

### DIFF
--- a/implementation/revapi.json
+++ b/implementation/revapi.json
@@ -1,50 +1,86 @@
-[ {
-  "extension" : "revapi.java",
-  "id" : "java",
-  "configuration" : {
-    "missing-classes" : {
-      "behavior" : "report",
-      "ignoreMissingAnnotations" : false
+[
+  {
+    "extension": "revapi.java",
+    "id": "java",
+    "configuration": {
+      "missing-classes": {
+        "behavior": "report",
+        "ignoreMissingAnnotations": false
+      }
+    }
+  },
+  {
+    "extension": "revapi.filter",
+    "configuration": {
+      "elements": {
+        "include": [
+          {
+            "matcher": "java-package",
+            "match": "io.smallrye.mutiny"
+          },
+          {
+            "matcher": "java-package",
+            "match": "io.smallrye.mutiny.groups"
+          },
+          {
+            "matcher": "java-package",
+            "match": "io.smallrye.mutiny.helpers.spies"
+          },
+          {
+            "matcher": "java-package",
+            "match": "io.smallrye.mutiny.helpers.test"
+          },
+          {
+            "matcher": "java-package",
+            "match": "io.smallrye.mutiny.infrastructure"
+          },
+          {
+            "matcher": "java-package",
+            "match": "io.smallrye.mutiny.operators"
+          },
+          {
+            "matcher": "java-package",
+            "match": "io.smallrye.mutiny.subscription"
+          },
+          {
+            "matcher": "java-package",
+            "match": "io.smallrye.mutiny.tuples"
+          },
+          {
+            "matcher": "java-package",
+            "match": "io.smallrye.mutiny.unchecked"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "extension": "revapi.differences",
+    "id": "breaking-changes",
+    "configuration": {
+      "criticality": "highlight",
+      "minSeverity": "POTENTIALLY_BREAKING",
+      "minCriticality": "documented",
+      "differences": []
+    }
+  },
+  {
+    "extension": "revapi.reporter.json",
+    "configuration": {
+      "minSeverity": "POTENTIALLY_BREAKING",
+      "minCriticality": "documented",
+      "output": "target/compatibility.json",
+      "indent": true,
+      "append": false,
+      "keepEmptyFile": true
+    }
+  },
+  {
+    "extension": "revapi.reporter.text",
+    "configuration": {
+      "minSeverity": "POTENTIALLY_BREAKING",
+      "minCriticality": "documented",
+      "output": "out"
     }
   }
-}, {
-  "extension" : "revapi.filter",
-  "configuration" : {
-    "elements" : {
-      "include" : [ {
-        "matcher" : "java-package",
-        "match" : "/io\\.smallrye\\.mutiny(\\..+)?/"
-      } ],
-      "exclude" : [ {
-        "matcher" : "java-package",
-        "match" : "/io\\.smallrye\\.mutiny\\.operators(\\..+)?/"
-      } ]
-    }
-  }
-}, {
-  "extension" : "revapi.differences",
-  "id" : "breaking-changes",
-  "configuration" : {
-    "criticality" : "highlight",
-    "minSeverity" : "POTENTIALLY_BREAKING",
-    "minCriticality" : "documented",
-    "differences" : [ ]
-  }
-}, {
-  "extension" : "revapi.reporter.json",
-  "configuration" : {
-    "minSeverity" : "POTENTIALLY_BREAKING",
-    "minCriticality" : "documented",
-    "output" : "target/compatibility.json",
-    "indent" : true,
-    "append" : false,
-    "keepEmptyFile" : true
-  }
-}, {
-  "extension" : "revapi.reporter.text",
-  "configuration" : {
-    "minSeverity" : "POTENTIALLY_BREAKING",
-    "minCriticality" : "documented",
-    "output" : "out"
-  }
-} ]
+]

--- a/implementation/src/main/module/module-info.java
+++ b/implementation/src/main/module/module-info.java
@@ -1,6 +1,17 @@
 open module io.smallrye.mutiny {
 
-    requires org.reactivestreams;
+    requires transitive org.reactivestreams;
+    requires transitive smallrye.common.annotation;
+
+    exports io.smallrye.mutiny;
+    exports io.smallrye.mutiny.groups;
+    exports io.smallrye.mutiny.helpers.spies;
+    exports io.smallrye.mutiny.helpers.test;
+    exports io.smallrye.mutiny.infrastructure;
+    exports io.smallrye.mutiny.operators;
+    exports io.smallrye.mutiny.subscription;
+    exports io.smallrye.mutiny.tuples;
+    exports io.smallrye.mutiny.unchecked;
 
     uses io.smallrye.mutiny.infrastructure.MultiInterceptor;
     uses io.smallrye.mutiny.infrastructure.ExecutorConfiguration;


### PR DESCRIPTION
We incorrectly assumed that open modules would export all packages, which is not the case.

- Open modules allow for (deep) reflection to all classes, which is something we want to allow. We have no good reason right now to restrict reflection in Mutiny.
- Exported packages need to be added manually, there is no wildcard. I did a selection of packages that shall be in the public API.
- I fixed transitive 'requires' clauses: Reactive Streams is part of the Mutiny API, just like SmallRye Common Annotations.
