### PR TITLE
Emit empty list when grouping item by time windows and no item in the window

### DIFF
--- a/implementation/revapi.json
+++ b/implementation/revapi.json
@@ -51,7 +51,15 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.mutiny.operators.multi.MultiBufferWithTimeoutOp<T>::<init>(io.smallrye.mutiny.Multi<T>, int, java.time.Duration, java.util.concurrent.ScheduledExecutorService)",
+        "new": "method void io.smallrye.mutiny.operators.multi.MultiBufferWithTimeoutOp<T>::<init>(io.smallrye.mutiny.Multi<T>, int, java.time.Duration, java.util.concurrent.ScheduledExecutorService, boolean)",
+        "justification": "New method adding the possibility to emit empty lists"
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",


### PR DESCRIPTION
Emit empty lists in the MultiBufferWithTimeoutOp operator when no items have been emitted during the time window.

Also fix the javadoc, as this was the described behavior.