### PR TITLE
Move io.smallrye.mutiny.operators.multi.processors to the public API

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -107,6 +107,7 @@
                         <sourceFileInclude>io/smallrye/mutiny/helpers/test/*.java</sourceFileInclude>
                         <sourceFileInclude>io/smallrye/mutiny/infrastructure/*.java</sourceFileInclude>
                         <sourceFileInclude>io/smallrye/mutiny/operators/*.java</sourceFileInclude>
+                        <sourceFileInclude>io/smallrye/mutiny/operators/multi/processors/*.java</sourceFileInclude>
                         <sourceFileInclude>io/smallrye/mutiny/subscription/*.java</sourceFileInclude>
                         <sourceFileInclude>io/smallrye/mutiny/tuples/*.java</sourceFileInclude>
                         <sourceFileInclude>io/smallrye/mutiny/unchecked/*.java</sourceFileInclude>

--- a/implementation/revapi.json
+++ b/implementation/revapi.json
@@ -40,6 +40,10 @@
           },
           {
             "matcher": "java-package",
+            "match": "io.smallrye.mutiny.operators.multi.processors"
+          },
+          {
+            "matcher": "java-package",
             "match": "io.smallrye.mutiny.subscription"
           },
           {

--- a/implementation/src/main/module/module-info.java
+++ b/implementation/src/main/module/module-info.java
@@ -9,6 +9,7 @@ open module io.smallrye.mutiny {
     exports io.smallrye.mutiny.helpers.test;
     exports io.smallrye.mutiny.infrastructure;
     exports io.smallrye.mutiny.operators;
+    exports io.smallrye.mutiny.operators.multi.processors;
     exports io.smallrye.mutiny.subscription;
     exports io.smallrye.mutiny.tuples;
     exports io.smallrye.mutiny.unchecked;


### PR DESCRIPTION
This API was documented, so it shall be JPMS-enabled.

Fixes #881
