### PR TITLE
AssertSubscriber rework

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSelectLastOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiSelectLastOp.java
@@ -73,6 +73,10 @@ public class MultiSelectLastOp<T> extends AbstractMultiOperator<T, T> {
 
         @Override
         public void request(long n) {
+            if (n < 0) {
+                onFailure(Subscriptions.getInvalidRequestException());
+                return;
+            }
             Subscriptions.add(requested, n);
             drain();
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/NeverMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/NeverMulti.java
@@ -30,7 +30,7 @@ public final class NeverMulti extends AbstractMulti<Object> {
 
     @Override
     public void subscribe(MultiSubscriber<? super Object> actual) {
-        actual.onSubscribe(Subscriptions.CANCELLED);
+        actual.onSubscribe(Subscriptions.empty());
     }
 
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromGeneratorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromGeneratorTest.java
@@ -112,7 +112,7 @@ public class MultiCreateFromGeneratorTest {
                 .subscribe().withSubscriber(AssertSubscriber.create());
 
         sub.request(0);
-        sub.assertFailedWith(IllegalArgumentException.class, "request must be positive");
+        sub.assertFailedWith(IllegalArgumentException.class, "must be greater than 0");
     }
 
     @Test
@@ -129,7 +129,7 @@ public class MultiCreateFromGeneratorTest {
                 .subscribe().withSubscriber(AssertSubscriber.create());
 
         sub.request(-10);
-        sub.assertFailedWith(IllegalArgumentException.class, "request must be positive");
+        sub.assertFailedWith(IllegalArgumentException.class, "must be greater than 0");
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSelectWhereAndWhenTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSelectWhereAndWhenTest.java
@@ -58,7 +58,7 @@ public class MultiSelectWhereAndWhenTest {
                 .filter(n -> n % 2 == 0)
                 .subscribe().withSubscriber(AssertSubscriber.create());
         sub.request(0);
-        sub.assertFailedWith(IllegalArgumentException.class, "request must be positive");
+        sub.assertFailedWith(IllegalArgumentException.class, "must be greater than 0");
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipWhereAndWhenTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiSkipWhereAndWhenTest.java
@@ -34,7 +34,7 @@ public class MultiSkipWhereAndWhenTest {
                 .skip().where(n -> n % 2 == 0)
                 .subscribe().withSubscriber(AssertSubscriber.create());
         sub.request(0);
-        sub.assertFailedWith(IllegalArgumentException.class, "request must be positive");
+        sub.assertFailedWith(IllegalArgumentException.class, "must be greater than 0");
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiDemandCappingTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiDemandCappingTest.java
@@ -80,7 +80,7 @@ class MultiDemandCappingTest {
                 .subscribe().withSubscriber(AssertSubscriber.create());
 
         sub.request(-1L);
-        sub.assertFailedWith(IllegalArgumentException.class, "request must be positive");
+        sub.assertFailedWith(IllegalArgumentException.class, "must be greater than 0");
     }
 
     @Test


### PR DESCRIPTION
- Fixed race conditions between request() and onSubscribe() (upfront demand).
- Made it a MultiSubscriber rather than just a plain Subscriber.
- Fixed minor glitches along the way due to the previous assumption of StrictSubscriber wrapping.