### PR TITLE
Revert "Bump testng from 7.5 to 7.6.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <junit4.version>4.13.2</junit4.version>
         <awaitility.version>4.2.0</awaitility.version>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
-        <testng.version>7.6.1</testng.version>
+        <testng.version>7.5</testng.version>
         <testng-junit5-engine.version>1.0.4</testng-junit5-engine.version>
         <mockito-core.version>4.7.0</mockito-core.version>
 


### PR DESCRIPTION
Reverts smallrye/smallrye-mutiny#1015 - this version of TestNG needs Java 11. 