### PR TITLE
Add isEmpty accessor to Multi Emitter buffer

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BufferItemMultiEmitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/BufferItemMultiEmitter.java
@@ -151,6 +151,13 @@ public class BufferItemMultiEmitter<T> extends BaseMultiEmitter<T> {
         } while (missed != 0);
     }
 
+    /**
+     * @return {@code true} if the emitter's buffer is empty
+     */
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+
     public static class EmitterBufferOverflowException extends BufferOverflowException {
 
         @Override


### PR DESCRIPTION
This commit adds a simple accessor to allow public view of the emitter's queue. 

I have a use case where I need to call emit() many times to deliver objects over reasteasy reactive, but my server's computation is happening so much faster than the reactive client-server communication that the Multi Emit buffer is causing my server to have out of memory issues. I would like to be able to block my server from processing more data until the current "batch" in the emit buffer has been emptied, and think having access to the queue's isEmpty() method is a fairly basic way to enable this and also other functionality.

However I am open to suggestions if there is perhaps a better/different/pre-existing way to do this 