### PR TITLE
Hidden Subscription checkcast scalability issue (Fixes #1080)

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/UniCallbackSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/UniCallbackSubscriber.java
@@ -6,8 +6,6 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 
-import org.reactivestreams.Subscription;
-
 import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
@@ -57,8 +55,7 @@ public class UniCallbackSubscriber<T> implements UniSubscriber<T>, UniSubscripti
 
     @Override
     public final void onFailure(Throwable t) {
-        UniSubscription sub = SUBSCRIPTION_UPDATER.getAndSet(this, CANCELLED);
-        if (sub == CANCELLED) {
+        if (SUBSCRIPTION_UPDATER.getAndSet(this, CANCELLED) == CANCELLED) {
             // Already cancelled, do nothing
             return;
         }
@@ -67,8 +64,7 @@ public class UniCallbackSubscriber<T> implements UniSubscriber<T>, UniSubscripti
 
     @Override
     public final void onItem(T x) {
-        Subscription sub = SUBSCRIPTION_UPDATER.getAndSet(this, CANCELLED);
-        if (sub == CANCELLED) {
+        if (SUBSCRIPTION_UPDATER.getAndSet(this, CANCELLED) == CANCELLED) {
             // Already cancelled, do nothing
             return;
         }
@@ -82,8 +78,8 @@ public class UniCallbackSubscriber<T> implements UniSubscriber<T>, UniSubscripti
 
     @Override
     public void cancel() {
-        Subscription sub = SUBSCRIPTION_UPDATER.getAndSet(this, CANCELLED);
-        if (sub != null) {
+        UniSubscription sub = SUBSCRIPTION_UPDATER.getAndSet(this, CANCELLED);
+        if (sub != CANCELLED) {
             sub.cancel();
         }
     }


### PR DESCRIPTION
The bytecode of the original `UniCallbackSubscriber::onItem` method reports:
```java
  // access flags 0x11
  // signature (TT;)V
  // declaration: void onItem(T)
  public final onItem(Ljava/lang/Object;)V
    TRYCATCHBLOCK L0 L1 L2 java/lang/Throwable
   L3
    LINENUMBER 70 L3
    GETSTATIC io/smallrye/mutiny/helpers/UniCallbackSubscriber.SUBSCRIPTION_UPDATER : Ljava/util/concurrent/atomic/AtomicReferenceFieldUpdater;
    ALOAD 0
    GETSTATIC io/smallrye/mutiny/helpers/EmptyUniSubscription.CANCELLED : Lio/smallrye/mutiny/subscription/UniSubscription;
    INVOKEVIRTUAL java/util/concurrent/atomic/AtomicReferenceFieldUpdater.getAndSet (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
    CHECKCAST org/reactivestreams/Subscription
    ASTORE 2
   L4
    LINENUMBER 71 L4
    ALOAD 2
    GETSTATIC io/smallrye/mutiny/helpers/EmptyUniSubscription.CANCELLED : Lio/smallrye/mutiny/subscription/UniSubscription;
    IF_ACMPNE L0
   L5
    LINENUMBER 73 L5
    RETURN
   L0
    LINENUMBER 77 L0
   FRAME APPEND [org/reactivestreams/Subscription]
    ALOAD 0
    GETFIELD io/smallrye/mutiny/helpers/UniCallbackSubscriber.onResultCallback : Ljava/util/function/Consumer;
    ALOAD 1
    INVOKEINTERFACE java/util/function/Consumer.accept (Ljava/lang/Object;)V (itf)
   L1
    LINENUMBER 80 L1
    GOTO L6
   L2
    LINENUMBER 78 L2
   FRAME SAME1 java/lang/Throwable
    ASTORE 3
   L7
    LINENUMBER 79 L7
    ALOAD 3
    INVOKESTATIC io/smallrye/mutiny/infrastructure/Infrastructure.handleDroppedException (Ljava/lang/Throwable;)V
   L6
    LINENUMBER 81 L6
   FRAME SAME
    RETURN
   L8
    LOCALVARIABLE t Ljava/lang/Throwable; L7 L6 3
    LOCALVARIABLE this Lio/smallrye/mutiny/helpers/UniCallbackSubscriber; L3 L8 0
    // signature Lio/smallrye/mutiny/helpers/UniCallbackSubscriber<TT;>;
    // declaration: this extends io.smallrye.mutiny.helpers.UniCallbackSubscriber<T>
    LOCALVARIABLE x Ljava/lang/Object; L3 L8 1
    // signature TT;
    // declaration: x extends T
    LOCALVARIABLE sub Lorg/reactivestreams/Subscription; L4 L8 2
    MAXSTACK = 3
    MAXLOCALS = 4
```

which is hiding a `CHECKCAST org/reactivestreams/Subscription` at `getAndSet` return type:

```java
    @Override
    public final void onItem(T x) {
        Subscription sub = SUBSCRIPTION_UPDATER.getAndSet(this, CANCELLED);
        if (sub == CANCELLED) {
            // ... etc etc
```
It can be easily removed thanks to the `onItem` logic, that doesn't requires to use the type but just compare it vs `CANCELLED`.

Results of this change is:
```java
  // access flags 0x11
  // signature (TT;)V
  // declaration: void onItem(T)
  public final onItem(Ljava/lang/Object;)V
    TRYCATCHBLOCK L0 L1 L2 java/lang/Throwable
   L3
    LINENUMBER 69 L3
    GETSTATIC io/smallrye/mutiny/helpers/UniCallbackSubscriber.SUBSCRIPTION_UPDATER : Ljava/util/concurrent/atomic/AtomicReferenceFieldUpdater;
    ALOAD 0
    GETSTATIC io/smallrye/mutiny/helpers/EmptyUniSubscription.CANCELLED : Lio/smallrye/mutiny/subscription/UniSubscription;
    INVOKEVIRTUAL java/util/concurrent/atomic/AtomicReferenceFieldUpdater.getAndSet (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
    GETSTATIC io/smallrye/mutiny/helpers/EmptyUniSubscription.CANCELLED : Lio/smallrye/mutiny/subscription/UniSubscription;
    IF_ACMPNE L0
   L4
    LINENUMBER 71 L4
    RETURN
   L0
    LINENUMBER 75 L0
   FRAME SAME
    ALOAD 0
    GETFIELD io/smallrye/mutiny/helpers/UniCallbackSubscriber.onResultCallback : Ljava/util/function/Consumer;
    ALOAD 1
    INVOKEINTERFACE java/util/function/Consumer.accept (Ljava/lang/Object;)V (itf)
   L1
    LINENUMBER 78 L1
    GOTO L5
   L2
    LINENUMBER 76 L2
   FRAME SAME1 java/lang/Throwable
    ASTORE 2
   L6
    LINENUMBER 77 L6
    ALOAD 2
    INVOKESTATIC io/smallrye/mutiny/infrastructure/Infrastructure.handleDroppedException (Ljava/lang/Throwable;)V
   L5
    LINENUMBER 79 L5
   FRAME SAME
    RETURN
   L7
    LOCALVARIABLE t Ljava/lang/Throwable; L6 L5 2
    LOCALVARIABLE this Lio/smallrye/mutiny/helpers/UniCallbackSubscriber; L3 L7 0
    // signature Lio/smallrye/mutiny/helpers/UniCallbackSubscriber<TT;>;
    // declaration: this extends io.smallrye.mutiny.helpers.UniCallbackSubscriber<T>
    LOCALVARIABLE x Ljava/lang/Object; L3 L7 1
    // signature TT;
    // declaration: x extends T
    MAXSTACK = 3
    MAXLOCALS = 3
```
The `CHECKCAST` is disappeared, leaving `io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor` and
`io.smallrye.mutiny.operators.uni.UniOnSubscribeInvoke$UniOnSubscribeInvokeProcessor` to just deal with
`io.smallrye.mutiny.subscription.UniSubscriber` checkcast on `io.smallrye.mutiny.operators.uni.UniOperatorProcessor.<init>(UniOperatorProcessor.java:24)`, that would save ping-pong the `secondary super cache's Klass` value, as reported on https://github.com/smallrye/smallrye-mutiny/issues/1080    
    
