### PR TITLE
Avoid type cache pollution on parameter validation in UniOperatorProcessor

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOperatorProcessor.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOperatorProcessor.java
@@ -20,8 +20,9 @@ public abstract class UniOperatorProcessor<I, O> implements UniSubscriber<I>, Un
 
     private volatile UniSubscription upstream;
 
-    public UniOperatorProcessor(UniSubscriber<? super O> downstream) {
-        this.downstream = ParameterValidation.nonNull(downstream, "downstream");
+    public UniOperatorProcessor(final UniSubscriber<? super O> downstream) {
+        ParameterValidation.nonNull(downstream, "downstream");
+        this.downstream = downstream;
     }
 
     @Override


### PR DESCRIPTION
Fixes #1112

The problem with the type checks was in the implied check on the return type compatibility of the `ParameterValidation.nonNull` method: it being generic, a check is necessary - normally this would be extremely cheap and negligible but in this case we better avoid assigning the returned reference.

cc/ @jponge 