### PR TITLE
When using Multi.createFrom().publisher and Multi.createFrom().safePublisher, return that Multi

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
@@ -147,6 +147,8 @@ public class MultiCreate {
      * the requests. Note that each Multi's subscriber would produce a new subscription.
      * <p>
      * If the Multi's observer cancels its subscription, the subscription to the {@link Publisher} is also cancelled.
+     * <p>
+     * If a {@code Multi} is passed as parameter, this {@code Multi} is returned.
      *
      * @param publisher the publisher, must not be {@code null}
      * @param <T> the type of item
@@ -156,6 +158,11 @@ public class MultiCreate {
     @CheckReturnValue
     public <T> Multi<T> safePublisher(Publisher<T> publisher) {
         Publisher<T> actual = nonNull(publisher, "publisher");
+
+        if (publisher instanceof Multi) {
+            // Should not call onMultiCreation - it should have been done already.
+            return (Multi<T>) publisher;
+        }
 
         return Infrastructure.onMultiCreation(new AbstractMulti<T>() {
             @Override
@@ -176,6 +183,8 @@ public class MultiCreate {
      * the requests. Note that each Multi's subscriber would produce a new subscription.
      * <p>
      * If the Multi's observer cancels its subscription, the subscription to the {@link Publisher} is also cancelled.
+     * <p>
+     * If a {@code Multi} is passed as parameter, this {@code Multi} is returned.
      *
      * @param publisher the publisher, must not be {@code null}
      * @param <T> the type of item
@@ -185,6 +194,11 @@ public class MultiCreate {
     @CheckReturnValue
     public <T> Multi<T> publisher(Publisher<T> publisher) {
         Publisher<T> actual = nonNull(publisher, "publisher");
+
+        if (publisher instanceof Multi) {
+            // Should not call onMultiCreation - it should have been done already.
+            return (Multi<T>) publisher;
+        }
 
         return Infrastructure.onMultiCreation(new AbstractMulti<T>() {
             @Override


### PR DESCRIPTION
This optimization avoids rewrapping the Multi, using a wrapper subscriber, and skipping the onMultiCreation callback.