### PR TITLE
When using `Multi.createFrom().publisher` and `Multi.createFrom().safePublisher` with a Multi, return that Multi directly

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
@@ -142,6 +142,8 @@ public class MultiCreate {
      * the requests. Note that each Multi's subscriber would produce a new subscription.
      * <p>
      * If the Multi's observer cancels its subscription, the subscription to the {@link Publisher} is also cancelled.
+     * <p>
+     * If a {@code Multi} is passed as parameter, this {@code Multi} is returned.
      *
      * @param publisher the publisher, must not be {@code null}
      * @param <T> the type of item
@@ -151,6 +153,11 @@ public class MultiCreate {
     @CheckReturnValue
     public <T> Multi<T> safePublisher(Publisher<T> publisher) {
         Publisher<T> actual = nonNull(publisher, "publisher");
+
+        if (publisher instanceof Multi) {
+            // Should not call onMultiCreation - it should have been done already.
+            return (Multi<T>) publisher;
+        }
 
         return Infrastructure.onMultiCreation(new AbstractMulti<T>() {
             @Override
@@ -171,6 +178,8 @@ public class MultiCreate {
      * the requests. Note that each Multi's subscriber would produce a new subscription.
      * <p>
      * If the Multi's observer cancels its subscription, the subscription to the {@link Publisher} is also cancelled.
+     * <p>
+     * If a {@code Multi} is passed as parameter, this {@code Multi} is returned.
      *
      * @param publisher the publisher, must not be {@code null}
      * @param <T> the type of item
@@ -180,6 +189,11 @@ public class MultiCreate {
     @CheckReturnValue
     public <T> Multi<T> publisher(Publisher<T> publisher) {
         Publisher<T> actual = nonNull(publisher, "publisher");
+
+        if (publisher instanceof Multi) {
+            // Should not call onMultiCreation - it should have been done already.
+            return (Multi<T>) publisher;
+        }
 
         return Infrastructure.onMultiCreation(new AbstractMulti<T>() {
             @Override

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromPublisherTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromPublisherTest.java
@@ -23,6 +23,13 @@ public class MultiCreateFromPublisherTest {
     }
 
     @Test
+    public void testThatPassingMultiReturnIt() {
+        Multi<String> multi = Multi.createFrom().item("a");
+        assertThat(multi).isSameAs(Multi.createFrom().publisher(multi));
+        assertThat(multi).isSameAs(Multi.createFrom().safePublisher(multi));
+    }
+
+    @Test
     public void testWithFailedPublisher() {
         AssertSubscriber<String> subscriber = Multi.createFrom().<String> publisher(
                 AdaptersToFlow.publisher(Flowable.error(new IOException("boom")))).subscribe()
@@ -120,6 +127,103 @@ public class MultiCreateFromPublisherTest {
         Flowable<Integer> flowable = Flowable.just(1, 2, 3, 4).doOnCancel(() -> cancellation.set(true));
 
         Multi<Integer> multi = Multi.createFrom().publisher(AdaptersToFlow.publisher(flowable));
+
+        multi.subscribe().withSubscriber(AssertSubscriber.create()).assertHasNotReceivedAnyItem()
+                .request(2)
+                .assertItems(1, 2)
+                .run(() -> assertThat(cancellation).isFalse())
+                .request(1)
+                .assertItems(1, 2, 3)
+                .cancel()
+                .request(1)
+                .assertItems(1, 2, 3)
+                .assertNotTerminated();
+
+        assertThat(cancellation).isTrue();
+    }
+
+    @Test
+    public void testWithMultiPassedInPublisher() {
+        AtomicLong requests = new AtomicLong();
+        AtomicInteger count = new AtomicInteger();
+        Multi<Integer> publisher = Multi.createFrom().deferred(() -> {
+            count.incrementAndGet();
+            return Multi.createFrom().items(1, 2, 3, 4);
+        }).onRequest().invoke(requests::addAndGet);
+
+        Multi<Integer> multi = Multi.createFrom().publisher(publisher);
+
+        multi.subscribe().withSubscriber(AssertSubscriber.create()).assertHasNotReceivedAnyItem()
+                .request(2)
+                .assertItems(1, 2)
+                .run(() -> assertThat(requests).hasValue(2))
+                .request(1)
+                .assertItems(1, 2, 3)
+                .request(1)
+                .assertItems(1, 2, 3, 4)
+                .run(() -> assertThat(requests).hasValue(4))
+                .assertCompleted();
+
+        assertThat(count).hasValue(1);
+
+        multi.subscribe().withSubscriber(AssertSubscriber.create()).assertHasNotReceivedAnyItem()
+                .request(2)
+                .assertItems(1, 2)
+                .request(1)
+                .assertItems(1, 2, 3)
+                .request(1)
+                .assertItems(1, 2, 3, 4)
+                .run(() -> assertThat(requests).hasValue(8))
+                .assertCompleted();
+
+        assertThat(count).hasValue(2);
+
+    }
+
+    @Test
+    public void testWithMultiPassedInSafePublisher() {
+        AtomicLong requests = new AtomicLong();
+        AtomicInteger count = new AtomicInteger();
+        Multi<Integer> publisher = Multi.createFrom().deferred(() -> {
+            count.incrementAndGet();
+            return Multi.createFrom().items(1, 2, 3, 4);
+        }).onRequest().invoke(requests::addAndGet);
+
+        Multi<Integer> multi = Multi.createFrom().safePublisher(publisher);
+
+        multi.subscribe().withSubscriber(AssertSubscriber.create()).assertHasNotReceivedAnyItem()
+                .request(2)
+                .assertItems(1, 2)
+                .run(() -> assertThat(requests).hasValue(2))
+                .request(1)
+                .assertItems(1, 2, 3)
+                .request(1)
+                .assertItems(1, 2, 3, 4)
+                .run(() -> assertThat(requests).hasValue(4))
+                .assertCompleted();
+
+        assertThat(count).hasValue(1);
+
+        multi.subscribe().withSubscriber(AssertSubscriber.create()).assertHasNotReceivedAnyItem()
+                .request(2)
+                .assertItems(1, 2)
+                .request(1)
+                .assertItems(1, 2, 3)
+                .request(1)
+                .assertItems(1, 2, 3, 4)
+                .run(() -> assertThat(requests).hasValue(8))
+                .assertCompleted();
+
+        assertThat(count).hasValue(2);
+
+    }
+
+    @Test
+    public void testThatCancellingTheMultiCancelTheMultiPassedInTheCreation() {
+        AtomicBoolean cancellation = new AtomicBoolean();
+        Multi<Integer> other = Multi.createFrom().items(1, 2, 3, 4).onCancellation().invoke(() -> cancellation.set(true));
+
+        Multi<Integer> multi = Multi.createFrom().publisher(other);
 
         multi.subscribe().withSubscriber(AssertSubscriber.create()).assertHasNotReceivedAnyItem()
                 .request(2)


### PR DESCRIPTION
This optimization avoids rewrapping the Multi, using wrapped subscribers and also skips `onMultiCreation` callback.

(cherry picked from commit 699ae6e19bf0668621a5425c2261cfc0ecdbfdd4)