### PR TITLE
Reduce flaky tests by increasing timeouts in CI

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/AssertSubscriber.java
@@ -1,6 +1,8 @@
 package io.smallrye.mutiny.helpers.test;
 
 import static io.smallrye.mutiny.helpers.test.AssertionHelper.*;
+import static java.lang.Integer.parseInt;
+import static java.time.Duration.ofSeconds;
 
 import java.time.Duration;
 import java.util.List;
@@ -26,8 +28,20 @@ public class AssertSubscriber<T> implements Subscriber<T>, ContextSupport {
 
     /**
      * The default timeout used by {@code await} method.
+     * <p>
+     * This static field is mutable, the authors assume that you know what you are doing if you ever feel like changing
+     * its value.
      */
-    public static Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
+    public static Duration DEFAULT_TIMEOUT;
+
+    /**
+     * Name of the environment variable for setting the default await methods timeout (in seconds).
+     */
+    public static final String DEFAULT_MUTINY_AWAIT_TIMEOUT = "DEFAULT_MUTINY_AWAIT_TIMEOUT";
+
+    static {
+        DEFAULT_TIMEOUT = ofSeconds(parseInt(System.getenv().getOrDefault(DEFAULT_MUTINY_AWAIT_TIMEOUT, "10")));
+    }
 
     /**
      * Latch waiting for the completion or failure event.
@@ -401,7 +415,7 @@ public class AssertSubscriber<T> implements Subscriber<T>, ContextSupport {
      * Awaits for the subscriber to receive {@code number} items in total (including the ones received after calling
      * this method).
      * If not enough items have been received before the default timeout, an {@link AssertionError} is thrown.
-     *
+     * <p>
      * Unlike {@link #awaitNextItems(int, int)}, this method does not request items from the upstream.
      *
      * @param number the number of items to expect, must be neither 0 nor negative.
@@ -415,7 +429,7 @@ public class AssertSubscriber<T> implements Subscriber<T>, ContextSupport {
      * Awaits for the subscriber to receive {@code number} items in total (including the ones received after calling
      * this method).
      * If not enough items have been received before the given timeout, an {@link AssertionError} is thrown.
-     *
+     * <p>
      * Unlike {@link #awaitNextItems(int, int)}, this method does not requests items from the upstream.
      *
      * @param number the number of items to expect, must be neither 0 nor negative.

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/BlockingIterableTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/BlockingIterableTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
@@ -37,7 +36,6 @@ import junit5.support.InfrastructureResource;
 public class BlockingIterableTest {
 
     @Test
-    @Timeout(5)
     public void testToIterable() {
         List<Integer> values = new ArrayList<>();
 
@@ -53,7 +51,6 @@ public class BlockingIterableTest {
     }
 
     @Test
-    @Timeout(5)
     public void testToIterableWithBufferSizeAndSupplier() {
         Queue<Integer> q = new ArrayBlockingQueue<>(1);
         List<Integer> values = new ArrayList<>();
@@ -66,7 +63,6 @@ public class BlockingIterableTest {
     }
 
     @Test
-    @Timeout(5)
     public void testToIterableWithEmptyStream() {
         List<Integer> values = new ArrayList<>();
 
@@ -78,7 +74,6 @@ public class BlockingIterableTest {
     }
 
     @Test
-    @Timeout(5)
     public void testToIterableWithUpstreamFailure() {
         assertThrows(RuntimeException.class, () -> {
             List<Integer> values = new ArrayList<>();
@@ -93,7 +88,6 @@ public class BlockingIterableTest {
     }
 
     @Test
-    @Timeout(5)
     public void testToStream() {
         List<Integer> values = new ArrayList<>();
 
@@ -105,7 +99,6 @@ public class BlockingIterableTest {
     }
 
     @Test
-    @Timeout(5)
     public void testToStreamWithEmptyStream() {
         List<Integer> values = new ArrayList<>();
         Multi.createFrom().<Integer> empty().subscribe().asStream().forEach(values::add);
@@ -113,7 +106,6 @@ public class BlockingIterableTest {
     }
 
     @Test
-    @Timeout(5)
     public void testCancellationOnClose() {
         List<Integer> values = new ArrayList<>();
 
@@ -126,7 +118,6 @@ public class BlockingIterableTest {
     }
 
     @Test
-    @Timeout(5)
     public void testParallelStreamComputation() {
         int n = 10_000;
 
@@ -139,7 +130,6 @@ public class BlockingIterableTest {
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
-    @Timeout(1)
     public void testToStreamWithFailure() {
         Multi<Integer> multi = Multi.createFrom().<Integer> emitter(e -> e.emit(1).emit(0).complete())
                 .map(v -> 4 / v);
@@ -149,7 +139,6 @@ public class BlockingIterableTest {
     }
 
     @Test
-    @Timeout(1)
     public void testToIterableWithFailure() {
         Multi<Integer> multi = Multi.createFrom().<Integer> emitter(e -> e.emit(1).emit(0).complete())
                 .map(v -> 4 / v);
@@ -159,7 +148,6 @@ public class BlockingIterableTest {
     }
 
     @Test
-    @Timeout(1)
     public void testToIterableWithCheckedFailure() {
         Multi<Integer> multi = Multi.createFrom().emitter(e -> e.emit(1).emit(0).fail(new IOException("boom")));
 
@@ -170,7 +158,6 @@ public class BlockingIterableTest {
     }
 
     @Test
-    @Timeout(1)
     public void testQueueSupplierFailing() {
         assertThatThrownBy(() -> Multi.createFrom().items(1, 2, 3, 4, 5, 6)
                 .subscribe().asIterable(10, () -> {
@@ -182,7 +169,6 @@ public class BlockingIterableTest {
     }
 
     @Test
-    @Timeout(1)
     public void testQueueSupplierReturningNull() {
         assertThatThrownBy(() -> Multi.createFrom().items(1, 2, 3, 4, 5, 6)
                 .subscribe().asIterable(10, () -> null).forEach(i -> {

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromTimePeriodTest.java
@@ -11,7 +11,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
@@ -105,7 +104,6 @@ public class MultiCreateFromTimePeriodTest {
     }
 
     @Test
-    @Timeout(1)
     public void testBackPressureOverflow() {
         AssertSubscriber<Long> subscriber = AssertSubscriber.create();
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIfNoItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIfNoItemTest.java
@@ -11,7 +11,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
@@ -83,7 +82,6 @@ public class MultiIfNoItemTest {
     }
 
     @Test
-    @Timeout(2)
     public void testFailureBeforeTimeout() {
         AtomicBoolean subscribed = new AtomicBoolean(false);
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToMultiTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiTransformToMultiTest.java
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
@@ -70,7 +69,6 @@ public class MultiTransformToMultiTest {
     }
 
     @Test
-    @Timeout(60)
     public void testConcatMapWithLotsOfItems() {
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
@@ -81,7 +79,7 @@ public class MultiTransformToMultiTest {
                 .subscribe(subscriber);
 
         subscriber
-                .await(Duration.ofSeconds(60))
+                .awaitCompletion(Duration.ofMinutes(5))
                 .assertCompleted();
 
         int current = 0;
@@ -92,7 +90,6 @@ public class MultiTransformToMultiTest {
     }
 
     @Test
-    @Timeout(60)
     public void testConcatMapWithLotsOfItemsAndFailurePropagation() {
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
@@ -103,7 +100,7 @@ public class MultiTransformToMultiTest {
                 .subscribe(subscriber);
 
         subscriber
-                .await(Duration.ofSeconds(60))
+                .awaitCompletion(Duration.ofMinutes(5))
                 .assertCompleted();
 
         int current = 0;
@@ -114,7 +111,6 @@ public class MultiTransformToMultiTest {
     }
 
     @Test
-    @Timeout(60)
     public void testConcatMapWithLotsOfItemsAndFailuresAndFailurePropagation() {
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
@@ -131,7 +127,7 @@ public class MultiTransformToMultiTest {
                 .subscribe(subscriber);
 
         subscriber
-                .await(Duration.ofSeconds(60))
+                .awaitFailure(Duration.ofMinutes(5))
                 .assertFailedWith(CompositeException.class, "boom");
 
         assertThat(subscriber.getItems().size()).isEqualTo(100_000 - 2);
@@ -143,7 +139,6 @@ public class MultiTransformToMultiTest {
     }
 
     @Test
-    @Timeout(60)
     public void testConcatMapWithLotsOfItemsAndFailuresWithoutFailurePropagation() {
         AssertSubscriber<Integer> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
 
@@ -159,7 +154,7 @@ public class MultiTransformToMultiTest {
                 .subscribe(subscriber);
 
         subscriber
-                .await(Duration.ofSeconds(60))
+                .awaitFailure(Duration.ofMinutes(5))
                 .assertFailedWith(IllegalArgumentException.class, "boom");
 
         assertThat(subscriber.getItems().size()).isEqualTo(99000 - 1);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
@@ -25,7 +25,7 @@ import junit5.support.InfrastructureResource;
 public class UniAwaitTest {
 
     @Test
-    @Timeout(1)
+    @Timeout(10)
     public void testAwaitingOnAnAlreadyResolvedUni() {
         assertThat(Uni.createFrom().item(1).await().indefinitely()).isEqualTo(1);
     }
@@ -132,7 +132,7 @@ public class UniAwaitTest {
     }
 
     @Test
-    @Timeout(1)
+    @Timeout(10)
     public void testTimeoutAndOptional() {
         assertThrows(TimeoutException.class,
                 () -> Uni.createFrom().nothing().await().asOptional().atMost(Duration.ofMillis(10)));

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniIfNoItemTest.java
@@ -10,7 +10,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
@@ -67,7 +66,6 @@ public class UniIfNoItemTest {
     }
 
     @Test
-    @Timeout(2)
     public void testFailureBeforeTimeout() {
         UniAssertSubscriber<Integer> subscriber = UniAssertSubscriber.create();
 

--- a/implementation/src/test/java/junit5/support/AwaitilityConfigurationExtension.java
+++ b/implementation/src/test/java/junit5/support/AwaitilityConfigurationExtension.java
@@ -7,6 +7,8 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+
 /**
  * Make sure Awaitility is configured with "sane" defaults.
  */
@@ -17,6 +19,7 @@ public class AwaitilityConfigurationExtension implements BeforeAllCallback {
         Awaitility.catchUncaughtExceptionsByDefault();
         Awaitility.setDefaultPollInterval(Duration.of(200, ChronoUnit.MILLIS));
         Awaitility.setDefaultPollDelay(Duration.of(50, ChronoUnit.MILLIS));
+        Awaitility.setDefaultTimeout(AssertSubscriber.DEFAULT_TIMEOUT);
         Awaitility.pollInSameThread();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -474,12 +474,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <environmentVariables>
-                                <!-- Mutiny -->
                                 <DEFAULT_MUTINY_AWAIT_TIMEOUT>120</DEFAULT_MUTINY_AWAIT_TIMEOUT>
-                                <!-- Reactive Streams TCK -->
-                                <DEFAULT_TIMEOUT_MILLIS>1500</DEFAULT_TIMEOUT_MILLIS>
-                                <DEFAULT_NO_SIGNALS_TIMEOUT_MILLIS>1500</DEFAULT_NO_SIGNALS_TIMEOUT_MILLIS>
-                                <DEFAULT_POLL_TIMEOUT_MILLIS_ENV>100</DEFAULT_POLL_TIMEOUT_MILLIS_ENV>
                             </environmentVariables>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-build-parent</artifactId>
-        <version>37</version>
+        <version>36</version>
     </parent>
 
     <groupId>io.smallrye.reactive</groupId>
@@ -81,10 +81,10 @@
         <rxjava3.version>3.1.5</rxjava3.version>
         <reactor-core.version>3.4.24</reactor-core.version>
 
-        <microprofile-reactive-streams.version>3.0</microprofile-reactive-streams.version>
+        <microprofile-reactive-streams.version>2.0</microprofile-reactive-streams.version>
         <microprofile-context-propagation.version>1.3</microprofile-context-propagation.version>
-        <smallrye-context-propagation.version>2.0.0</smallrye-context-propagation.version>
-        <smallrye-config.version>3.0.0</smallrye-config.version>
+        <smallrye-context-propagation.version>1.2.2</smallrye-context-propagation.version>
+        <smallrye-config.version>1.10.0</smallrye-config.version>
         <smallrye-common-annotation.version>2.0.0</smallrye-common-annotation.version>
 
         <junit.version>5.9.1</junit.version>
@@ -453,6 +453,34 @@
                             <source>11</source>
                             <release>11</release>
                             <detectJavaApiLink>false</detectJavaApiLink>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>running-in-ci</id>
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <environmentVariables>
+                                <!-- Mutiny -->
+                                <DEFAULT_MUTINY_AWAIT_TIMEOUT>120</DEFAULT_MUTINY_AWAIT_TIMEOUT>
+                                <!-- Reactive Streams TCK -->
+                                <DEFAULT_TIMEOUT_MILLIS>1500</DEFAULT_TIMEOUT_MILLIS>
+                                <DEFAULT_NO_SIGNALS_TIMEOUT_MILLIS>1500</DEFAULT_NO_SIGNALS_TIMEOUT_MILLIS>
+                                <DEFAULT_POLL_TIMEOUT_MILLIS_ENV>100</DEFAULT_POLL_TIMEOUT_MILLIS_ENV>
+                            </environmentVariables>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
- GitHub Action expose a `CI=true` environment variable
- A few JUnit tests had useless hard-coded timeouts
-  Some long running tests have seen explicit timeouts increased to accomodate slow runners

Note: this has been tested across multiple runs in a tiny sized QEmu Linux VM.
