### PR TITLE
Fix typo in Javadoc of UniCombine.any()

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniCombine.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniCombine.java
@@ -22,8 +22,8 @@ public class UniCombine {
      * of these competing unis. If the passed iterable is empty, the resulting {@link Uni} gets a {@code null} item
      * just after subscription.
      * <p>
-     * This method subscribes to the set of {@link Uni}. When one of the {@link Uni} fires an item or a failure
-     * a failure, the event is propagated downstream. Also the other subscriptions are cancelled.
+     * This method subscribes to the set of {@link Uni}. When one of the {@link Uni} fires an item or a failure,
+     * the event is propagated downstream. Also the other subscriptions are cancelled.
      * <p>
      * Note that the callback from the subscriber are called on the thread used to fire the event of the selected
      * {@link Uni}. Use {@link Uni#emitOn(Executor)} to change that thread.


### PR DESCRIPTION
Remove the duplicated "a failure" in "... fires an item or a failure a failure, ...".