### PR TITLE
Report concurrent onNext signals in HalfSerializer

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/HalfSerializer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/HalfSerializer.java
@@ -36,6 +36,10 @@ public final class HalfSerializer {
                     subscriber.onComplete();
                 }
             }
+        } else {
+            IllegalStateException err = new IllegalStateException(
+                    "HalfSerializer has detected concurrent onNext(item) signals which is not permitted by the Reactive Streams protocol");
+            onError(subscriber, err, wip, container);
         }
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/HalfSerializerTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/HalfSerializerTest.java
@@ -59,7 +59,7 @@ public class HalfSerializerTest {
         Subscription subscription = mock(Subscription.class);
         s.onSubscribe(subscription);
         HalfSerializer.onNext(s, 1, wip, failure);
-        test.assertItems(1).assertNotTerminated();
+        test.assertItems(1).assertFailedWith(IllegalStateException.class, "concurrent onNext(item) signals");
     }
 
     @Test


### PR DESCRIPTION
Such concurrent signals are a violation of the Reactive Streams protocol.