### PR TITLE
Issue #1316: Kotlin - Remove unnecessary suspend modifier from asFlow and Uni builder

### DIFF
--- a/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/Multi.kt
+++ b/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/Multi.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.launch
  * @property bufferCapacity the type (defined by [Channel] constants) or the capacity (>0 <[Int.MAX_VALUE]) of the channel, defaulting to [Channel.UNLIMITED]
  * @property bufferOverflowStrategy action strategy on exceeding the [bufferCapacity], see [BufferOverflow].
  */
-suspend fun <T> Multi<T>.asFlow(
+fun <T> Multi<T>.asFlow(
     bufferCapacity: Int = Channel.UNLIMITED,
     bufferOverflowStrategy: BufferOverflow = BufferOverflow.SUSPEND
 ): Flow<T> = callbackFlow<T> {

--- a/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/Uni.kt
+++ b/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/Uni.kt
@@ -71,6 +71,6 @@ fun <T> Deferred<T>.asUni(): Uni<T> = Uni.createFrom().emitter { em: UniEmitter<
  */
 @ExperimentalCoroutinesApi
 @OptIn(DelicateCoroutinesApi::class)
-suspend fun <T> uni(context: CoroutineScope = GlobalScope, suspendSupplier: suspend () -> T): Uni<T> = context.async {
+fun <T> uni(context: CoroutineScope = GlobalScope, suspendSupplier: suspend () -> T): Uni<T> = context.async {
     suspendSupplier()
 }.asUni()

--- a/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/UniCoroutineBuilderTest.kt
+++ b/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/UniCoroutineBuilderTest.kt
@@ -3,6 +3,7 @@ package io.smallrye.mutiny.coroutines
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber
 import kotlin.test.Test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import org.assertj.core.api.Assertions.assertThat
 
 @ExperimentalCoroutinesApi
@@ -10,43 +11,46 @@ class UniCoroutineBuilderTest {
 
     @Test
     fun `test build uni from item`() {
-        testBlocking {
-            // Given
-            val item = "wrap me plenty"
+        // Given
+        val item = "wrap me plenty"
 
-            // When
-            val uni = uni { item }
-            val subscriber = UniAssertSubscriber.create<String>()
-            uni.subscribe().withSubscriber(subscriber)
-
-            // Then
-            assertThat(subscriber.awaitItem().item).isSameAs(item)
+        // When
+        val uni = uni {
+            delay(1)
+            item
         }
+        val subscriber = UniAssertSubscriber.create<String>()
+        uni.subscribe().withSubscriber(subscriber)
+
+        // Then
+        assertThat(subscriber.awaitItem().item).isSameAs(item)
     }
 
     @Test
     fun `test build uni from null`() {
-        testBlocking {
-            // Given & When
-            val uni = uni { null }
-            val subscriber = UniAssertSubscriber.create<Any?>()
-            uni.subscribe().withSubscriber(subscriber)
-
-            // Then
-            assertThat(subscriber.awaitItem().item).isNull()
+        // Given & When
+        val uni = uni {
+            delay(1)
+            null
         }
+        val subscriber = UniAssertSubscriber.create<Any?>()
+        uni.subscribe().withSubscriber(subscriber)
+
+        // Then
+        assertThat(subscriber.awaitItem().item).isNull()
     }
 
     @Test
     fun `test build uni from failure`() {
-        testBlocking {
-            // Given & When
-            val uni = uni { throw Exception("Kaboom") }
-            val subscriber = UniAssertSubscriber.create<Any?>()
-            uni.subscribe().withSubscriber(subscriber)
-
-            // Then
-            assertThat(subscriber.awaitFailure().failure).hasMessage("Kaboom")
+        // Given & When
+        val uni = uni {
+            delay(1)
+            throw Exception("Kaboom")
         }
+        val subscriber = UniAssertSubscriber.create<Any?>()
+        uni.subscribe().withSubscriber(subscriber)
+
+        // Then
+        assertThat(subscriber.awaitFailure().failure).hasMessage("Kaboom")
     }
 }


### PR DESCRIPTION
Tries to solve https://github.com/smallrye/smallrye-mutiny/issues/1316
Fixes https://github.com/smallrye/smallrye-mutiny/issues/1324

@hantsy, you're right, the `suspend` modifier is not needed for `asFlow`.
Your referenced implementation of kotlinx-coroutines-reactive would required an additional dependency, that's why I would prefer to stay with the own implementation, especially as it's also capable of buffer handling.