### PR TITLE
Remove reference to the `then` shortcut

### DIFF
--- a/documentation/docs/guides/shortcut-methods.md
+++ b/documentation/docs/guides/shortcut-methods.md
@@ -33,7 +33,6 @@ The following table lists the available shortcuts available by the `Uni` class:
 | `uni.map(x -> y)`                                        | `uni.onItem().transform(x -> y)`                                                                    |
 | `uni.flatMap(x -> uni2)`                                 | `uni.onItem().transformToUni(x -> uni2)`                                                            |
 | `uni.chain(x -> uni2)`                                   | `uni.onItem().transformToUni(x -> uni2)`                                                            |
-| `uni.then(() -> uni2)`                                   | `uni.onItem().transformToUni(ignored -> uni2)`                                                      |
 | `uni.invoke(x -> System.out.println(x))`                 | `uni.onItem().invoke(x -> System.out.println(x))`                                                   |
 | `uni.call(x -> uni2)`                                    | `uni.onItem().call(x -> uni2)`                                                                      |
 | `uni.eventually(() -> System.out.println("eventually"))` | `uni.onItemOrFailure().invoke((ignoredItem, ignoredException) -> System.out.println("eventually"))` |

--- a/implementation/src/main/java/io/smallrye/mutiny/Multi.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Multi.java
@@ -609,7 +609,7 @@ public interface Multi<T> extends Publisher<T> {
      * Cap all downstream subscriber requests to a maximum value.
      * <p>
      * This is a shortcut for:
-     * 
+     *
      * <pre>
      * multi.capDemandsUsing(outstanding -&gt; Math.min(outstanding, actual))
      * </pre>

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -533,7 +533,7 @@ public interface Uni<T> {
      * Session session = getSomeSession();
      * session.find(Fruit.class, id)
      *        .chain(fruit -> session.remove(fruit)
-     *        .then(() -> session.flush())
+     *        .chain(ignored -> session.flush())
      *        .eventually(() -> session.close());
      * }
      * </pre>

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/GeneratorEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/GeneratorEmitter.java
@@ -16,14 +16,14 @@ public interface GeneratorEmitter<T> {
 
     /**
      * Emit an item.
-     * 
+     *
      * @param item the item
      */
     void emit(T item);
 
     /**
      * Emit a failure and terminate the stream.
-     * 
+     *
      * @param failure the failure
      */
     void fail(Throwable failure);

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnFailure.java
@@ -27,7 +27,7 @@ import io.smallrye.mutiny.subscription.Cancellable;
  * retry ({@link #retry()}). Maybe, you just want to look at the failure ({@link #invoke(Consumer)}).
  * <p>
  * You can configure the type of failure on which your handler is called using:
- * 
+ *
  * <pre>
  * {@code
  * multi.onFailure(IOException.class).recoverWithItem("boom")

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnRequest.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnRequest.java
@@ -25,7 +25,7 @@ public class MultiOnRequest<T> {
      * Action when items are being requested.
      * The request is propagated upstream when the action has completed.
      * An error is forwarded downstream if the action throws an exception.
-     * 
+     *
      * @param consumer the action
      * @return the new {@link Multi}
      */

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnTerminate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnTerminate.java
@@ -55,7 +55,7 @@ public class MultiOnTerminate<T> {
     /**
      * Attaches an action that is executed when the {@link Multi} emits a completion or a failure or when the subscriber
      * cancels the subscription.
-     * 
+     *
      * @param mapper the function to execute where the first argument is a non-{@code null} exception on failure, and
      *        the second argument is a boolean which is {@code true} when the subscriber cancels the subscription.
      *        The function returns a {@link Uni} and must not be {@code null}.

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniCreate.java
@@ -159,7 +159,7 @@ public class UniCreate {
      * immediately after subscription. If it's not the case the callbacks of the subscriber are called on the thread used to
      * wait the result (a thread from the Mutiny infrastructure default executor).
      * <p>
-     * 
+     *
      * @param future the future, must not be {@code null}
      * @param <T> the type of item
      * @return the produced {@link Uni}

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniMemoize.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniMemoize.java
@@ -81,7 +81,7 @@ public class UniMemoize<T> {
 
     /**
      * Memoize the received item or failure indefinitely.
-     * 
+     *
      * @return a new {@link Uni}
      * @apiNote This is an experimental API
      */

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnFailure.java
@@ -25,7 +25,7 @@ import io.smallrye.mutiny.operators.uni.UniOnItemConsume;
  * ({@link #invoke(Consumer)}).
  * <p>
  * You can configure the type of failure on which your handler is called using:
- * 
+ *
  * <pre>
  * {@code
  * uni.onFailure(IOException.class).recoverWithItem("boom")

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnSubscribe.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniOnSubscribe.java
@@ -26,7 +26,7 @@ import io.smallrye.mutiny.subscription.UniSubscription;
  * uni.onSubscription().invoke(sub -> System.out.println("subscribed"));
  * // Delay the subscription by 1 second (or until an asynchronous action completes)
  * uni.onSubscription().call(sub -> Uni.createFrom(1).onItem().delayIt().by(Duration.ofSecond(1)));
- *}
+ * }
  * </pre>
  *
  * @param <T> the type of item

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/StrictMultiSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/StrictMultiSubscriber.java
@@ -21,7 +21,7 @@ import io.smallrye.mutiny.subscription.MultiSubscriber;
  * <li>3.9: negative requests should emit an onError(IllegalArgumentException)</li>
  * <li>2.12: onSubscribe must be called at most once (subscription cancelled and onError called)</li>
  * </ul>
- * 
+ *
  * @param <T> the type of item
  */
 public class StrictMultiSubscriber<T>

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/Queues.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/queues/Queues.java
@@ -72,7 +72,7 @@ public class Queues {
     /**
      * Returns an unbounded Queue.
      * The queue is array-backed. Each array has the given size. If the queue is full, new arrays can be allocated.
-     * 
+     *
      * @param size the size of the array
      * @param <T> the type of item
      * @return the unbound queue supplier
@@ -90,7 +90,7 @@ public class Queues {
 
     /**
      * Creates a new multi-producer single consumer unbounded queue.
-     * 
+     *
      * @param <T> the type of item
      * @return the queue
      */
@@ -100,7 +100,7 @@ public class Queues {
 
     /**
      * Create a queue of a strict fixed size.
-     * 
+     *
      * @param size the queue size
      * @param <T> the elements type
      * @return a new queue

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/spies/Spy.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/spies/Spy.java
@@ -24,7 +24,7 @@ public interface Spy {
 
     /**
      * Spy {@link Uni#onSubscription()} events.
-     * 
+     *
      * @param upstream the upstream
      * @param <T> the item type
      * @return a new {@link Uni}
@@ -195,7 +195,7 @@ public interface Spy {
 
     /**
      * Spy {@link Multi#onItem()} events and optionally keep track of the items.
-     * 
+     *
      * @param upstream the upstream
      * @param trackItems {@code true} when items shall be tracked, {@code false} otherwise
      * @param <T> the items type

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiConcatMapOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiConcatMapOp.java
@@ -271,7 +271,7 @@ public class MultiConcatMapOp<I, O> extends AbstractMultiOperator<I, O> {
         /**
          * Downstream passed as {@code null} to {@link SwitchableSubscriptionSubscriber} as accessors are not reachable.
          * Effective downstream is {@code parent}.
-         * 
+         *
          * @param parent parent as downstream
          */
         ConcatMapInner(ConcatMapMainSubscriber<?, O> parent) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiScanOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiScanOp.java
@@ -9,7 +9,7 @@ import io.smallrye.mutiny.subscription.MultiSubscriber;
 
 /**
  * Scan operator accumulating items of the same type as the upstream.
- * 
+ *
  * @param <T> the type of item
  */
 public final class MultiScanOp<T> extends AbstractMultiOperator<T, T> {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipFirstOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSkipFirstOp.java
@@ -23,7 +23,7 @@ public final class MultiSkipFirstOp<T> extends AbstractMultiOperator<T, T> {
     @Override
     public void subscribe(MultiSubscriber<? super T> actual) {
         if (numberOfItems == 0) {
-            // Pass-through 
+            // Pass-through
             upstream.subscribe(actual);
         } else {
             upstream.subscribe(new SkipFirstProcessor<>(actual, numberOfItems));

--- a/implementation/src/main/java/io/smallrye/mutiny/subscription/SafeSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/subscription/SafeSubscriber.java
@@ -49,7 +49,7 @@ public final class SafeSubscriber<T> implements Subscriber<T>, Subscription, Con
 
     /**
      * For testing purpose only.
-     * 
+     *
      * @return whether the subscriber is in a terminal state.
      */
     boolean isDone() {

--- a/implementation/src/test/java/io/smallrye/mutiny/converters/UniCreateFromTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/converters/UniCreateFromTest.java
@@ -48,7 +48,7 @@ public class UniCreateFromTest {
             throw new IllegalStateException("boom");
         })
                 .await().indefinitely()).isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("boom");
+                .hasMessageContaining("boom");
 
         AtomicInteger counter = new AtomicInteger();
         Uni<Integer> uni = Uni.createFrom().item(counter::incrementAndGet);
@@ -76,7 +76,7 @@ public class UniCreateFromTest {
             throw new IllegalStateException("boom");
         })
                 .await().indefinitely()).isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("boom");
+                .hasMessageContaining("boom");
 
         AtomicInteger counter = new AtomicInteger();
         Uni<Integer> uni = Uni.createFrom().failure(() -> new IllegalStateException("boom-" + counter.incrementAndGet()));

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/test/AbstractSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/test/AbstractSubscriberTest.java
@@ -148,12 +148,12 @@ public class AbstractSubscriberTest {
         assertThatThrownBy(() -> await()
                 .pollDelay(Duration.ofMillis(1))
                 .atMost(Duration.ofMillis(2)).untilAsserted(() -> subscriber.awaitFailure(DEFAULT_TIMEOUT)))
-                        .isInstanceOf(ConditionTimeoutException.class);
+                .isInstanceOf(ConditionTimeoutException.class);
 
         assertThatThrownBy(() -> await()
                 .pollDelay(Duration.ofMillis(1))
                 .atMost(Duration.ofMillis(2)).untilAsserted(subscriber::awaitCompletion))
-                        .isInstanceOf(ConditionTimeoutException.class);
+                .isInstanceOf(ConditionTimeoutException.class);
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/helpers/test/AssertSubscriberTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/helpers/test/AssertSubscriberTest.java
@@ -376,7 +376,7 @@ public class AssertSubscriberTest {
         assertThatThrownBy(() -> Multi.createFrom().<Integer> failure(new TestException())
                 .onFailure().call(() -> smallDelay)
                 .subscribe().withSubscriber(AssertSubscriber.create(1)).awaitCompletion()).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("failure");
+                .hasMessageContaining("failure");
     }
 
     @Test
@@ -439,28 +439,28 @@ public class AssertSubscriberTest {
         assertThatThrownBy(() -> Multi.createFrom().empty()
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItem()).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("completion").hasMessageContaining("item");
+                .hasMessageContaining("completion").hasMessageContaining("item");
 
         // Already failed
         assertThatThrownBy(() -> Multi.createFrom().failure(new TestException())
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItem()).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("failure").hasMessageContaining("item")
-                        .hasMessageContaining(TestException.class.getName());
+                .hasMessageContaining("failure").hasMessageContaining("item")
+                .hasMessageContaining(TestException.class.getName());
 
         // Completion instead of item
         assertThatThrownBy(() -> Multi.createFrom().empty()
                 .onCompletion().call(() -> smallDelay)
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItem(SMALL.multipliedBy(2))).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("completion").hasMessageContaining("item");
+                .hasMessageContaining("completion").hasMessageContaining("item");
 
         // Failure instead of item
         assertThatThrownBy(() -> Multi.createFrom().failure(new TestException())
                 .onFailure().call(() -> smallDelay)
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItem(SMALL.multipliedBy(2))).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("failure").hasMessageContaining("item");
+                .hasMessageContaining("failure").hasMessageContaining("item");
 
         // Item
         Multi.createFrom().items(1)
@@ -480,8 +480,8 @@ public class AssertSubscriberTest {
                 .onItem().call(() -> mediumDelay)
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItem(SMALL)).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("item")
-                        .hasMessageContaining(SMALL.toMillis() + " ms");
+                .hasMessageContaining("item")
+                .hasMessageContaining(SMALL.toMillis() + " ms");
     }
 
     @Test
@@ -490,50 +490,50 @@ public class AssertSubscriberTest {
         assertThatThrownBy(() -> Multi.createFrom().empty()
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItems(2)).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("completion").hasMessageContaining("item");
+                .hasMessageContaining("completion").hasMessageContaining("item");
 
         assertThatThrownBy(() -> Multi.createFrom().empty()
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItems(2, 1)).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("completion").hasMessageContaining("item");
+                .hasMessageContaining("completion").hasMessageContaining("item");
 
         assertThatThrownBy(() -> Multi.createFrom().empty()
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItems(2, 1, Duration.ofSeconds(1))).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("completion").hasMessageContaining("item");
+                .hasMessageContaining("completion").hasMessageContaining("item");
 
         // Already failed
         assertThatThrownBy(() -> Multi.createFrom().failure(new TestException())
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItems(2)).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("failure").hasMessageContaining("item")
-                        .hasMessageContaining(TestException.class.getName());
+                .hasMessageContaining("failure").hasMessageContaining("item")
+                .hasMessageContaining(TestException.class.getName());
 
         assertThatThrownBy(() -> Multi.createFrom().failure(new TestException())
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItems(2, 1)).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("failure").hasMessageContaining("item")
-                        .hasMessageContaining(TestException.class.getName());
+                .hasMessageContaining("failure").hasMessageContaining("item")
+                .hasMessageContaining(TestException.class.getName());
 
         assertThatThrownBy(() -> Multi.createFrom().failure(new TestException())
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItems(2, 1, Duration.ofSeconds(1))).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("failure").hasMessageContaining("item")
-                        .hasMessageContaining(TestException.class.getName());
+                .hasMessageContaining("failure").hasMessageContaining("item")
+                .hasMessageContaining(TestException.class.getName());
 
         // Completion instead of item
         assertThatThrownBy(() -> Multi.createFrom().emitter(e -> e.emit(1).complete())
                 .onCompletion().call(() -> smallDelay)
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItems(2, SMALL.multipliedBy(2))).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("completion").hasMessageContaining("item").hasMessageContaining("0");
+                .hasMessageContaining("completion").hasMessageContaining("item").hasMessageContaining("0");
 
         // Failure instead of item
         assertThatThrownBy(() -> Multi.createFrom().emitter(e -> e.emit(1).fail(new TestException()))
                 .onFailure().call(() -> smallDelay)
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitNextItems(2, SMALL.multipliedBy(2))).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("failure").hasMessageContaining("item").hasMessageContaining("0");
+                .hasMessageContaining("failure").hasMessageContaining("item").hasMessageContaining("0");
 
         // Item
         Multi.createFrom().items(1, 2, 3)
@@ -556,8 +556,8 @@ public class AssertSubscriberTest {
                 .emitOn(Infrastructure.getDefaultExecutor())
                 .subscribe().withSubscriber(AssertSubscriber.create(3))
                 .awaitNextItems(3, SMALL)).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("item")
-                        .hasMessageContaining(SMALL.toMillis() + " ms");
+                .hasMessageContaining("item")
+                .hasMessageContaining(SMALL.toMillis() + " ms");
     }
 
     @RepeatedTest(10)
@@ -566,27 +566,27 @@ public class AssertSubscriberTest {
         assertThatThrownBy(() -> Multi.createFrom().empty()
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitItems(2)).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("terminal").hasMessageContaining("item");
+                .hasMessageContaining("terminal").hasMessageContaining("item");
 
         // Already failed
         assertThatThrownBy(() -> Multi.createFrom().failure(new TestException())
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitItems(2)).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("terminal").hasMessageContaining("item");
+                .hasMessageContaining("terminal").hasMessageContaining("item");
 
         // Completion instead of item
         assertThatThrownBy(() -> Multi.createFrom().emitter(e -> e.emit(1).complete())
                 .onCompletion().call(() -> smallDelay)
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitItems(2, SMALL.multipliedBy(100))).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("completion").hasMessageContaining("item").hasMessageContaining("1");
+                .hasMessageContaining("completion").hasMessageContaining("item").hasMessageContaining("1");
 
         // Failure instead of item
         assertThatThrownBy(() -> Multi.createFrom().emitter(e -> e.emit(1).fail(new TestException()))
                 .onFailure().call(() -> smallDelay)
                 .subscribe().withSubscriber(AssertSubscriber.create(1))
                 .awaitItems(2, SMALL.multipliedBy(100))).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("failure").hasMessageContaining("item").hasMessageContaining("1");
+                .hasMessageContaining("failure").hasMessageContaining("item").hasMessageContaining("1");
 
         // Item
         Multi.createFrom().items(1, 2, 3)
@@ -609,20 +609,20 @@ public class AssertSubscriberTest {
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor())
                 .subscribe().withSubscriber(AssertSubscriber.create(3))
                 .awaitItems(3, SMALL)).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("item");
+                .hasMessageContaining("item");
 
         // Have received more items than expected.
         assertThatThrownBy(() -> Multi.createFrom().items(1, 2, 3)
                 .subscribe().withSubscriber(AssertSubscriber.create(3))
                 .awaitItems(2, SMALL)).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("item").hasMessageContaining("2").hasMessageContaining("3");
+                .hasMessageContaining("item").hasMessageContaining("2").hasMessageContaining("3");
 
         // Already Cancelled
         assertThatThrownBy(() -> Multi.createFrom().items(1, 2, 3)
                 .subscribe().withSubscriber(new AssertSubscriber<>(1, true))
                 .awaitItems(2, SMALL)).isInstanceOf(AssertionError.class)
-                        .hasMessageContaining("item").hasMessageContaining("2").hasMessageContaining("0")
-                        .hasMessageContaining("terminal");
+                .hasMessageContaining("item").hasMessageContaining("2").hasMessageContaining("0")
+                .hasMessageContaining("terminal");
 
         // Cancellation while waiting.
         assertThatThrownBy(() -> {
@@ -654,7 +654,7 @@ public class AssertSubscriberTest {
         assertThatThrownBy(
                 () -> Multi.createFrom().empty().subscribe().withSubscriber(AssertSubscriber.create(1))
                         .assertLastItem(1))
-                                .isInstanceOf(AssertionError.class);
+                .isInstanceOf(AssertionError.class);
 
         Multi.createFrom().items(1, 2, 3, 4)
                 .subscribe().withSubscriber(AssertSubscriber.create(2))

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
@@ -182,7 +182,7 @@ public class MultiGroupTest {
     public void testAsListsOnEmptyStream() {
         assertThat(
                 Multi.createFrom().empty().group().intoLists().of(2).collect().last().await().indefinitely())
-                        .isNull();
+                .isNull();
     }
 
     @Test
@@ -368,7 +368,7 @@ public class MultiGroupTest {
     public void testAsMultisOnEmptyStream() {
         assertThat(
                 Multi.createFrom().empty().group().intoMultis().of(2).collect().last().await().indefinitely())
-                        .isNull();
+                .isNull();
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnEventTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiOnEventTest.java
@@ -600,9 +600,9 @@ public class MultiOnEventTest {
                     return sub.onItem().invoke(c -> twoGotCalled.incrementAndGet());
                 })
                 .collect().asList().await().indefinitely())
-                        .isInstanceOf(CompletionException.class)
-                        .hasCauseInstanceOf(IOException.class)
-                        .hasMessageContaining("boom");
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(IOException.class)
+                .hasMessageContaining("boom");
 
         assertThat(twoGotCalled).hasValue(2);
         assertThat(res).hasValue(2);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipTest.java
@@ -294,9 +294,9 @@ public class MultiSkipTest {
         Multi<Integer> upstream2 = Multi.createFrom().failure(new TestException("boom"));
         new MultiSkipUntilOtherOp<>(Multi.createBy().concatenating().streams(upstream1, upstream2),
                 Multi.createFrom().item(0))
-                        .subscribe().withSubscriber(AssertSubscriber.create(10))
-                        .assertItems(1, 2, 3, 4, 5, 6)
-                        .assertFailedWith(TestException.class, "boom");
+                .subscribe().withSubscriber(AssertSubscriber.create(10))
+                .assertItems(1, 2, 3, 4, 5, 6)
+                .assertFailedWith(TestException.class, "boom");
     }
 
     @Test
@@ -309,7 +309,7 @@ public class MultiSkipTest {
 
         AssertSubscriber<Long> subscriber = new MultiSkipUntilOtherOp<>(upstream,
                 Multi.createFrom().nothing().onCancellation().invoke(() -> otherCancelled.set(true)))
-                        .subscribe().withSubscriber(AssertSubscriber.create(1));
+                .subscribe().withSubscriber(AssertSubscriber.create(1));
 
         subscriber.cancel();
         assertThat(upstreamCancelled).isTrue();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
@@ -52,7 +52,8 @@ public class UniAwaitTest {
     public void testAwaitingOnAnAsyncUni() {
         assertThat(
                 Uni.createFrom().emitter(emitter -> new Thread(() -> emitter.complete(1)).start()).await()
-                        .indefinitely()).isEqualTo(1);
+                        .indefinitely())
+                .isEqualTo(1);
     }
 
     @Test
@@ -103,7 +104,8 @@ public class UniAwaitTest {
     public void testAwaitAsOptionalWithResult() {
         assertThat(
                 Uni.createFrom().emitter(emitter -> new Thread(() -> emitter.complete(1)).start()).await().asOptional()
-                        .indefinitely()).contains(1);
+                        .indefinitely())
+                .contains(1);
     }
 
     @Test
@@ -121,14 +123,16 @@ public class UniAwaitTest {
     public void testAwaitAsOptionalWithNull() {
         assertThat(
                 Uni.createFrom().emitter(emitter -> new Thread(() -> emitter.complete(null)).start()).await()
-                        .asOptional().indefinitely()).isEmpty();
+                        .asOptional().indefinitely())
+                .isEmpty();
     }
 
     @Test
     public void testAwaitAsOptionalWithTimeout() {
         assertThat(
                 Uni.createFrom().emitter(emitter -> new Thread(() -> emitter.complete(1)).start()).await().asOptional()
-                        .atMost(Duration.ofMillis(1000))).contains(1);
+                        .atMost(Duration.ofMillis(1000)))
+                .contains(1);
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemFailWithTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniOnItemFailWithTest.java
@@ -94,7 +94,7 @@ public class UniOnItemFailWithTest {
         assertThatThrownBy(() -> one
                 .onItem().failWith(i -> new IOException("boom-" + i))
                 .await().indefinitely()).isInstanceOf(CompletionException.class).hasCauseInstanceOf(IOException.class)
-                        .hasMessageContaining("boom-1");
+                .hasMessageContaining("boom-1");
     }
 
     @Test
@@ -118,7 +118,7 @@ public class UniOnItemFailWithTest {
         assertThatThrownBy(() -> one
                 .onItem().failWith(() -> new IOException("boom"))
                 .await().indefinitely()).isInstanceOf(CompletionException.class).hasCauseInstanceOf(IOException.class)
-                        .hasMessageContaining("boom");
+                .hasMessageContaining("boom");
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
@@ -254,17 +254,17 @@ public class UniZipTest {
 
         assertThatThrownBy(
                 () -> Uni.combine().all().unis(uni1, uni2, uni3, failed, uni4).discardItems().await().indefinitely())
-                        .isInstanceOf(CompletionException.class)
-                        .hasCauseInstanceOf(IOException.class)
-                        .hasMessageContaining("boom");
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(IOException.class)
+                .hasMessageContaining("boom");
 
         Uni<Integer> failed2 = Uni.createFrom().failure(new IllegalStateException("d'oh"));
 
         assertThatThrownBy(
                 () -> Uni.combine().all().unis(uni1, uni2, uni3, failed, uni4, failed2).collectFailures().discardItems()
                         .await().indefinitely())
-                                .isInstanceOf(CompositeException.class)
-                                .hasMessageContaining("boom").hasMessageContaining("d'oh");
+                .isInstanceOf(CompositeException.class)
+                .hasMessageContaining("boom").hasMessageContaining("d'oh");
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedFunctionTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/unchecked/UncheckedFunctionTest.java
@@ -31,7 +31,7 @@ public class UncheckedFunctionTest {
                     }
                     return i;
                 })).await().indefinitely()).isInstanceOf(RuntimeException.class).hasCauseInstanceOf(IOException.class)
-                        .hasMessageContaining("boom");
+                .hasMessageContaining("boom");
 
         assertThatThrownBy(() -> Uni.createFrom().item(0)
                 .map(function(i -> {


### PR DESCRIPTION
Fix #1224

- Remove then from the shortcut list and from the javadoc
- Apply the new formatter.
