### PR TITLE
Update the impsort plugin to fix build with maven 3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <moditect-maven-plugin.version>1.0.0.RC2</moditect-maven-plugin.version>
         <jandex-maven-plugin.version>1.2.3</jandex-maven-plugin.version>
         <bnd-maven-plugin.version>6.4.0</bnd-maven-plugin.version>
+        <impsort.plugin.version>1.8.0</impsort.plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -386,6 +387,25 @@
                     <!-- Specify old version as the latest 1.x release -->
                     <oldVersion>1.8.0</oldVersion>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code</groupId>
+                <artifactId>impsort-maven-plugin</artifactId>
+                <version>${impsort.plugin.version}</version>
+                <configuration>
+                    <groups>java.,javax.,jakarta.,org.,com.</groups>
+                    <staticGroups>*</staticGroups>
+                    <skip>${format.skip}</skip>
+                    <removeUnused>true</removeUnused>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>sort-imports</id>
+                        <goals>
+                            <goal>sort</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
We cannot update the smallrye parent as it pulls the jakarta dependencies.