### PR TITLE
Fix race conditions un UniMemoizeOp

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniMemoizeOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniMemoizeOp.java
@@ -1,41 +1,39 @@
 package io.smallrye.mutiny.operators.uni;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
-import static java.util.Collections.synchronizedList;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BooleanSupplier;
 
 import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.operators.AbstractUni;
 import io.smallrye.mutiny.operators.UniOperator;
+import io.smallrye.mutiny.subscription.ContextSupport;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
 
-public class UniMemoizeOp<I> extends UniOperator<I, I> implements UniSubscriber<I> {
+public class UniMemoizeOp<I> extends UniOperator<I, I> implements UniSubscriber<I>, ContextSupport {
+
+    private UniSubscription currentUpstreamSubscription;
+
+    private Context currentContext = Context.empty();
 
     private enum State {
         INIT,
-        SUBSCRIBING,
-        SUBSCRIBED,
+        WAITING_FOR_UPSTREAM,
         CACHING
     }
 
     private final BooleanSupplier invalidationRequested;
 
-    private final AtomicReference<State> state = new AtomicReference<>(State.INIT);
+    private State state = State.INIT;
 
-    private final AtomicInteger wip = new AtomicInteger();
-    private final List<UniSubscriberWrapper<? super I>> subscribers = synchronizedList(new ArrayList<>());
+    private final ReentrantLock internalLock = new ReentrantLock();
 
-    private volatile UniSubscription upstreamSubscription;
-    private volatile I item;
-    private volatile Throwable failure;
-    private volatile Context lastContextInUse;
+    private final ConcurrentLinkedQueue<UniSubscriber<? super I>> awaiters = new ConcurrentLinkedQueue<>();
+
+    private Object cachedResult = null;
 
     public UniMemoizeOp(Uni<? extends I> upstream) {
         this(upstream, () -> false);
@@ -47,183 +45,106 @@ public class UniMemoizeOp<I> extends UniOperator<I, I> implements UniSubscriber<
     }
 
     @Override
-    public Context context() {
-        return lastContextInUse;
+    public void subscribe(UniSubscriber<? super I> subscriber) {
+        nonNull(subscriber, "subscriber");
+        try {
+            internalLock.lock();
+            checkForInvalidation();
+            switch (state) {
+                case INIT:
+                    state = State.WAITING_FOR_UPSTREAM;
+                    awaiters.add(subscriber);
+                    currentContext = subscriber.context();
+                    upstream().subscribe().withSubscriber(this);
+                    break;
+                case WAITING_FOR_UPSTREAM:
+                    awaiters.add(subscriber);
+                    break;
+                case CACHING:
+                    forwardTo(subscriber);
+                    break;
+            }
+            subscriber.onSubscribe(new MemoizedSubscription(subscriber));
+        } finally {
+            internalLock.unlock();
+        }
     }
 
-    @Override
-    public void subscribe(UniSubscriber<? super I> subscriber) {
-        if (invalidationRequested.getAsBoolean() && state.get() != State.SUBSCRIBING) {
-            state.set(State.INIT);
-            if (upstreamSubscription != null) {
-                upstreamSubscription.cancel();
+    private void checkForInvalidation() {
+        if (invalidationRequested.getAsBoolean()) {
+            state = State.INIT;
+            if (currentUpstreamSubscription != null) {
+                currentUpstreamSubscription.cancel();
+                currentUpstreamSubscription = null;
             }
         }
-
-        // Wrap the subscriber
-        UniSubscriberWrapper<? super I> wrapper = new UniSubscriberWrapper<>(subscriber);
-
-        // Early exit with cached data
-        if (state.get() == State.CACHING) {
-            subscriber.onSubscribe(wrapper::markCancelled);
-            if (!wrapper.isCancelled()) {
-                if (failure != null) {
-                    subscriber.onFailure(failure);
-                } else {
-                    subscriber.onItem(item);
-                }
-            }
-            return;
-        }
-
-        subscribers.add(wrapper);
-
-        if (state.compareAndSet(State.INIT, State.SUBSCRIBING)) {
-            // This thread is performing the upstream subscription
-            this.lastContextInUse = subscriber.context();
-            AbstractUni.subscribe(upstream(), this);
-        }
-        drain();
     }
 
     @Override
     public void onSubscribe(UniSubscription subscription) {
-        if (state.compareAndSet(State.SUBSCRIBING, State.SUBSCRIBED)) {
-            upstreamSubscription = subscription;
-            drain();
-        } else {
-            subscription.cancel();
-        }
-    }
-
-    private void drain() {
-        // Check if another thread is working
-        if (wip.getAndIncrement() != 0) {
-            return;
-        }
-
-        // Big loop
-        int missed = 1;
-        for (;;) {
-            ArrayList<UniSubscriberWrapper<? super I>> wrappers;
-            I currentItem;
-            Throwable currentFailure;
-
-            if (!subscribers.isEmpty()) {
-                // Thread-safe copy
-                synchronized (subscribers) {
-                    wrappers = new ArrayList<>(subscribers);
-                }
-
-                // Handle subscribers
-                for (UniSubscriberWrapper<? super I> wrapper : wrappers) {
-                    if (wrapper.isCancelled()) {
-                        subscribers.remove(wrapper);
-                        continue;
-                    }
-
-                    currentItem = item;
-                    currentFailure = failure;
-                    State state = this.state.get();
-
-                    if (wrapper.isAwaitingSubscription()) {
-                        switch (state) {
-                            case INIT:
-                            case SUBSCRIBING:
-                                break;
-                            case SUBSCRIBED:
-                                wrapper.subscriber.onSubscribe(wrapper::markCancelled);
-                                wrapper.markSubscribed();
-                                break;
-                            case CACHING:
-                                wrapper.subscriber.onSubscribe(wrapper::markCancelled);
-                                wrapper.markSubscribed();
-                                try {
-                                    if (!wrapper.isCancelled()) {
-                                        if (currentFailure != null) {
-                                            wrapper.subscriber.onFailure(currentFailure);
-                                        } else {
-                                            wrapper.subscriber.onItem(currentItem);
-                                        }
-                                    }
-                                } finally {
-                                    subscribers.remove(wrapper);
-                                }
-                                break;
-                            default:
-                                throw new IllegalStateException("Current state is " + state);
-                        }
-                    } else if (state == State.CACHING && wrapper.isAwaitingResult()) {
-                        if (failure != null) {
-                            wrapper.subscriber.onFailure(currentFailure);
-                        } else {
-                            wrapper.subscriber.onItem(currentItem);
-                        }
-                        subscribers.remove(wrapper);
-                    }
-                }
-            }
-
-            missed = wip.addAndGet(-missed);
-            if (missed == 0) {
-                break;
-            }
-        }
+        this.currentUpstreamSubscription = subscription;
     }
 
     @Override
     public void onItem(I item) {
-        if (state.get() == State.SUBSCRIBED) {
-            this.item = item;
-            this.failure = null;
-            state.set(State.CACHING);
-            drain();
+        try {
+            internalLock.lock();
+            if (state == State.WAITING_FOR_UPSTREAM) {
+                state = State.CACHING;
+                cachedResult = item;
+                notifyAwaiters();
+            }
+        } finally {
+            internalLock.unlock();
         }
     }
 
     @Override
     public void onFailure(Throwable failure) {
-        if (state.get() == State.SUBSCRIBED) {
-            this.item = null;
-            this.failure = failure;
-            state.set(State.CACHING);
-            drain();
+        try {
+            internalLock.lock();
+            if (state == State.WAITING_FOR_UPSTREAM) {
+                state = State.CACHING;
+                cachedResult = failure;
+                notifyAwaiters();
+            }
+        } finally {
+            internalLock.unlock();
         }
     }
 
-    private static class UniSubscriberWrapper<I> {
-
-        enum Status {
-            AWAITING_SUBSCRIPTION,
-            AWAITING_RESULT,
-            CANCELLED
+    @SuppressWarnings("unchecked")
+    private void forwardTo(UniSubscriber<? super I> subscriber) {
+        if (cachedResult instanceof Throwable) {
+            subscriber.onFailure((Throwable) cachedResult);
+        } else {
+            subscriber.onItem((I) cachedResult);
         }
+    }
 
-        final UniSubscriber<? super I> subscriber;
-        final AtomicReference<Status> status = new AtomicReference<>(Status.AWAITING_SUBSCRIPTION);
+    @Override
+    public Context context() {
+        return currentContext;
+    }
 
-        UniSubscriberWrapper(UniSubscriber<? super I> subscriber) {
+    private void notifyAwaiters() {
+        UniSubscriber<? super I> awaiter;
+        while ((awaiter = awaiters.poll()) != null) {
+            forwardTo(awaiter);
+        }
+    }
+
+    private class MemoizedSubscription implements UniSubscription {
+
+        private final UniSubscriber<? super I> subscriber;
+
+        MemoizedSubscription(UniSubscriber<? super I> subscriber) {
             this.subscriber = subscriber;
         }
 
-        void markCancelled() {
-            status.set(Status.CANCELLED);
-        }
-
-        void markSubscribed() {
-            status.compareAndSet(Status.AWAITING_SUBSCRIPTION, Status.AWAITING_RESULT);
-        }
-
-        boolean isCancelled() {
-            return status.get() == Status.CANCELLED;
-        }
-
-        boolean isAwaitingSubscription() {
-            return status.get() == Status.AWAITING_SUBSCRIPTION;
-        }
-
-        boolean isAwaitingResult() {
-            return status.get() == Status.AWAITING_RESULT;
+        @Override
+        public void cancel() {
+            awaiters.remove(subscriber);
         }
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/UniMemoizeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/UniMemoizeTest.java
@@ -519,4 +519,19 @@ class UniMemoizeTest {
         subscriber2.awaitItem().assertItem("hello-1");
     }
 
+    @Test
+    public void reproducer_1303() throws ExecutionException, InterruptedException {
+        // See https://github.com/quarkusio/quarkus/issues/33602
+        var ex = Executors.newFixedThreadPool(1);
+        for (int i = 0; i < 500_000; i++) {
+            CompletableFuture<Object> cf = new CompletableFuture<>();
+            Uni.createFrom().emitter(emitter -> ex.submit(() -> emitter.complete(new Object())))
+                    .memoize().indefinitely()
+                    .subscribe().with(cf::complete);
+            if (cf.get() == null) {
+                throw new RuntimeException();
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Moving to a lock-based design with a 3 states machine. This is more appropriate to the requirements of memoization wrt signals.

Fixes #1303