### PR TITLE
Disabling MultiConcatMapNoPrefetchTest in CI until 1254 has been fixed

### DIFF
--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiConcatMapNoPrefetchTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiConcatMapNoPrefetchTest.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -21,6 +22,7 @@ import io.smallrye.mutiny.groups.MultiFlatten;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true") // TODO Disabled in CI until https://github.com/smallrye/smallrye-mutiny/issues/1254 has been fixed
 class MultiConcatMapNoPrefetchTest {
 
     AtomicInteger upstreamRequestCount;


### PR DESCRIPTION
This is to reduce CI failures due to this flaky test for which investigations are under way.

See: https://github.com/smallrye/smallrye-mutiny/issues/1254