### PR TITLE
New Multi demand pacing operator

### DIFF
--- a/documentation/src/main/jekyll/_data/categories.yml
+++ b/documentation/src/main/jekyll/_data/categories.yml
@@ -30,6 +30,7 @@
     - logging
     - context-passing
     - replaying-multis
+    - controlling-demand
 
 - name: Integration
   guides:

--- a/documentation/src/main/jekyll/_data/guides.yml
+++ b/documentation/src/main/jekyll/_data/guides.yml
@@ -325,3 +325,9 @@ replaying-multis:
   text: Learn how multiple subscribers can replay from a Multi
   labels:
     - advanced
+
+controlling-demand:
+  title: Controlling the demand
+  text: Learn about custom operators for controlling the upstream demand
+  labels:
+    - advanced

--- a/documentation/src/main/jekyll/guides/controlling-demand.adoc
+++ b/documentation/src/main/jekyll/guides/controlling-demand.adoc
@@ -1,0 +1,28 @@
+:page-layout: guides
+:page-guide-id: controlling-demand
+:page-liquid:
+:page-show-toc: false
+:include_dir: ../../../../src/test/java/guides/operators
+
+A subscription is used for 2 purposes: cancelling a request and demanding batches of items.
+
+The `Multi.paceDemand()` operator can be used to automatically issue requests at certain points in time.
+
+The following example issues requests of 25 items every 100ms:
+
+[source,java,indent=0]
+----
+include::{include_dir}/ControlDemandTest.java[tags=pacing]
+----
+
+`FixedDemandPacer` is a simple _pacer_ with a fixed demand and a fixed delay.
+
+You can create more elaborated pacers by implementing the `DemandPacer` interface.
+To do so you provide an initial request and a function to evaluate the next request which is evaluated based on the previous request and the number of items emitted since the last request:
+
+[source,java,indent=0]
+----
+include::{include_dir}/ControlDemandTest.java[tags=custom-pacer]
+----
+
+The previous example is a custom pacer that doubles the demand and increases the delay for each new request.

--- a/documentation/src/test/java/guides/operators/ControlDemandTest.java
+++ b/documentation/src/test/java/guides/operators/ControlDemandTest.java
@@ -1,0 +1,48 @@
+package guides.operators;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.subscription.DemandPacer;
+import io.smallrye.mutiny.subscription.FixedDemandPacer;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ControlDemandTest {
+
+    @Test
+    void pacing() {
+        // tag::pacing[]
+        FixedDemandPacer pacer = new FixedDemandPacer(25L, Duration.ofMillis(100L));
+
+        Multi<Integer> multi = Multi.createFrom().range(0, 100)
+                .paceDemand().on(Infrastructure.getDefaultWorkerPool()).using(pacer);
+        // end::pacing[]
+
+        AssertSubscriber<Integer> sub = multi.subscribe().withSubscriber(AssertSubscriber.create());
+        sub.awaitCompletion();
+        assertThat(sub.getItems()).hasSize(100);
+    }
+
+    @Test
+    void customPacer() {
+        // tag::custom-pacer[]
+        DemandPacer pacer = new DemandPacer() {
+
+            @Override
+            public Request initial() {
+                return new Request(10L, Duration.ofMillis(100L));
+            }
+
+            @Override
+            public Request apply(Request previousRequest, long observedItemsCount) {
+                return new Request(previousRequest.demand() * 2, previousRequest.delay().plus(10, ChronoUnit.MILLIS));
+            }
+        };
+        // end::custom-pacer[]
+    }
+}

--- a/implementation/revapi.json
+++ b/implementation/revapi.json
@@ -85,6 +85,12 @@
           "new": "method io.smallrye.mutiny.groups.MultiReplay io.smallrye.mutiny.groups.MultiReplay::upTo(long)",
           "annotation": "@io.smallrye.common.annotation.CheckReturnValue",
           "justification": "Not breaking. The annotation was missing and has now be added."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method io.smallrye.mutiny.groups.MultiDemandPacing<T> io.smallrye.mutiny.Multi<T>::paceDemand()",
