### PR TITLE
Fix description of some operator shortcuts in Javadoc

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -323,7 +323,7 @@ public interface Multi<T> extends Publisher<T> {
      * <p>
      * Items that do not satisfy the predicate are discarded.
      * <p>
-     * This method is a shortcut for {@code multi.transform().byFilteringItemsWith(predicate)}.
+     * This method is a shortcut for {@code multi.select().where(predicate)}.
      *
      * @param predicate a predicate, must not be {@code null}
      * @return the new {@link Multi}

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -466,7 +466,7 @@ public interface Uni<T> {
      * {@link Uni} returned by this method.
      * <p>
      * This operation is generally named {@code flatMap}.
-     * This method is a shortcut on {@link UniOnItem#transformToUni(Function)} onItem().transformToUni(mapper)}.
+     * This method is a shortcut on {@link UniOnItem#transformToUni(Function)} {@code onItem().transformToUni(mapper)}.
      *
      * @param mapper the function called with the item of this {@link Uni} and producing the {@link Uni},
      *        must not be {@code null}, must not return {@code null}.
@@ -498,7 +498,7 @@ public interface Uni<T> {
      * {@link Uni} returned by this method.
      * <p>
      * This operation is generally named {@code flatMap}.
-     * This method is a shortcut for {@link UniOnItem#transformToUni(Function) onItem().transformToUni(mapper)}.
+     * This method is a shortcut for {@link UniOnItem#transformToUni(Function)} {@code onItem().transformToUni(mapper)}.
      *
      * @param mapper the function called with the item of this {@link Uni} and producing the {@link Uni},
      *        must not be {@code null}, must not return {@code null}.


### PR DESCRIPTION
The patch is obvious.