### PR TITLE
Concatmap no prefetch – backport 1.x

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -460,7 +460,7 @@ public interface Multi<T> extends Publisher<T> {
      * produced {@link Multi}. The flatten process makes sure that the items are not interleaved.
      * </ul>
      * <p>
-     * This method is equivalent to {@code multi.onItem().transformToMulti(mapper).concatenate()}.
+     * This method is equivalent to {@code multi.onItem().transformToMulti(mapper).concatenate(true)}.
      *
      * @param mapper the {@link Function} producing {@link Publisher} / {@link Multi} for each items emitted by the
      *        upstream {@link Multi}

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiFlatten.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiFlatten.java
@@ -11,6 +11,7 @@ import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.queues.Queues;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.multi.MultiConcatMapOp;
 import io.smallrye.mutiny.operators.multi.MultiFlatMapOp;
 
 /**
@@ -113,13 +114,41 @@ public class MultiFlatten<I, O> {
      * (potentially a {@code Multi}). The mapper must not return {@code null}</li>
      * <li>The items contained in each of the produced {@link Publisher} are then <strong>concatenated</strong> in the
      * produced {@link Multi}. The returned object lets you configure the flattening process.</li>
+     * <li>If {@code prefetch} is set to {@code true}, {@code flatMap} operator is used with upstream prefetch of
+     * {@code requests} parameter configured previously.</li>
+     * <li>If {@code prefetch} is set to {@code false}, {@code concatMap} operator is used without prefetch,
+     * meaning that items are requested lazily from the upstream, one at a time.</li>
+     * </ul>
+     *
+     * @param prefetch whether the operator prefetches items from upstream, or not.
+     * @return the object to configure the {@code concatMap} operation.
+     */
+    @CheckReturnValue
+    public Multi<O> concatenate(boolean prefetch) {
+        return Infrastructure
+                .onMultiCreation(prefetch ? new MultiFlatMapOp<>(upstream, mapper, collectFailureUntilCompletion, 1, requests)
+                        : new MultiConcatMapOp<>(upstream, mapper, collectFailureUntilCompletion));
+    }
+
+    /**
+     * Produces a {@link Multi} containing the items from {@link Publisher} produced by the {@code mapper} for each
+     * item emitted by this {@link Multi}.
+     * <p>
+     * The operators behaves as follows:
+     * <ul>
+     * <li>for each item emitted by this {@link Multi}, the mapper is called and produces a {@link Publisher}
+     * (potentially a {@code Multi}). The mapper must not return {@code null}</li>
+     * <li>The items contained in each of the produced {@link Publisher} are then <strong>concatenated</strong> in the
+     * produced {@link Multi}. The returned object lets you configure the flattening process.</li>
+     * <li>This operator defaults to without prefetch, meaning that items are requested lazily from the upstream,
+     * one at a time.</li>
      * </ul>
      *
      * @return the object to configure the {@code concatMap} operation.
      */
     @CheckReturnValue
     public Multi<O> concatenate() {
-        return Infrastructure.onMultiCreation(
-                new MultiFlatMapOp<>(upstream, mapper, collectFailureUntilCompletion, 1, requests));
+        return concatenate(true);
     }
+
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiConcatMapOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiConcatMapOp.java
@@ -1,0 +1,318 @@
+package io.smallrye.mutiny.operators.multi;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.ParameterValidation;
+import io.smallrye.mutiny.helpers.Subscriptions;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.subscription.ContextSupport;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+import io.smallrye.mutiny.subscription.SwitchableSubscriptionSubscriber;
+
+/**
+ * ConcatMap operator without prefetching items from the upstream.
+ * Requests are forwarded lazily to the upstream when:
+ * <ul>
+ * <li>First downstream request.</li>
+ * <li>The inner has no more outstanding requests.</li>
+ * <li>The inner completed without emitting items or with outstanding requests.</li>
+ * </ul>
+ *
+ * This operator can collect failures and postpone them until termination.
+ *
+ * @param <I> the upstream value type / input type
+ * @param <O> the output value type / produced type
+ */
+public class MultiConcatMapOp<I, O> extends AbstractMultiOperator<I, O> {
+
+    private final Function<? super I, ? extends Publisher<? extends O>> mapper;
+
+    private final boolean postponeFailurePropagation;
+
+    public MultiConcatMapOp(Multi<? extends I> upstream,
+            Function<? super I, ? extends Publisher<? extends O>> mapper,
+            boolean postponeFailurePropagation) {
+        super(upstream);
+        this.mapper = mapper;
+        this.postponeFailurePropagation = postponeFailurePropagation;
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super O> subscriber) {
+        if (subscriber == null) {
+            throw new NullPointerException("The subscriber must not be `null`");
+        }
+        ConcatMapMainSubscriber<I, O> sub = new ConcatMapMainSubscriber<>(subscriber,
+                mapper,
+                postponeFailurePropagation);
+
+        upstream.subscribe(Infrastructure.onMultiSubscription(upstream, sub));
+    }
+
+    public static final class ConcatMapMainSubscriber<I, O> implements MultiSubscriber<I>, Subscription, ContextSupport {
+
+        private static final int STATE_NEW = 0; // no request yet -- send first upstream request at this state
+        private static final int STATE_READY = 1; // first upstream request done, ready to receive items
+        private static final int STATE_EMITTING = 2; // received item from the upstream, subscribed to the inner
+        private static final int STATE_OUTER_TERMINATED = 3; // outer terminated, waiting for the inner to terminate
+        private static final int STATE_TERMINATED = 4; // inner and outer terminated
+        private static final int STATE_CANCELLED = 5; // cancelled
+        final AtomicInteger state = new AtomicInteger(STATE_NEW);
+
+        final MultiSubscriber<? super O> downstream;
+        final Function<? super I, ? extends Publisher<? extends O>> mapper;
+        private final boolean delayError;
+
+        final AtomicReference<Throwable> failures = new AtomicReference<>();
+
+        volatile Subscription upstream = null;
+        private static final AtomicReferenceFieldUpdater<ConcatMapMainSubscriber, Subscription> UPSTREAM_UPDATER = AtomicReferenceFieldUpdater
+                .newUpdater(ConcatMapMainSubscriber.class, Subscription.class, "upstream");
+
+        final ConcatMapInner<O> inner;
+
+        ConcatMapMainSubscriber(
+                MultiSubscriber<? super O> downstream,
+                Function<? super I, ? extends Publisher<? extends O>> mapper,
+                boolean delayError) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+            this.delayError = delayError;
+            this.inner = new ConcatMapInner<>(this);
+        }
+
+        @Override
+        public void request(long n) {
+            if (n > 0) {
+                if (state.compareAndSet(STATE_NEW, STATE_READY)) {
+                    upstream.request(1);
+                    // No outstanding requests from inner, forward the request to upstream
+                } else if (state.get() == STATE_READY && inner.requested() == 0) {
+                    upstream.request(1);
+                }
+                inner.request(n);
+            } else {
+                downstream.onFailure(new IllegalArgumentException("Invalid requests, must be greater than 0"));
+            }
+        }
+
+        @Override
+        public void cancel() {
+            while (true) {
+                int state = this.state.get();
+                if (state == STATE_CANCELLED) {
+                    return;
+                }
+                if (this.state.compareAndSet(state, STATE_CANCELLED)) {
+                    if (state == STATE_OUTER_TERMINATED) {
+                        inner.cancel();
+                    } else {
+                        inner.cancel();
+                        upstream.cancel();
+                    }
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (UPSTREAM_UPDATER.compareAndSet(this, null, s)) {
+                downstream.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onItem(I item) {
+            if (!state.compareAndSet(STATE_READY, STATE_EMITTING)) {
+                return;
+            }
+
+            try {
+                Publisher<? extends O> p = mapper.apply(item);
+                if (p == null) {
+                    throw new NullPointerException(ParameterValidation.MAPPER_RETURNED_NULL);
+                }
+
+                p.subscribe(inner);
+            } catch (Throwable e) {
+                if (postponeFailure(e, upstream)) {
+                    innerComplete(0L);
+                }
+            }
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            if (postponeFailure(t, inner)) {
+                onCompletion();
+            }
+        }
+
+        @Override
+        public void onCompletion() {
+            while (true) {
+                int state = this.state.get();
+                if (state == STATE_NEW || state == STATE_READY) {
+                    if (this.state.compareAndSet(state, STATE_TERMINATED)) {
+                        terminateDownstream();
+                        return;
+                    }
+                } else if (state == STATE_EMITTING) {
+                    if (this.state.compareAndSet(state, STATE_OUTER_TERMINATED)) {
+                        return;
+                    }
+                } else {
+                    return;
+                }
+            }
+        }
+
+        public synchronized void tryEmit(O value) {
+            switch (state.get()) {
+                case STATE_EMITTING:
+                case STATE_OUTER_TERMINATED:
+                    downstream.onItem(value);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        public void innerComplete(long emitted) {
+            while (true) {
+                int state = this.state.get();
+                if (state == STATE_EMITTING) {
+                    if (this.state.compareAndSet(state, STATE_READY)) {
+                        // Inner completed but there are outstanding requests from inner,
+                        // Or the inner completed without producing any items
+                        // Request new item from upstream
+                        if (inner.requested() != 0L || emitted == 0) {
+                            upstream.request(1);
+                        }
+                        return;
+                    }
+                } else if (state == STATE_OUTER_TERMINATED) {
+                    if (this.state.compareAndSet(state, STATE_TERMINATED)) {
+                        terminateDownstream();
+                        return;
+                    }
+                } else {
+                    return;
+                }
+            }
+        }
+
+        public void innerFailure(Throwable e, long emitted) {
+            if (postponeFailure(e, upstream)) {
+                innerComplete(emitted);
+            }
+        }
+
+        private boolean postponeFailure(Throwable e, Subscription subscription) {
+            if (e == null) {
+                return true;
+            }
+
+            Subscriptions.addFailure(failures, e);
+
+            if (delayError) {
+                return true;
+            }
+
+            while (true) {
+                int state = this.state.get();
+                if (state == STATE_CANCELLED || state == STATE_TERMINATED) {
+                    return false;
+                } else {
+                    if (this.state.compareAndSet(state, STATE_TERMINATED)) {
+                        subscription.cancel();
+                        synchronized (this) {
+                            downstream.onFailure(failures.get());
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+
+        private void terminateDownstream() {
+            Throwable ex = failures.get();
+            if (ex != null) {
+                downstream.onFailure(ex);
+                return;
+            }
+            downstream.onCompletion();
+        }
+
+        @Override
+        public Context context() {
+            if (downstream instanceof ContextSupport) {
+                return ((ContextSupport) downstream).context();
+            } else {
+                return Context.empty();
+            }
+        }
+
+    }
+
+    static final class ConcatMapInner<O> extends SwitchableSubscriptionSubscriber<O> {
+        private final ConcatMapMainSubscriber<?, O> parent;
+
+        long emitted;
+
+        /**
+         * Downstream passed as {@code null} to {@link SwitchableSubscriptionSubscriber} as accessors are not reachable.
+         * Effective downstream is {@code parent}.
+         * 
+         * @param parent parent as downstream
+         */
+        ConcatMapInner(ConcatMapMainSubscriber<?, O> parent) {
+            super(null);
+            this.parent = parent;
+        }
+
+        @Override
+        public void onItem(O item) {
+            emitted++;
+            parent.tryEmit(item);
+        }
+
+        @Override
+        public void onFailure(Throwable failure) {
+            long p = emitted;
+
+            if (p != 0L) {
+                emitted = 0L;
+                emitted(p);
+            }
+
+            parent.innerFailure(failure, p);
+        }
+
+        @Override
+        public void onCompletion() {
+            long p = emitted;
+
+            if (p != 0L) {
+                emitted = 0L;
+                emitted(p);
+            }
+
+            parent.innerComplete(p);
+        }
+
+        @Override
+        public Context context() {
+            return parent.context();
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/SwitchableSubscriptionSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/SwitchableSubscriptionSubscriber.java
@@ -139,6 +139,10 @@ public abstract class SwitchableSubscriptionSubscriber<O> implements MultiSubscr
         drain();
     }
 
+    public long requested() {
+        return requested;
+    }
+
     @Override
     public final void request(long n) {
         if (n <= 0) {

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiConcatMapNoPrefetchTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiConcatMapNoPrefetchTest.java
@@ -1,0 +1,271 @@
+package io.smallrye.mutiny.operators.multi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.smallrye.mutiny.CompositeException;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.groups.MultiFlatten;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+class MultiConcatMapNoPrefetchTest {
+
+    AtomicInteger upstreamRequestCount;
+    Multi<Integer> upstream;
+
+    @BeforeEach
+    void setUp() {
+        upstreamRequestCount = new AtomicInteger();
+        upstream = Multi.createFrom().generator(() -> upstreamRequestCount, (counter, emitter) -> {
+            int requestCount = counter.getAndIncrement();
+            emitter.emit(requestCount);
+            return counter;
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("argsTransformToUni")
+    void testTransformToUni(boolean prefetch, int[] upstreamRequests) {
+        Multi<Integer> result = upstream.onItem()
+                .transformToUni(integer -> Uni.createFrom().item(integer)
+                        .onItem().delayIt().by(Duration.ofMillis(10)))
+                .concatenate(prefetch);
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(5);
+        result.runSubscriptionOn(Infrastructure.getDefaultExecutor()).subscribe(ts);
+        ts.request(5);
+        ts.awaitItems(10);
+        await().untilAsserted(() -> assertThat(upstreamRequestCount).hasValue(upstreamRequests[0]));
+        ts.request(1);
+        ts.awaitItems(11);
+        await().untilAsserted(() -> assertThat(upstreamRequestCount).hasValue(upstreamRequests[1]));
+        ts.request(1);
+        ts.awaitItems(12);
+        await().untilAsserted(() -> assertThat(upstreamRequestCount).hasValue(upstreamRequests[2]));
+    }
+
+    private static Stream<Arguments> argsTransformToUni() {
+        return Stream.of(
+                Arguments.of(true, new int[] { 11, 12, 13 }),
+                Arguments.of(false, new int[] { 10, 11, 12 }));
+    }
+
+    @ParameterizedTest
+    @MethodSource("argsTransformToMulti")
+    void testTransformToMulti(boolean prefetch, int[] upstreamRequests) {
+        Multi<Integer> result = upstream.onItem()
+                .transformToMulti(i -> Multi.createFrom().items(i, i))
+                .concatenate(prefetch);
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(5);
+        result.runSubscriptionOn(Infrastructure.getDefaultExecutor()).subscribe(ts);
+        ts.request(5);
+        ts.awaitItems(10);
+        await().untilAsserted(() -> assertThat(upstreamRequestCount).hasValue(upstreamRequests[0]));
+        ts.request(1);
+        ts.awaitItems(11);
+        await().untilAsserted(() -> assertThat(upstreamRequestCount).hasValue(upstreamRequests[1]));
+        ts.request(1);
+        ts.awaitItems(12);
+        await().untilAsserted(() -> assertThat(upstreamRequestCount).hasValue(upstreamRequests[2]));
+    }
+
+    private static Stream<Arguments> argsTransformToMulti() {
+        return Stream.of(
+                Arguments.of(true, new int[] { 6, 6, 7 }),
+                Arguments.of(false, new int[] { 5, 6, 6 }));
+    }
+
+    @ParameterizedTest
+    @MethodSource("argsNoPrefetchPostponeFailure")
+    void testNoPrefetchPostponeFailure(boolean postponeFailure, Integer[] expectedItems, int expectedUpstreamRequest) {
+        AtomicInteger itemCounter = new AtomicInteger();
+        MultiFlatten<Integer, Integer> flatten = upstream.onItem().transformToMulti(i -> {
+            if (itemCounter.incrementAndGet() == 3) {
+                return Multi.createFrom().emitter(e -> {
+                    e.emit(i);
+                    e.fail(new IllegalArgumentException("3rd item"));
+                });
+            }
+            return Multi.createFrom().items(i, i);
+        });
+        Multi<Integer> result = (postponeFailure ? flatten.collectFailures() : flatten).concatenate(false);
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(5);
+        result.runSubscriptionOn(Infrastructure.getDefaultExecutor()).subscribe(ts);
+        ts.request(5);
+        ts.awaitItems(expectedItems.length);
+        ts.assertItems(expectedItems);
+        await().untilAsserted(() -> assertThat(upstreamRequestCount).hasValue(expectedUpstreamRequest));
+    }
+
+    private static Stream<Arguments> argsNoPrefetchPostponeFailure() {
+        return Stream.of(
+                Arguments.of(true, new Integer[] { 0, 0, 1, 1, 2, 3, 3, 4, 4, 5 }, 6),
+                Arguments.of(false, new Integer[] { 0, 0, 1, 1, 2 }, 3));
+    }
+
+    @Test
+    void testNoPrefetchWithConcatMapEmptyMulti() {
+        Multi<Integer> result = upstream.select().first(20).onItem()
+                .transformToMulti(i -> Multi.createFrom().<Integer> empty())
+                .concatenate(false);
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(5);
+        result.runSubscriptionOn(Infrastructure.getDefaultExecutor()).subscribe(ts);
+        ts.request(5);
+        await().untilAsserted(() -> assertThat(upstreamRequestCount).hasValueGreaterThan(10));
+        ts.assertHasNotReceivedAnyItem().assertCompleted();
+    }
+
+    @Test
+    void testNoPrefetchWithConcatMapContainingEmpty() {
+        Multi<Integer> result = upstream.onItem()
+                .transformToMulti(i -> (i % 3 == 0) ? Multi.createFrom().empty() : Multi.createFrom().item(i))
+                .concatenate(false);
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(5);
+        result.runSubscriptionOn(Infrastructure.getDefaultExecutor()).subscribe(ts);
+        ts.request(5);
+        ts.awaitItems(10);
+        await().untilAsserted(() -> assertThat(upstreamRequestCount).hasValueGreaterThan(10));
+        ts.assertItems(1, 2, 4, 5, 7, 8, 10, 11, 13, 14);
+        ts.request(1);
+        ts.awaitItems(11);
+        await().untilAsserted(() -> assertThat(upstreamRequestCount).hasValueGreaterThan(11));
+        ts.assertLastItem(16);
+    }
+
+    @Test
+    void testNoPrefetchWithConcatMapEmptyUni() {
+        Multi<Integer> result = upstream.select().first(20).onItem()
+                .transformToUni(i -> Uni.createFrom().<Integer> nullItem())
+                .concatenate(false);
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(5);
+        result.runSubscriptionOn(Infrastructure.getDefaultExecutor()).subscribe(ts);
+        ts.request(5);
+        await().untilAsserted(() -> assertThat(upstreamRequestCount).hasValueGreaterThan(10));
+        ts.assertHasNotReceivedAnyItem().assertCompleted();
+    }
+
+    @Test
+    void testMapperReturningNull() {
+        Multi<Integer> result = upstream
+                .onItem().transformToMulti(i -> {
+                    if (i == 0) {
+                        return Multi.createFrom().items(i);
+                    }
+                    return null;
+                })
+                .concatenate(false);
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(2);
+        result.subscribe(ts);
+        ts.assertItems(0);
+        ts.assertFailedWith(NullPointerException.class);
+    }
+
+    @Test
+    void testMapperReturningNullpostponeFailure() {
+        Multi<Integer> result = upstream.select().first(5)
+                .onItem().transformToUni(i -> (Uni<Integer>) null)
+                .collectFailures()
+                .concatenate(false);
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(5);
+        result.subscribe(ts);
+        ts.assertHasNotReceivedAnyItem().assertFailedWith(CompositeException.class);
+    }
+
+    @Test
+    void testUpstreamFailure() {
+        Multi<Integer> result = upstream
+                .onItem().failWith(() -> new RuntimeException("boom"))
+                .onItem().transformToUni(i -> Uni.createFrom().item(i))
+                .concatenate(false);
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(1);
+        result.subscribe(ts);
+        ts.assertHasNotReceivedAnyItem().assertFailedWith(RuntimeException.class);
+    }
+
+    @Test
+    void testUpstreamFailurepostponeFailure() {
+        Multi<Integer> result = upstream.select().first(5)
+                .onItem().failWith(() -> new RuntimeException("boom"))
+                .onItem().transformToUni(i -> Uni.createFrom().item(i))
+                .collectFailures()
+                .concatenate(false);
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(1);
+        result.subscribe(ts);
+        ts.assertHasNotReceivedAnyItem().assertFailedWith(RuntimeException.class);
+    }
+
+    @Test
+    void testCancelledSubscription() {
+        CompletableFuture<Integer> inner = new CompletableFuture<>();
+        AtomicBoolean upstreamCancelled = new AtomicBoolean();
+        AtomicBoolean innerCancelled = new AtomicBoolean();
+        Multi<Integer> result = upstream
+                .onCancellation().invoke(() -> upstreamCancelled.set(true))
+                .onItem().transformToUni(i -> Uni.createFrom().completionStage(inner)
+                        .onCancellation().invoke(() -> innerCancelled.set(true)))
+                .concatenate(false);
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(1);
+        result.subscribe(ts);
+        ts.cancel();
+        assertThat(upstreamCancelled).isTrue();
+        assertThat(innerCancelled).isTrue();
+        ts.assertHasNotReceivedAnyItem();
+    }
+
+    @Test
+    void testCancelledSubscriptionAfterTermination() {
+        upstream = Multi.createFrom().generator(() -> upstreamRequestCount, (counter, emitter) -> {
+            int requestCount = counter.getAndIncrement();
+            emitter.emit(requestCount);
+            emitter.complete();
+            return counter;
+        });
+        CompletableFuture<Integer> inner = new CompletableFuture<>();
+        AtomicBoolean innerCancelled = new AtomicBoolean();
+        AtomicBoolean downstreamCancelled = new AtomicBoolean();
+        Multi<Integer> result = upstream
+                .onItem().transformToUni(i -> Uni.createFrom().completionStage(inner)
+                        .emitOn(Infrastructure.getDefaultExecutor())
+                        .onCancellation().invoke(() -> innerCancelled.set(true)))
+                .concatenate(false)
+                .onCancellation().invoke(() -> downstreamCancelled.set(true));
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(1);
+        result.subscribe(ts);
+        ts.cancel();
+        assertThat(innerCancelled).isTrue();
+        assertThat(downstreamCancelled).isTrue();
+    }
+
+    @Test
+    void testInnerCompleteSubscriptionAfterTermination() {
+        upstream = Multi.createFrom().generator(() -> upstreamRequestCount, (counter, emitter) -> {
+            int requestCount = counter.getAndIncrement();
+            emitter.emit(requestCount);
+            emitter.complete();
+            return counter;
+        });
+        CompletableFuture<Integer> inner = new CompletableFuture<>();
+        Multi<Integer> result = upstream
+                .onItem().transformToUni(i -> Uni.createFrom().completionStage(inner)
+                        .emitOn(Infrastructure.getDefaultExecutor()))
+                .concatenate(false);
+        AssertSubscriber<Integer> ts = new AssertSubscriber<>(1);
+        result.subscribe(ts);
+        inner.complete(0);
+        ts.awaitCompletion();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -380,6 +380,8 @@
                 <configuration>
                     <!-- Do not compute compatibility on the documentation -->
                     <skip>${revapi.skip}</skip>
+                    <!-- Specify old version as the latest 1.x release -->
+                    <oldVersion>1.6.0</oldVersion>
                 </configuration>
             </plugin>
         </plugins>

--- a/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/MultiConcatMapNoPrefetchCompletionStageTckTest.java
+++ b/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/MultiConcatMapNoPrefetchCompletionStageTckTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
-public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Long> {
+public class MultiConcatMapNoPrefetchCompletionStageTckTest extends AbstractPublisherTck<Long> {
 
     @Test
     public void flatMapCsStageShouldMapFutures() {
@@ -21,7 +21,8 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Lon
         CompletableFuture<Integer> two = new CompletableFuture<>();
         CompletableFuture<Integer> three = new CompletableFuture<>();
         CompletionStage<List<Integer>> result = Multi.createFrom().<CompletionStage<Integer>> items(one, two, three)
-                .onItem().transformToUni(i -> Uni.createFrom().completionStage(i)).merge()
+                .onItem().transformToUni(i -> Uni.createFrom().completionStage(i))
+                .concatenate(false)
                 .collect().asList()
                 .subscribeAsCompletionStage();
         one.complete(1);
@@ -35,7 +36,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Lon
         return upstream(elements)
                 // Use supplyAsync on purpose to check the concurrency.
                 .onItem().transformToUni(i -> Uni.createFrom().completionStage(CompletableFuture.supplyAsync(() -> i)))
-                .merge();
+                .concatenate(false);
     }
 
     @Override
@@ -43,7 +44,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Lon
         return failedUpstream()
                 // Use supplyAsync on purpose to check the concurrency.
                 .onItem().transformToUni(i -> Uni.createFrom().completionStage(CompletableFuture.supplyAsync(() -> i)))
-                .merge();
+                .concatenate(false);
     }
 
     @Test
@@ -52,7 +53,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Lon
         CompletableFuture<Integer> two = new CompletableFuture<>();
         CompletableFuture<Integer> three = new CompletableFuture<>();
         CompletionStage<List<Integer>> result = Multi.createFrom().<CompletionStage<Integer>> items(one, two, three)
-                .onItem().transformToUni(i -> Uni.createFrom().completionStage(i)).merge(1)
+                .onItem().transformToUni(i -> Uni.createFrom().completionStage(i)).concatenate(false)
                 .collect().asList()
                 .subscribeAsCompletionStage();
         three.complete(3);
@@ -71,7 +72,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Lon
                 .onItem().transformToUni(cs -> {
                     Assert.assertEquals(1, concurrentMaps.incrementAndGet());
                     return Uni.createFrom().completionStage(cs);
-                }).merge(1)
+                }).concatenate(false)
                 .collect().asList()
                 .subscribeAsCompletionStage();
         concurrentMaps.decrementAndGet();
@@ -89,7 +90,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Lon
                 Multi.createFrom().failure(new QuietRuntimeException("failed"))
                         .onItem().transformToUni(
                                 i -> Uni.createFrom().completionStage(CompletableFuture.completedFuture(i)))
-                        .merge()
+                        .concatenate(false)
                         .collect().asList()
                         .subscribeAsCompletionStage()));
     }
@@ -102,7 +103,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Lon
                     .onTermination().invoke(() -> cancelled.complete(null))
                     .onItem().transformToUni(i -> {
                         throw new QuietRuntimeException("failed");
-                    }).merge()
+                    }).concatenate(false)
                     .collect().asList()
                     .subscribeAsCompletionStage();
             Await.await(cancelled);
@@ -120,7 +121,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Lon
                         CompletableFuture<Object> failed = new CompletableFuture<>();
                         failed.completeExceptionally(new QuietRuntimeException("failed"));
                         return Uni.createFrom().completionStage(failed);
-                    }).merge()
+                    }).concatenate(false)
                     .collect().asList()
                     .subscribeAsCompletionStage();
             Await.await(cancelled);
@@ -137,7 +138,7 @@ public class MultiFlatMapCompletionStageTckTest extends AbstractPublisherTck<Lon
                     .onItem()
                     .transformToUni(i -> Uni.createFrom().completionStage(CompletableFuture.completedFuture(null))
                             .onItem().ifNull().failWith(new NullPointerException()))
-                    .merge()
+                    .concatenate(false)
                     .collect().asList()
                     .subscribeAsCompletionStage();
             Await.await(cancelled);

--- a/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/MultiConcatMapNoPrefetchTckTest.java
+++ b/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/MultiConcatMapNoPrefetchTckTest.java
@@ -1,0 +1,147 @@
+package io.smallrye.mutiny.tcktests;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.Multi;
+
+public class MultiConcatMapNoPrefetchTckTest extends AbstractPublisherTck<Long> {
+
+    private ScheduledExecutorService executor;
+
+    @BeforeTest
+    public void init() {
+        executor = Executors.newScheduledThreadPool(4);
+    }
+
+    @AfterTest
+    public void shutdown() {
+        executor.shutdown();
+    }
+
+    public ScheduledExecutorService getExecutor() {
+        return executor;
+    }
+
+    @Test
+    public void flatMapStageShouldMapElements() {
+
+        Assert.assertEquals(Await.await(Multi.createFrom().items(1, 2, 3)
+                .emitOn(executor)
+                .onItem().transformToMulti(n -> Multi.createFrom().items(n, n, n))
+                .concatenate(false)
+                .collect().asList()
+                .subscribeAsCompletionStage()), Arrays.asList(1, 1, 1, 2, 2, 2, 3, 3, 3));
+    }
+
+    @Test
+    public void flatMapStageShouldAllowEmptySubStreams() {
+        Assert.assertEquals(Await.await(Multi.createFrom().items(Multi.createFrom().empty(), Multi.createFrom().items(1, 2))
+                .onItem().transformToMulti(Function.identity())
+                .concatenate(false)
+                .collect().asList()
+                .subscribeAsCompletionStage()), Arrays.asList(1, 2));
+    }
+
+    @Test
+    public void flatMapStageShouldHandleExceptions() {
+        Assert.assertThrows(QuietRuntimeException.class, () -> {
+            CompletableFuture<Void> cancelled = new CompletableFuture<>();
+            CompletionStage<List<Object>> result = infiniteStream()
+                    .onTermination().invoke((f, c) -> {
+                        if (c) {
+                            cancelled.complete(null);
+                        }
+                    })
+                    .onItem().transformToMulti(foo -> {
+                        throw new QuietRuntimeException("failed");
+                    })
+                    .concatenate(false)
+                    .collect().asList()
+                    .subscribeAsCompletionStage();
+            Await.await(cancelled);
+            Await.await(result);
+        });
+    }
+
+    @Test
+    public void flatMapStageShouldPropagateUpstreamExceptions() {
+        Assert.assertThrows(QuietRuntimeException.class,
+                () -> Await.await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
+                        .onItem().transformToMulti(x -> Multi.createFrom().item(x))
+                        .concatenate(false)
+                        .collect().asList()
+                        .subscribeAsCompletionStage()));
+    }
+
+    @Test
+    public void flatMapStageShouldPropagateSubstreamExceptions() {
+        Assert.assertThrows(QuietRuntimeException.class, () -> {
+            CompletableFuture<Void> cancelled = new CompletableFuture<>();
+            CompletionStage<List<Object>> result = infiniteStream()
+                    .onTermination().invoke(() -> cancelled.complete(null))
+                    .onItem().transformToMulti(f -> Multi.createFrom().failure(new QuietRuntimeException("failed")))
+                    .concatenate(false)
+                    .collect().asList()
+                    .subscribeAsCompletionStage();
+            Await.await(cancelled);
+            Await.await(result);
+        });
+    }
+
+    @Test
+    public void concatMapStageShouldOnlySubscribeToOnePublisherAtATime() throws Exception {
+        AtomicInteger activePublishers = new AtomicInteger();
+
+        CompletionStage<List<Integer>> result = Multi.createFrom().items(1, 2, 3, 4, 5)
+                .onItem().transformToMulti(id -> Multi.createFrom()
+                        .publisher(new ScheduledPublisher(id, activePublishers, this::getExecutor)))
+                .concatenate(false)
+                .collect().asList()
+                .subscribeAsCompletionStage();
+
+        Assert.assertEquals(result.toCompletableFuture().get(2, TimeUnit.SECONDS),
+                Arrays.asList(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void flatMapStageShouldPropagateCancelToSubstreams() {
+        CompletableFuture<Void> outerCancelled = new CompletableFuture<>();
+        CompletableFuture<Void> innerCancelled = new CompletableFuture<>();
+        Await.await(infiniteStream()
+                .onTermination().invoke(() -> outerCancelled.complete(null))
+                .onItem().transformToMulti(i -> infiniteStream().onTermination().invoke(() -> innerCancelled.complete(null)))
+                .concatenate(false)
+                .select().first(5)
+                .collect().asList()
+                .subscribeAsCompletionStage());
+
+        Await.await(outerCancelled);
+        Await.await(innerCancelled);
+    }
+
+    @Override
+    public org.reactivestreams.Publisher<Long> createPublisher(long elements) {
+        return upstream(elements)
+                .concatMap(x -> Multi.createFrom().item(x));
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        return failedUpstream()
+                .concatMap(x -> Multi.createFrom().item(x));
+    }
+}


### PR DESCRIPTION
Backport of #997 to 1.x branch.
ConcatMap methods default to the previous implementation of prefetching.