+          "justification": "New Multi paceDemand experimental operator"
         }
       ]
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -617,7 +617,7 @@ public interface Multi<T> extends Publisher<T> {
      *         .paceDemand().on(Infrastructure.getDefaultWorkerPool()).using(pacer);
      * </pre>
      *
-     * <strong>Important: this operator is not compliant with the reactive streams specification.</strong>
+     * <strong>Important: this operator is NOT compliant with the reactive streams specification.</strong>
      * Downstream demand requests are being ignored, so it is possible that this operator requests more than what the downstream
      * subscriber would want, depending on the {@link io.smallrye.mutiny.subscription.DemandPacer}
      * object in use.

--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -560,7 +560,7 @@ public interface Multi<T> extends Publisher<T> {
      * <p>
      * The provided function takes this {@link Multi} and the {@link Context} as parameters, and returns a {@link Multi}
      * to build the sub-pipeline, as in:
-     * 
+     *
      * <pre>
      * {@code
      * someMulti.withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.getOrElse("foo", () -> "yolo")));
@@ -587,7 +587,7 @@ public interface Multi<T> extends Publisher<T> {
      *
      * <p>
      * This is a shortcut for:
-     * 
+     *
      * <pre>
      * {@code
      * someMulti.withContext((multi, ctx) -> multi.onItem().transform(item -> new ItemWithContext<>(ctx, item)));
@@ -602,4 +602,30 @@ public interface Multi<T> extends Publisher<T> {
     default Multi<ItemWithContext<T>> attachContext() {
         return this.withContext((multi, ctx) -> multi.onItem().transform(item -> new ItemWithContext<>(ctx, item)));
     }
+
+    /**
+     * A demand-pacer allows controlling upstream demand using a request and a delay.
+     * <p>
+     * Each time the delay expires the pacer can evaluate a new demand based on the previous request and the number of emitted
+     * items that have been observed since the previous request.
+     * <p>
+     * In the following example a demand of 25 is issued every 100ms, using the default worker pool to perform requests:
+     * 
+     * <pre>
+     * var pacer = new FixedDemandPacer(25L, Duration.ofMillis(100L));
+     * var multi = Multi.createFrom().range(0, 100)
+     *         .paceDemand().on(Infrastructure.getDefaultWorkerPool()).using(pacer);
+     * </pre>
+     *
+     * <strong>Important: this operator is not compliant with the reactive streams specification.</strong>
+     * Downstream demand requests are being ignored, so it is possible that this operator requests more than what the downstream
+     * subscriber would want, depending on the {@link io.smallrye.mutiny.subscription.DemandPacer}
+     * object in use.
+     *
+     * @return a group to configure the demand pacing
+     */
+    @Experimental("Demand pacing is a new experimental API introduced in Mutiny 1.5.0")
+    @CheckReturnValue
+    MultiDemandPacing<T> paceDemand();
+
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiDemandPacing.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiDemandPacing.java
@@ -1,0 +1,48 @@
+package io.smallrye.mutiny.groups;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.operators.multi.MultiDemandPacer;
+import io.smallrye.mutiny.subscription.DemandPacer;
+
+@Experimental("Demand pacing is a new experimental API introduced in Mutiny 1.5.0")
+public class MultiDemandPacing<T> {
+
+    private final AbstractMulti<T> upstream;
+    private ScheduledExecutorService executor = Infrastructure.getDefaultWorkerPool();
+
+    public MultiDemandPacing(AbstractMulti<T> upstream) {
+        this.upstream = upstream;
+    }
+
+    /**
+     * Sets the executor to use for issuing demand requests.
+     * The default is to use {@link Infrastructure#getDefaultWorkerPool()}.
+     *
+     * @param executor the executor, must not be {@code null}
+     * @return this group
+     */
+    @CheckReturnValue
+    public MultiDemandPacing<T> on(ScheduledExecutorService executor) {
+        this.executor = nonNull(executor, "executor");
+        return this;
+    }
+
+    /**
+     * Sets the demand pacer and return the new {@link Multi}.
+     *
+     * @param pacer the pacer, must not be {@code null}
+     * @return the new {@link Multi}
+     */
+    @CheckReturnValue
+    public Multi<T> using(DemandPacer pacer) {
+        return Infrastructure.onMultiCreation(new MultiDemandPacer<>(upstream, executor, nonNull(pacer, "pacer")));
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
@@ -174,4 +174,10 @@ public abstract class AbstractMulti<T> implements Multi<T> {
     public <R> Multi<R> withContext(BiFunction<Multi<T>, Context, Multi<R>> builder) {
         return Infrastructure.onMultiCreation(new MultiWithContext<>(this, nonNull(builder, "builder")));
     }
+
+    @Override
+    public MultiDemandPacing<T> paceDemand() {
+        return new MultiDemandPacing<>(this);
+    }
+
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDemandPacer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDemandPacer.java
@@ -1,0 +1,143 @@
+package io.smallrye.mutiny.operators.multi;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.Subscriptions;
+import io.smallrye.mutiny.subscription.ContextSupport;
+import io.smallrye.mutiny.subscription.DemandPacer;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+public class MultiDemandPacer<T> extends AbstractMultiOperator<T, T> {
+
+    private final ScheduledExecutorService executor;
+    private final DemandPacer pacer;
+
+    public MultiDemandPacer(Multi<? extends T> upstream, ScheduledExecutorService executor, DemandPacer pacer) {
+        super(upstream);
+        this.executor = executor;
+        this.pacer = pacer;
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super T> subscriber) {
+        upstream.subscribe(new MultiSubscriptionPacerProcessor<>(subscriber, executor, pacer));
+    }
+
+    private static class MultiSubscriptionPacerProcessor<T> extends MultiOperatorProcessor<T, T> {
+
+        private final ScheduledExecutorService executor;
+        private final DemandPacer pacer;
+
+        private final AtomicLong itemsCounter = new AtomicLong();
+        private ScheduledFuture<?> scheduledFuture;
+        private DemandPacer.Request currentRequest;
+
+        MultiSubscriptionPacerProcessor(MultiSubscriber<? super T> downstream, ScheduledExecutorService executor,
+                DemandPacer pacer) {
+            super(downstream);
+            this.executor = executor;
+            this.pacer = pacer;
+        }
+
+        @Override
+        public Context context() {
+            if (downstream instanceof ContextSupport) {
+                return ((ContextSupport) downstream).context();
+            } else {
+                return Context.empty();
+            }
+        }
+
+        private void demandAndSchedule(ScheduledExecutorService executor) {
+            long demand = currentRequest.demand();
+            long delay = currentRequest.delay().toNanos();
+            scheduledFuture = executor.schedule(this::tick, delay, TimeUnit.NANOSECONDS);
+            upstream.request(demand);
+        }
+
+        private void tick() {
+            if (upstream == Subscriptions.CANCELLED) {
+                return;
+            }
+            long numberOfItemsEmitted = itemsCounter.getAndSet(0L);
+            try {
+                currentRequest = pacer.apply(currentRequest, numberOfItemsEmitted);
+                if (currentRequest == null) {
+                    cancel();
+                    downstream.onFailure(new NullPointerException("The pacer provided a null request"));
+                    return;
+                }
+            } catch (Throwable failure) {
+                cancel();
+                downstream.onFailure(failure);
+                return;
+            }
+            demandAndSchedule(executor);
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            super.onSubscribe(subscription);
+            try {
+                currentRequest = pacer.initial();
+            } catch (Throwable failure) {
+                cancel();
+                downstream.onFailure(failure);
+                return;
+            }
+            if (currentRequest == null) {
+                cancel();
+                downstream.onFailure(new NullPointerException("The pacer provided a null initial request"));
+            } else {
+                demandAndSchedule(executor);
+            }
+        }
+
+        @Override
+        public void onItem(T item) {
+            if (upstream == Subscriptions.CANCELLED) {
+                return;
+            }
+            itemsCounter.incrementAndGet();
+            downstream.onNext(item);
+        }
+
+        @Override
+        public void onFailure(Throwable failure) {
+            if (upstream == Subscriptions.CANCELLED) {
+                return;
+            }
+            cancel();
+            downstream.onError(failure);
+        }
+
+        @Override
+        public void onCompletion() {
+            if (upstream == Subscriptions.CANCELLED) {
+                return;
+            }
+            cancel();
+            downstream.onComplete();
+        }
+
+        @Override
+        public void cancel() {
+            if (scheduledFuture != null) {
+                scheduledFuture.cancel(true);
+            }
+            super.cancel();
+        }
+
+        @Override
+        public void request(long numberOfItems) {
+            // Ignore on purpose
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/DemandPacer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/DemandPacer.java
@@ -1,0 +1,88 @@
+package io.smallrye.mutiny.subscription;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
+import static io.smallrye.mutiny.helpers.ParameterValidation.validate;
+
+import java.time.Duration;
+
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Interface for {@link Multi} demand pacers and the {@link Multi#paceDemand()} operator.
+ * <p>
+ * A demand-pacer allows controlling upstream demand using a request and a delay.
+ * Each time the delay expires the pacer can evaluate a new demand based on the previous request and the number of emitted items
+ * that have been observed since the previous request.
+ * <p>
+ * The {@link FixedDemandPacer} offers a fixed delay / fixed demand implementation, but custom / adaptive strategies can be
+ * provided through this {@link DemandPacer} interface.
+ */
+@Experimental("Demand pacing is a new experimental API introduced in Mutiny 1.5.0")
+public interface DemandPacer {
+
+    /**
+     * A demand request.
+     */
+    @Experimental("Demand pacing is a new experimental API introduced in Mutiny 1.5.0")
+    class Request {
+
+        private final long demand;
+        private final Duration delay;
+
+        /**
+         * Constructs a new request.
+         *
+         * @param demand the number of items, must be strictly positive
+         * @param delay the delay, must not be {@code null}, must be strictly positive
+         */
+        public Request(long demand, Duration delay) {
+            this.demand = positive(demand, "demand");
+            this.delay = validate(delay, "delay");
+        }
+
+        /**
+         * Get the demand.
+         *
+         * @return the demand
+         */
+        public long demand() {
+            return demand;
+        }
+
+        /**
+         * Get the delay
+         *
+         * @return the delay
+         */
+        public Duration delay() {
+            return delay;
+        }
+
+        @Override
+        public String toString() {
+            return "Request{" +
+                    "demand=" + demand +
+                    ", delay=" + delay +
+                    '}';
+        }
+    }
+
+    /**
+     * Get the initial request.
+     * <p>
+     * This will be called at the {@link Multi#paceDemand()} operator subscription time.
+     *
+     * @return the request, must not be {@code null}
+     */
+    Request initial();
+
+    /**
+     * Evaluate the next request after the previous request delay has expired.
+     *
+     * @param previousRequest the previous request
+     * @param observedItemsCount the number of emitted items that have been observed since the last request
+     * @return the request, must not be {@code null}
+     */
+    Request apply(Request previousRequest, long observedItemsCount);
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/DemandPacer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/DemandPacer.java
@@ -4,6 +4,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
 import static io.smallrye.mutiny.helpers.ParameterValidation.validate;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 import io.smallrye.common.annotation.Experimental;
 import io.smallrye.mutiny.Multi;
@@ -39,6 +40,9 @@ public interface DemandPacer {
         public Request(long demand, Duration delay) {
             this.demand = positive(demand, "demand");
             this.delay = validate(delay, "delay");
+            if (delay == ChronoUnit.FOREVER.getDuration()) {
+                throw new IllegalArgumentException("ChronoUnit.FOREVER is not a correct delay value");
+            }
         }
 
         /**

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/FixedDemandPacer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/FixedDemandPacer.java
@@ -1,0 +1,28 @@
+package io.smallrye.mutiny.subscription;
+
+import java.time.Duration;
+
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * A demand pacer with a fixed delay / fixed demand.
+ */
+@Experimental("Demand pacing is a new experimental API introduced in Mutiny 1.5.0")
+public class FixedDemandPacer implements DemandPacer {
+
+    private final Request request;
+
+    public FixedDemandPacer(long demand, Duration delay) {
+        request = new Request(demand, delay);
+    }
+
+    @Override
+    public Request initial() {
+        return request;
+    }
+
+    @Override
+    public Request apply(Request previousRequest, long observedItemsCount) {
+        return request;
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiDemandPacingTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiDemandPacingTest.java
@@ -1,0 +1,181 @@
+package io.smallrye.mutiny.groups;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.subscription.DemandPacer;
+import io.smallrye.mutiny.subscription.FixedDemandPacer;
+
+class MultiDemandPacingTest {
+
+    @Test
+    void rejectNullParameters() {
+        Multi<Integer> multi = Multi.createFrom().range(1, 100);
+        assertThatThrownBy(() -> multi.paceDemand().on(null)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be `null`");
+        assertThatThrownBy(() -> multi.paceDemand().using(null)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be `null`");
+    }
+
+    @Test
+    void fixedDemandPacer() {
+        ArrayList<Long> requests = new ArrayList<>();
+        FixedDemandPacer pacer = new FixedDemandPacer(25L, Duration.ofMillis(100L));
+        AssertSubscriber<Integer> sub = Multi.createFrom().range(0, 100)
+                .onRequest().invoke(requests::add)
+                .paceDemand().on(Infrastructure.getDefaultWorkerPool()).using(pacer)
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        sub.awaitCompletion();
+        assertThat(sub.getItems()).hasSize(100).contains(58, 63, 69);
+        assertThat(requests).containsExactly(25L, 25L, 25L, 25L);
+    }
+
+    @Test
+    void fixedDemandPacerWithFailure() {
+        ArrayList<Long> requests = new ArrayList<>();
+        FixedDemandPacer pacer = new FixedDemandPacer(25L, Duration.ofMillis(100L));
+        AssertSubscriber<Integer> sub = Multi.createFrom().<Integer> failure(new IOException("boom"))
+                .onRequest().invoke(requests::add)
+                .paceDemand().using(pacer)
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        sub.awaitFailure();
+        assertThat(sub.getItems()).isEmpty();
+        assertThat(requests).containsExactly(25L);
+    }
+
+    @Test
+    void fixedDemandPacerWithCancellation() {
+        ArrayList<Long> requests = new ArrayList<>();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        FixedDemandPacer pacer = new FixedDemandPacer(25L, Duration.ofSeconds(5L));
+        AssertSubscriber<Integer> sub = Multi.createFrom().range(0, 100)
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .onRequest().invoke(requests::add)
+                .paceDemand().using(pacer)
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        sub.cancel();
+
+        sub.assertNotTerminated();
+        assertThat(cancelled).isTrue();
+        assertThat(sub.getItems()).hasSize(25);
+        assertThat(requests).containsExactly(25L);
+    }
+
+    @Test
+    void fixedDemandPacerWithEarlyCancellation() {
+        ArrayList<Long> requests = new ArrayList<>();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        AtomicReference<Subscription> subscriptionBox = new AtomicReference<>();
+        FixedDemandPacer pacer = new FixedDemandPacer(25L, Duration.ofSeconds(5L));
+        AssertSubscriber<Integer> sub = Multi.createFrom().range(0, 100)
+                .onCancellation().invoke(() -> cancelled.set(true))
+                .onRequest().invoke(e -> {
+                    requests.add(e);
+                    subscriptionBox.get().cancel();
+                })
+                .onSubscription().invoke(subscriptionBox::set)
+                .paceDemand().using(pacer)
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        sub.assertNotTerminated();
+        assertThat(cancelled).isTrue();
+        assertThat(sub.getItems()).isEmpty();
+        assertThat(requests).containsExactly(25L);
+    }
+
+    @Test
+    void pacerMustNotReturnNullInitialRequest() {
+        AssertSubscriber<Integer> sub = Multi.createFrom().range(0, 100)
+                .paceDemand().using(new DemandPacer() {
+                    @Override
+                    public Request initial() {
+                        return null;
+                    }
+
+                    @Override
+                    public Request apply(Request previousRequest, long observedItemsCount) {
+                        return new Request(100, Duration.ofSeconds(1L));
+                    }
+                }).subscribe().withSubscriber(AssertSubscriber.create());
+        sub.awaitFailure().assertFailedWith(NullPointerException.class, "The pacer provided a null initial request");
+    }
+
+    @Test
+    void pacerMustNotFailOnInitialRequest() {
+        AssertSubscriber<Integer> sub = Multi.createFrom().range(0, 100)
+                .paceDemand().using(new DemandPacer() {
+                    @Override
+                    public Request initial() {
+                        throw new RuntimeException("boom");
+                    }
+
+                    @Override
+                    public Request apply(Request previousRequest, long observedItemsCount) {
+                        return new Request(100, Duration.ofSeconds(1L));
+                    }
+                }).subscribe().withSubscriber(AssertSubscriber.create());
+        sub.awaitFailure().assertFailedWith(RuntimeException.class, "boom");
+    }
+
+    @Test
+    void pacerMustNotReturnNullRequests() {
+        AssertSubscriber<Integer> sub = Multi.createFrom().range(0, 100)
+                .paceDemand().using(new DemandPacer() {
+                    @Override
+                    public Request initial() {
+                        return new Request(1L, Duration.ofMillis(100L));
+                    }
+
+                    @Override
+                    public Request apply(Request previousRequest, long observedItemsCount) {
+                        return null;
+                    }
+                }).subscribe().withSubscriber(AssertSubscriber.create());
+        sub.awaitFailure().assertFailedWith(NullPointerException.class, "The pacer provided a null request");
+    }
+
+    @Test
+    void pacerMustNotFailRequests() {
+        AssertSubscriber<Integer> sub = Multi.createFrom().range(0, 100)
+                .paceDemand().using(new DemandPacer() {
+                    @Override
+                    public Request initial() {
+                        return new Request(1L, Duration.ofMillis(100L));
+                    }
+
+                    @Override
+                    public Request apply(Request previousRequest, long observedItemsCount) {
+                        throw new RuntimeException("boom");
+                    }
+                }).subscribe().withSubscriber(AssertSubscriber.create());
+        sub.awaitFailure().assertFailedWith(RuntimeException.class, "boom");
+    }
+
+    @Test
+    void contextIsPropagated() {
+        FixedDemandPacer pacer = new FixedDemandPacer(25L, Duration.ofMillis(50L));
+        AssertSubscriber<String> sub = Multi.createFrom().range(0, 100)
+                .withContext((multi, ctx) -> multi.onItem().transform(n -> n + "::" + ctx.<String> get("foo")))
+                .paceDemand().using(pacer)
+                .subscribe().withSubscriber(AssertSubscriber.create(Context.of("foo", "bar")));
+
+        sub.awaitCompletion();
+        assertThat(sub.getItems()).hasSize(100).contains("58::bar", "63::bar", "69::bar");
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/DemandPacerRequestTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/DemandPacerRequestTest.java
@@ -1,0 +1,39 @@
+package io.smallrye.mutiny.subscription;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DemandPacerRequestTest {
+
+    @Test
+    void validateCorrectDemand() {
+        new DemandPacer.Request(123L, Duration.ofSeconds(10));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = { -1L, 0L })
+    void rejectBadDemands(long demand) {
+        assertThatThrownBy(() -> new DemandPacer.Request(demand, Duration.ofSeconds(10)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("`demand` must be greater than zero`");
+    }
+
+    @Test
+    void rejectNullDuration() {
+        assertThatThrownBy(() -> new DemandPacer.Request(10L, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("`delay` must not be `null`");
+    }
+
+    @Test
+    void rejectNegativeDuration() {
+        assertThatThrownBy(() -> new DemandPacer.Request(10L, Duration.ofSeconds(-10L)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("`delay` must be greater than zero");
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/subscription/DemandPacerRequestTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/subscription/DemandPacerRequestTest.java
@@ -3,6 +3,7 @@ package io.smallrye.mutiny.subscription;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,5 +36,12 @@ class DemandPacerRequestTest {
         assertThatThrownBy(() -> new DemandPacer.Request(10L, Duration.ofSeconds(-10L)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("`delay` must be greater than zero");
+    }
+
+    @Test
+    void rejectDurationOfForever() {
+        assertThatThrownBy(() -> new DemandPacer.Request(100L, ChronoUnit.FOREVER.getDuration()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ChronoUnit.FOREVER is not a correct delay value");
     }
 }


### PR DESCRIPTION
Demand pacing can be controlled from previous demands and the number of emitted items since the last request.

The initial implementation ships with a fixed demand implementation of the demand pacing interface.
Users can easily define their own policies, and we can introduce other concrete implementations in the future given use-cases and patterns.

This operator is not reactive-streams compliant because the downstream demand has to be ignored.

See #872
