### PR TITLE
Multi overflow unbounded strategy was actually bounded

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOverflow.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOverflow.java
@@ -26,6 +26,18 @@ public class MultiOverflow<T> {
      * @return the new multi
      */
     @CheckReturnValue
+    public Multi<T> bufferUnconditionally() {
+        return new MultiOverflowStrategy<>(upstream, null, null).bufferUnconditionally();
+    }
+
+    /**
+     * When the downstream cannot keep up with the upstream emissions, instruct to use a <strong>bounded</strong>
+     * buffer of the default size to store the items until they are consumed.
+     *
+     * @return the new multi
+     * @see Infrastructure#setMultiOverflowDefaultBufferSize(int)
+     */
+    @CheckReturnValue
     public Multi<T> buffer() {
         return new MultiOverflowStrategy<>(upstream, null, null).buffer();
     }
@@ -65,7 +77,7 @@ public class MultiOverflow<T> {
 
     /**
      * Define an overflow callback.
-     * 
+     *
      * @param consumer the dropped item consumer, must not be {@code null}, must not return {@code null}
      * @return an object to select the overflow management strategy
      */

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOverflowStrategy.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOverflowStrategy.java
@@ -38,14 +38,15 @@ public class MultiOverflowStrategy<T> {
     }
 
     /**
-     * When the downstream cannot keep up with the upstream emissions, instruct to use an <strong>unbounded</strong>
-     * buffer to store the items until they are consumed.
+     * When the downstream cannot keep up with the upstream emissions, instruct to use a <strong>bounded</strong>
+     * buffer of the default size to store the items until they are consumed.
      *
      * @return the new multi
+     * @see Infrastructure#setMultiOverflowDefaultBufferSize(int)
      */
     @CheckReturnValue
     public Multi<T> buffer() {
-        return buffer(128);
+        return buffer(Infrastructure.getMultiOverflowDefaultBufferSize());
     }
 
     /**
@@ -60,6 +61,18 @@ public class MultiOverflowStrategy<T> {
     public Multi<T> buffer(int size) {
         return Infrastructure.onMultiCreation(new MultiOnOverflowBufferOp<>(upstream, positive(size, "size"),
                 false, dropConsumer, dropUniMapper));
+    }
+
+    /**
+     * When the downstream cannot keep up with the upstream emissions, instruct to use an <strong>unbounded</strong>
+     * buffer to store the items until they are consumed.
+     *
+     * @return the new multi
+     */
+    @CheckReturnValue
+    public Multi<T> bufferUnconditionally() {
+        return Infrastructure.onMultiCreation(new MultiOnOverflowBufferOp<>(upstream,
+                Infrastructure.getMultiOverflowDefaultBufferSize(), true, dropConsumer, dropUniMapper));
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/UniCallbackSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/UniCallbackSubscriber.java
@@ -3,7 +3,6 @@ package io.smallrye.mutiny.helpers;
 import static io.smallrye.mutiny.helpers.EmptyUniSubscription.CANCELLED;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
-import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 

--- a/implementation/src/main/java/io/smallrye/mutiny/infrastructure/Infrastructure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/infrastructure/Infrastructure.java
@@ -7,12 +7,28 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Subscriber;
-import java.util.function.*;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.LongConsumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.groups.MultiOverflowStrategy;
 import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.tuples.Functions;
@@ -48,11 +64,14 @@ public class Infrastructure {
     private static BooleanSupplier canCallerThreadBeBlockedSupplier;
     private static OperatorLogger operatorLogger = PrintOperatorEventOperatorLogger.INSTANCE;
 
+    private static int multiOverflowDefaultBufferSize = 128;
+
     public static void reload() {
         clearInterceptors();
         reloadUniInterceptors();
         reloadMultiInterceptors();
         reloadCallbackDecorators();
+        multiOverflowDefaultBufferSize = 128;
     }
 
     /**
@@ -391,6 +410,24 @@ public class Infrastructure {
     // For testing purpose only
     public static void resetOperatorLogger() {
         Infrastructure.operatorLogger = PrintOperatorEventOperatorLogger.INSTANCE;
+    }
+
+    /**
+     * Get the default overflow buffer size fpr {@link MultiOverflowStrategy#buffer()}.
+     *
+     * @return the default value
+     */
+    public static int getMultiOverflowDefaultBufferSize() {
+        return multiOverflowDefaultBufferSize;
+    }
+
+    /**
+     * Sets the default overflow buffer size fpr {@link MultiOverflowStrategy#buffer()}.
+     *
+     * @param size the buffer size, must be strictly positive
+     */
+    public static void setMultiOverflowDefaultBufferSize(int size) {
+        multiOverflowDefaultBufferSize = ParameterValidation.positive(size, "size");
     }
 
     /**

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/InfrastructureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/InfrastructureTest.java
@@ -1,0 +1,43 @@
+package io.smallrye.mutiny.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import junit5.support.InfrastructureResource;
+
+@ResourceLock(InfrastructureResource.NAME)
+class InfrastructureTest {
+
+    @AfterEach
+    void reset() {
+        Infrastructure.reload();
+    }
+
+    @Test
+    @DisplayName("Ensure Infrastructure.setMultiOverflowDefaultBufferSize rejects 0 buffer sizes")
+    void rejectZeroMultiOverflowBufferSizes() {
+        IllegalArgumentException err = assertThrows(IllegalArgumentException.class,
+                () -> Infrastructure.setMultiOverflowDefaultBufferSize(0));
+        assertThat(err).hasMessageContaining("must be greater than zero");
+    }
+
+    @Test
+    @DisplayName("Ensure Infrastructure.setMultiOverflowDefaultBufferSize rejects negative buffer sizes")
+    void rejectNegativeMultiOverflowBufferSizes() {
+        IllegalArgumentException err = assertThrows(IllegalArgumentException.class,
+                () -> Infrastructure.setMultiOverflowDefaultBufferSize(-100));
+        assertThat(err).hasMessageContaining("must be greater than zero");
+    }
+
+    @Test
+    @DisplayName("Ensure Infrastructure.setMultiOverflowDefaultBufferSize accepts correct buffer sizes")
+    void acceptCorrectMultiOverflowBufferSizes() {
+        Infrastructure.setMultiOverflowDefaultBufferSize(256);
+        assertThat(Infrastructure.getMultiOverflowDefaultBufferSize()).isEqualTo(256);
+    }
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnOverflowTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnOverflowTest.java
@@ -582,4 +582,36 @@ public class MultiOnOverflowTest {
 
         sub.assertFailedWith(RuntimeException.class, "boom :: 2");
     }
+
+    @Test
+    public void boundedOverflowBufferShallSignalOverflow() {
+        AssertSubscriber<Integer> sub = AssertSubscriber.create(1);
+        Multi.createFrom().range(1, 1000)
+                .onOverflow().buffer(20)
+                .subscribe(sub);
+
+        sub.assertFailedWith(BackPressureFailure.class);
+    }
+
+    @Test
+    public void defaultBoundedOverflowBufferShallSignalOverflow() {
+        AssertSubscriber<Integer> sub = AssertSubscriber.create(1);
+        Multi.createFrom().range(1, 1000)
+                .onOverflow().buffer()
+                .subscribe(sub);
+
+        sub.assertFailedWith(BackPressureFailure.class);
+    }
+
+    @Test
+    public void unboundedOverflowShallNotSignalOverflow() {
+        AssertSubscriber<Integer> sub = AssertSubscriber.create(1);
+        Multi.createFrom().range(1, 1000)
+                .onOverflow().bufferUnconditionally()
+                .subscribe(sub);
+
+        sub.assertNotTerminated();
+        sub.request(Long.MAX_VALUE);
+        sub.assertCompleted();
+    }
 }


### PR DESCRIPTION
- Fixed `multi.onOverflow().buffer()` to use an infrastructure-provided default buffer size
- Added `multi.onOverflow().bufferUnconditionally()` as an unbounded strategy
- Fixed the documentation
- Added a few tests

Fixes #1040
