### PR TITLE
Fix the capping operators outstanding demand management

### DIFF
--- a/documentation/src/main/jekyll/guides/controlling-demand.adoc
+++ b/documentation/src/main/jekyll/guides/controlling-demand.adoc
@@ -41,6 +41,8 @@ include::{include_dir}/ControlDemandTest.java[tags=capConstant]
 ----
 
 Here we cap requests to 50 items, so it takes 2 requests to get all 100 items of the upstream range.
+The first request of 75 items is capped to a request of 50 items, leaving an outstanding demand of 25 items.
+The second request of 25 items is added to the outstanding demand, resulting in a request of 50 items and completing the stream.
 
 You can also define a custom function that provides a capping value based on a custom formula, or based on earlier demand observations:
 

--- a/documentation/src/test/java/guides/operators/ControlDemandTest.java
+++ b/documentation/src/test/java/guides/operators/ControlDemandTest.java
@@ -55,10 +55,12 @@ class ControlDemandTest {
                 .capDemandsTo(50L)
                 .subscribe().withSubscriber(sub);
 
-        sub.request(Long.MAX_VALUE).assertNotTerminated();
+        // A first batch of 50 (capped), 25 remain outstanding
+        sub.request(75L).assertNotTerminated();
         assertThat(sub.getItems()).hasSize(50);
 
-        sub.request(Long.MAX_VALUE).assertCompleted();
+        // Second batch: 25 + 25 = 50
+        sub.request(25L).assertCompleted();
         assertThat(sub.getItems()).hasSize(100);
         // end::capConstant[]
     }
@@ -82,7 +84,7 @@ class ControlDemandTest {
         assertThat(sub.getItems()).hasSize(75);
 
         sub.request(1L).assertNotTerminated();
-        assertThat(sub.getItems()).hasSize(76);
+        assertThat(sub.getItems()).hasSize(94);
 
         sub.request(Long.MAX_VALUE).assertCompleted();
         assertThat(sub.getItems()).hasSize(100);

--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -635,7 +635,7 @@ public interface Multi<T> extends Publisher<T> {
      * This is a shortcut for:
      * 
      * <pre>
-     * multi.capDemandsUsing(request -&gt; Math.min(request, actual))
+     * multi.capDemandsUsing(outstanding -&gt; Math.min(outstanding, actual))
      * </pre>
      *
      * @param max the maximum demand
@@ -645,17 +645,19 @@ public interface Multi<T> extends Publisher<T> {
     @CheckReturnValue
     default Multi<T> capDemandsTo(long max) {
         long actual = positive(max, "max");
-        return capDemandsUsing(request -> Math.min(request, actual));
+        return capDemandsUsing(outstanding -> Math.min(outstanding, actual));
     }
 
     /**
      * Cap all downstream subscriber requests to a value computed by a function.
      * <p>
-     * The function must return a valid demand which is strictly positive and below or equal to that of the subscriber request.
-     * The function argument is the subscriber request.
+     * The function must return a valid demand which is strictly positive and below or equal to that of the current outstanding
+     * demand.
+     * The function argument is the current outstanding demand.
      *
-     * @param function the function, must not be {@code null}, must not return {@code null}, must return a long such that
-     *        {@code (0 < n <= request)} where {@code request} is initial the subscriber request
+     * @param function the function, must not be {@code null}, must not return {@code null}, must return a {@code long} such
+     *        that
+     *        {@code (0 < n <= outstanding)} where {@code outstanding} is the current outstanding demand
      * @return the new {@link Multi}
      */
     @Experimental("Demand capping is a new experimental API introduced in Mutiny 1.5.0")


### PR DESCRIPTION
Although not apparent in the TCK tests, not tracking the outstanding demand is against the RS semantics.

This changes the capping evaluation from that of the triggering (subscription) request to evaluating the outstanding demand.

Fixes #886
