### PR TITLE
Update shortcuts.adoc to show the parenthesis of the uni.eventually shortcut

### DIFF
--- a/documentation/src/main/jekyll/guides/shortcuts.adoc
+++ b/documentation/src/main/jekyll/guides/shortcuts.adoc
@@ -50,8 +50,8 @@ The following table lists the available shortcuts available by the `Uni` class:
 |`uni.call(x -> uni2)`
 |`uni.onItem().call(x -> uni2)`
 
-|`uni.eventually(() -> System.out.println("eventually"))`
-|`uni.onItemOrFailure().invoke((ignoredItem, ignoredException) -> System.out.println("eventually"))`
+|`uni.eventually\(() -> System.out.println("eventually"))`
+|`uni.onItemOrFailure().invoke\((ignoredItem, ignoredException) -> System.out.println("eventually"))`
 
 |`uni.eventually(() -> uni2)`
 |`uni.onItemOrFailure().call((ignoredItem, ignoredException) -> uni2)`


### PR DESCRIPTION
The generated documentation for uni.eventually was missing the parenthesis.

Now it is correctly showing
`
uni.eventually(() → System.out.println("eventually"))
`
instead of
`
uni.eventually) → System.out.println("eventually"
`

and

`
uni.onItemOrFailure().invoke((ignoredItem, ignoredException) → System.out.println("eventually"))
`
instead of
`
uni.onItemOrFailure().invokeignoredItem, ignoredException) → System.out.println("eventually"
`

in the documentation.
