### PR TITLE
Remove failSeverity RevAPI XML configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,6 @@
                                 <goal>check</goal>
                             </goals>
                             <configuration>
-                                <failSeverity>breaking</failSeverity>
                                 <checkDependencies>false</checkDependencies>
                                 <analysisConfigurationFiles>
                                     <file>${project.basedir}/revapi.json</file>


### PR DESCRIPTION
failSeverity is deprecated and replaced with maximumCriticality.

However, renaming the XML tag results in an obscure error due to a conflict with the JSON settings. Removing that XML configuration fragments solves the issue.

Note: I have tested locally renaming a method in the public API and it got properly reported as breaking change.