### PR TITLE
Issue #1317: Kotlin - Add typed variants of Uni.awaitSuspending

### DIFF
--- a/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/Uni.kt
+++ b/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/Uni.kt
@@ -39,6 +39,16 @@ suspend fun <T> Uni<T>.awaitSuspending() = suspendCancellableCoroutine<T> { cont
 }
 
 /**
+ * Like [awaitSuspending], but fails with an [IllegalStateException] if there's no item produced by this [Uni].
+ */
+suspend fun <T> Uni<T>.awaitItem(): T = checkNotNull(awaitSuspending()) { "Uni did not emit an item" }
+
+/**
+ * Like [awaitSuspending], but with the explicit need of `null` handling.
+ */
+suspend fun <T> Uni<T>.awaitItemOrNull(): T? = awaitSuspending()
+
+/**
  * Provide this [Deferred]s value or failure as [Uni].
  *
  * If the surrounding coroutine fails or gets cancelled that failure is propagated as well.

--- a/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/UniAwaitSuspendingTest.kt
+++ b/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/UniAwaitSuspendingTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 
 class UniAwaitSuspendingTest {
 
@@ -140,5 +141,52 @@ class UniAwaitSuspendingTest {
 
         // Then
         assertThat(item).isEqualTo(23)
+    }
+
+    @Test
+    fun `test awaitItem with non null item`() {
+        // Given
+        val nonNullUni: Uni<String> = Uni.createFrom().item("blue pill")
+
+        // When
+        val nonNullItem: String = testBlocking { nonNullUni.awaitItem() }
+
+        // Then
+        assertThat(nonNullItem).isNotNull()
+    }
+
+    @Test
+    fun `test awaitItem with null item`() {
+        // Given
+        val nullUni: Uni<String> = Uni.createFrom().nullItem();
+
+        // When & Then
+        assertThatThrownBy {
+            testBlocking { nullUni.awaitItem() }
+        }.isInstanceOf(IllegalStateException::class.java).hasMessage("Uni did not emit an item")
+    }
+
+    @Test
+    fun `test awaitItemOrNull with non null item`() {
+        // Given
+        val nonNullUni: Uni<String> = Uni.createFrom().item("blue pill")
+
+        // When
+        val nonNullItem: String? = testBlocking { nonNullUni.awaitItemOrNull() }
+
+        // Then
+        assertThat(nonNullItem).isNotNull()
+    }
+
+    @Test
+    fun `test awaitItemOrNull with null item`() {
+        // Given
+        val nullUni: Uni<String> = Uni.createFrom().nullItem()
+
+        // When
+        val nullItem: String? = testBlocking { nullUni.awaitItemOrNull() }
+
+        // Then
+        assertThat(nullItem).isNull()
     }
 }


### PR DESCRIPTION
Proposal to solve https://github.com/smallrye/smallrye-mutiny/issues/1317

@hantsy - your reference methods `awaitSingle*` extends a Publisher with potential numerous items, whereas Uni isn't a Publisher and emits at max one item.
That's why I don't consider "single" a good naming.

Happy to hear your opinion. 