### PR TITLE
refactor: reworked Uni combination APIs

### DIFF
--- a/.build/WaitForCentral.java
+++ b/.build/WaitForCentral.java
@@ -109,7 +109,7 @@ class WaitForCentral implements Callable<Integer> {
         }
 
         Uni<Boolean> completed = Uni.combine().all().unis(unis)
-            .combinedWith(list -> {
+            .with(list -> {
                 boolean done = true;
                 for (Object r : list) {
                     Result res = (Result) r;

--- a/context-propagation/src/test/java/io/smallrye/mutiny/context/UniContextPropagationTest.java
+++ b/context-propagation/src/test/java/io/smallrye/mutiny/context/UniContextPropagationTest.java
@@ -161,7 +161,7 @@ public class UniContextPropagationTest {
         }).runSubscriptionOn(executor);
 
         Uni.combine().all().unis(uni1, uni2, uni3)
-                .combinedWith((item1, item2, item3) -> {
+                .with((item1, item2, item3) -> {
                     assertThat(ctx).isSameAs(MyContext.get());
                     return item1 + item2 + item3;
                 })
@@ -213,7 +213,7 @@ public class UniContextPropagationTest {
 
         // Same but with biFunction
         Uni.combine().all().unis(uni1, uni2)
-                .combinedWith((a, b) -> {
+                .with((a, b) -> {
                     assertThat(ctx).isSameAs(MyContext.get());
                     return a + b;
                 })
@@ -284,7 +284,7 @@ public class UniContextPropagationTest {
         }).runSubscriptionOn(executor);
 
         Uni.combine().all().unis(uni1, uni2, uni3, uni4)
-                .combinedWith((item1, item2, item3, item4) -> {
+                .with((item1, item2, item3, item4) -> {
                     assertThat(ctx).isSameAs(MyContext.get());
                     return item1 + item2 + item3 + item4;
                 })
@@ -297,7 +297,7 @@ public class UniContextPropagationTest {
                         });
 
         Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5)
-                .combinedWith((item1, item2, item3, item4, item5) -> {
+                .with((item1, item2, item3, item4, item5) -> {
                     assertThat(ctx).isSameAs(MyContext.get());
                     return item1 + item2 + item3 + item4 + item5;
                 })
@@ -310,7 +310,7 @@ public class UniContextPropagationTest {
                         });
 
         Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6)
-                .combinedWith((item1, item2, item3, item4, item5, item6) -> {
+                .with((item1, item2, item3, item4, item5, item6) -> {
                     assertThat(ctx).isSameAs(MyContext.get());
                     return item1 + item2 + item3 + item4 + item5 + item6;
                 })
@@ -323,7 +323,7 @@ public class UniContextPropagationTest {
                         });
 
         Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7)
-                .combinedWith((item1, item2, item3, item4, item5, item6, item7) -> {
+                .with((item1, item2, item3, item4, item5, item6, item7) -> {
                     assertThat(ctx).isSameAs(MyContext.get());
                     return item1 + item2 + item3 + item4 + item5 + item6 + item7;
                 })
@@ -336,7 +336,7 @@ public class UniContextPropagationTest {
                         });
 
         Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8)
-                .combinedWith((item1, item2, item3, item4, item5, item6, item7, item8) -> {
+                .with((item1, item2, item3, item4, item5, item6, item7, item8) -> {
                     assertThat(ctx).isSameAs(MyContext.get());
                     return item1 + item2 + item3 + item4 + item5 + item6 + item7 + item8;
                 })
@@ -349,7 +349,7 @@ public class UniContextPropagationTest {
                         });
 
         Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9)
-                .combinedWith((item1, item2, item3, item4, item5, item6, item7, item8, item9) -> {
+                .with((item1, item2, item3, item4, item5, item6, item7, item8, item9) -> {
                     assertThat(ctx).isSameAs(MyContext.get());
                     return item1 + item2 + item3 + item4 + item5 + item6 + item7 + item8 + item9;
                 })

--- a/documentation/src/test/java/guides/operators/CombiningItemsTest.java
+++ b/documentation/src/test/java/guides/operators/CombiningItemsTest.java
@@ -4,7 +4,6 @@ import guides.extension.SystemOut;
 import guides.extension.SystemOutCaptureExtension;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.tuples.Tuple;
 import io.smallrye.mutiny.tuples.Tuple2;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,7 +48,7 @@ public class CombiningItemsTest<A, B> {
 
         // <combined-with>
         Uni<Map<String, Response>> uni = Uni.combine()
-                .all().unis(uniA, uniB).combinedWith(
+                .all().unis(uniA, uniB).with(
                         listOfResponses -> {
                             Map<String, Response> map = new LinkedHashMap<>();
                             map.put("A", (Response) listOfResponses.get(0));
@@ -60,6 +59,21 @@ public class CombiningItemsTest<A, B> {
         // </combined-with>
 
         assertThat(uni.await().indefinitely()).containsKeys("A", "B");
+
+        // <combined-with-uni>
+        Uni<Map<String, Response>> uni1 = Uni.combine()
+                .all().unis(uniA, uniB).withUni(
+                        listOfResponses -> {
+                            Map<String, Response> map = new LinkedHashMap<>();
+                            map.put("A", (Response) listOfResponses.get(0));
+                            map.put("B", (Response) listOfResponses.get(1));
+                            return Uni.createFrom().item(map);
+                        }
+                );
+        // </combined-with-uni>
+
+        assertThat(uni1.await().indefinitely()).containsKeys("A", "B");
+
 
         Thread.sleep(100);
     }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup2.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup2.java
@@ -52,10 +52,24 @@ public class UniAndGroup2<T1, T2> extends UniAndGroupIterable<T1> {
      *
      * @param combinator the combinator function, must not be {@code null}
      * @param <O> the type of item
-     * @return the resulting {@link Uni}. The items are combined into a {@link Tuple2 Tuple2&lt;T1, T2&gt;}.
+     * @return the resulting {@code Uni<O>}. The items are combined into {@link O}
+     * @deprecated use {@link #with(BiFunction)} instead
      */
+    @Deprecated
     @CheckReturnValue
     public <O> Uni<O> combinedWith(BiFunction<T1, T2, O> combinator) {
+        return with(combinator);
+    }
+
+    /**
+     * Creates the resulting {@link Uni}. The items are combined using the given combinator function.
+     *
+     * @param combinator the combinator function, must not be {@code null}
+     * @param <O> the type of item
+     * @return the resulting {@code Uni<O>}. The items are combined into {@link O}
+     */
+    @CheckReturnValue
+    public <O> Uni<O> with(BiFunction<T1, T2, O> combinator) {
         BiFunction<T1, T2, O> actual = Infrastructure.decorate(nonNull(combinator, "combinator"));
         return combine(actual);
     }
@@ -68,7 +82,32 @@ public class UniAndGroup2<T1, T2> extends UniAndGroupIterable<T1> {
             T2 item2 = (T2) list.get(1);
             return combinator.apply(item1, item2);
         };
-        return super.combinedWith(function);
+        return super.with(function);
+    }
+
+    /**
+     * Creates the resulting {@link Uni}. The items are combined using the given combinator function,
+     * and the resulting {@code Uni<Uni<O>>} is flattened.
+     *
+     * @param combinator the combinator function, must not be {@code null}
+     * @param <O> the type of item
+     * @return the resulting {@link Uni}. The items are combined into a {@link Tuple2 Tuple2&lt;T1, T2&gt;}.
+     */
+    @CheckReturnValue
+    public <O> Uni<O> withUni(BiFunction<T1, T2, Uni<O>> combinator) {
+        BiFunction<T1, T2, Uni<O>> actual = Infrastructure.decorate(nonNull(combinator, "combinator"));
+        return combineUni(actual);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <O> Uni<O> combineUni(BiFunction<T1, T2, Uni<O>> combinator) {
+        Function<List<?>, Uni<O>> function = list -> {
+            Tuples.ensureArity(list, 2);
+            T1 item1 = (T1) list.get(0);
+            T2 item2 = (T2) list.get(1);
+            return combinator.apply(item1, item2);
+        };
+        return super.with(function).flatMap(Function.identity());
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup3.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup3.java
@@ -30,8 +30,17 @@ public class UniAndGroup3<T1, T2, T3> extends UniAndGroupIterable<T1> {
         return combine(Tuple3::of);
     }
 
+    /**
+     * @deprecated use {@link #with(Functions.Function3)} instead
+     */
+    @Deprecated
     @CheckReturnValue
     public <O> Uni<O> combinedWith(Functions.Function3<T1, T2, T3, O> combinator) {
+        return with(combinator);
+    }
+
+    @CheckReturnValue
+    public <O> Uni<O> with(Functions.Function3<T1, T2, T3, O> combinator) {
         Functions.Function3<T1, T2, T3, O> actual = Infrastructure.decorate(nonNull(combinator, "combinator"));
         return combine(actual);
     }
@@ -45,7 +54,24 @@ public class UniAndGroup3<T1, T2, T3> extends UniAndGroupIterable<T1> {
             T3 item3 = (T3) list.get(2);
             return combinator.apply(item1, item2, item3);
         };
-        return super.combinedWith(function);
+        return super.with(function);
     }
 
+    @CheckReturnValue
+    public <O> Uni<O> withUni(Functions.Function3<T1, T2, T3, Uni<O>> combinator) {
+        Functions.Function3<T1, T2, T3, Uni<O>> actual = Infrastructure.decorate(nonNull(combinator, "combinator"));
+        return combineUni(actual);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <O> Uni<O> combineUni(Functions.Function3<T1, T2, T3, Uni<O>> combinator) {
+        Function<List<?>, Uni<O>> function = list -> {
+            Tuples.ensureArity(list, 3);
+            T1 item1 = (T1) list.get(0);
+            T2 item2 = (T2) list.get(1);
+            T3 item3 = (T3) list.get(2);
+            return combinator.apply(item1, item2, item3);
+        };
+        return super.with(function).flatMap(Function.identity());
+    }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup4.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup4.java
@@ -30,8 +30,17 @@ public class UniAndGroup4<T1, T2, T3, T4> extends UniAndGroupIterable<T1> {
         return combine(Tuple4::of);
     }
 
+    /**
+     * @deprecated use {@link #with(Functions.Function4)} instead
+     */
+    @Deprecated
     @CheckReturnValue
     public <O> Uni<O> combinedWith(Functions.Function4<T1, T2, T3, T4, O> combinator) {
+        return with(combinator);
+    }
+
+    @CheckReturnValue
+    public <O> Uni<O> with(Functions.Function4<T1, T2, T3, T4, O> combinator) {
         Functions.Function4<T1, T2, T3, T4, O> actual = Infrastructure.decorate(nonNull(combinator, "combinator"));
         return combine(actual);
     }
@@ -46,7 +55,26 @@ public class UniAndGroup4<T1, T2, T3, T4> extends UniAndGroupIterable<T1> {
             T4 item4 = (T4) list.get(3);
             return combinator.apply(item1, item2, item3, item4);
         };
-        return super.combinedWith(function);
+        return super.with(function);
+    }
+
+    @CheckReturnValue
+    public <O> Uni<O> withUni(Functions.Function4<T1, T2, T3, T4, Uni<O>> combinator) {
+        Functions.Function4<T1, T2, T3, T4, Uni<O>> actual = Infrastructure.decorate(nonNull(combinator, "combinator"));
+        return combineUni(actual);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <O> Uni<O> combineUni(Functions.Function4<T1, T2, T3, T4, Uni<O>> combinator) {
+        Function<List<?>, Uni<O>> function = list -> {
+            Tuples.ensureArity(list, 4);
+            T1 item1 = (T1) list.get(0);
+            T2 item2 = (T2) list.get(1);
+            T3 item3 = (T3) list.get(2);
+            T4 item4 = (T4) list.get(3);
+            return combinator.apply(item1, item2, item3, item4);
+        };
+        return super.with(function).flatMap(Function.identity());
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup5.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup5.java
@@ -31,8 +31,17 @@ public class UniAndGroup5<T1, T2, T3, T4, T5> extends UniAndGroupIterable<T1> {
         return combine(Tuple5::of);
     }
 
+    /**
+     * @deprecated use {@link #with(Functions.Function5)} instead
+     */
+    @Deprecated
     @CheckReturnValue
     public <O> Uni<O> combinedWith(Functions.Function5<T1, T2, T3, T4, T5, O> combinator) {
+        return with(combinator);
+    }
+
+    @CheckReturnValue
+    public <O> Uni<O> with(Functions.Function5<T1, T2, T3, T4, T5, O> combinator) {
         Functions.Function5<T1, T2, T3, T4, T5, O> actual = Infrastructure
                 .decorate(nonNull(combinator, "combinator"));
         return combine(actual);
@@ -49,7 +58,27 @@ public class UniAndGroup5<T1, T2, T3, T4, T5> extends UniAndGroupIterable<T1> {
             T5 item5 = (T5) list.get(4);
             return combinator.apply(item1, item2, item3, item4, item5);
         };
-        return super.combinedWith(function);
+        return super.with(function);
     }
 
+    @CheckReturnValue
+    public <O> Uni<O> withUni(Functions.Function5<T1, T2, T3, T4, T5, Uni<O>> combinator) {
+        Functions.Function5<T1, T2, T3, T4, T5, Uni<O>> actual = Infrastructure
+                .decorate(nonNull(combinator, "combinator"));
+        return combineUni(actual);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <O> Uni<O> combineUni(Functions.Function5<T1, T2, T3, T4, T5, Uni<O>> combinator) {
+        Function<List<?>, Uni<O>> function = list -> {
+            Tuples.ensureArity(list, 5);
+            T1 item1 = (T1) list.get(0);
+            T2 item2 = (T2) list.get(1);
+            T3 item3 = (T3) list.get(2);
+            T4 item4 = (T4) list.get(3);
+            T5 item5 = (T5) list.get(4);
+            return combinator.apply(item1, item2, item3, item4, item5);
+        };
+        return super.with(function).flatMap(Function.identity());
+    }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup6.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup6.java
@@ -31,8 +31,17 @@ public class UniAndGroup6<T1, T2, T3, T4, T5, T6> extends UniAndGroupIterable<T1
         return combine(Tuple6::of);
     }
 
+    /**
+     * @deprecated use {@link #with(Functions.Function6)} instead
+     */
+    @Deprecated
     @CheckReturnValue
     public <O> Uni<O> combinedWith(Functions.Function6<T1, T2, T3, T4, T5, T6, O> combinator) {
+        return with(combinator);
+    }
+
+    @CheckReturnValue
+    public <O> Uni<O> with(Functions.Function6<T1, T2, T3, T4, T5, T6, O> combinator) {
         Functions.Function6<T1, T2, T3, T4, T5, T6, O> actual = Infrastructure
                 .decorate(nonNull(combinator, "combinator"));
         return combine(actual);
@@ -50,7 +59,29 @@ public class UniAndGroup6<T1, T2, T3, T4, T5, T6> extends UniAndGroupIterable<T1
             T6 item6 = (T6) list.get(5);
             return combinator.apply(item1, item2, item3, item4, item5, item6);
         };
-        return super.combinedWith(function);
+        return super.with(function);
+    }
+
+    @CheckReturnValue
+    public <O> Uni<O> withUni(Functions.Function6<T1, T2, T3, T4, T5, T6, Uni<O>> combinator) {
+        Functions.Function6<T1, T2, T3, T4, T5, T6, Uni<O>> actual = Infrastructure
+                .decorate(nonNull(combinator, "combinator"));
+        return combineUni(actual);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <O> Uni<O> combineUni(Functions.Function6<T1, T2, T3, T4, T5, T6, Uni<O>> combinator) {
+        Function<List<?>, Uni<O>> function = list -> {
+            Tuples.ensureArity(list, 6);
+            T1 item1 = (T1) list.get(0);
+            T2 item2 = (T2) list.get(1);
+            T3 item3 = (T3) list.get(2);
+            T4 item4 = (T4) list.get(3);
+            T5 item5 = (T5) list.get(4);
+            T6 item6 = (T6) list.get(5);
+            return combinator.apply(item1, item2, item3, item4, item5, item6);
+        };
+        return super.with(function).flatMap(Function.identity());
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup7.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup7.java
@@ -28,11 +28,20 @@ public class UniAndGroup7<T1, T2, T3, T4, T5, T6, T7> extends UniAndGroupIterabl
 
     @CheckReturnValue
     public Uni<Tuple7<T1, T2, T3, T4, T5, T6, T7>> asTuple() {
-        return combinedWith(Tuple7::of);
+        return combine(Tuple7::of);
+    }
+
+    /**
+     * @deprecated use {@link #with(Functions.Function7)} instead
+     */
+    @Deprecated
+    @CheckReturnValue
+    public <O> Uni<O> combinedWith(Functions.Function7<T1, T2, T3, T4, T5, T6, T7, O> combinator) {
+        return with(combinator);
     }
 
     @CheckReturnValue
-    public <O> Uni<O> combinedWith(Functions.Function7<T1, T2, T3, T4, T5, T6, T7, O> combinator) {
+    public <O> Uni<O> with(Functions.Function7<T1, T2, T3, T4, T5, T6, T7, O> combinator) {
         Functions.Function7<T1, T2, T3, T4, T5, T6, T7, O> actual = Infrastructure
                 .decorate(nonNull(combinator, "combinator"));
         return combine(actual);
@@ -52,7 +61,30 @@ public class UniAndGroup7<T1, T2, T3, T4, T5, T6, T7> extends UniAndGroupIterabl
 
             return combinator.apply(item1, item2, item3, item4, item5, item6, item7);
         };
-        return super.combinedWith(function);
+        return super.with(function);
     }
 
+    @CheckReturnValue
+    public <O> Uni<O> withUni(Functions.Function7<T1, T2, T3, T4, T5, T6, T7, Uni<O>> combinator) {
+        Functions.Function7<T1, T2, T3, T4, T5, T6, T7, Uni<O>> actual = Infrastructure
+                .decorate(nonNull(combinator, "combinator"));
+        return combineUni(actual);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <O> Uni<O> combineUni(Functions.Function7<T1, T2, T3, T4, T5, T6, T7, Uni<O>> combinator) {
+        Function<List<?>, Uni<O>> function = list -> {
+            Tuples.ensureArity(list, 7);
+            T1 item1 = (T1) list.get(0);
+            T2 item2 = (T2) list.get(1);
+            T3 item3 = (T3) list.get(2);
+            T4 item4 = (T4) list.get(3);
+            T5 item5 = (T5) list.get(4);
+            T6 item6 = (T6) list.get(5);
+            T7 item7 = (T7) list.get(6);
+
+            return combinator.apply(item1, item2, item3, item4, item5, item6, item7);
+        };
+        return super.with(function).flatMap(Function.identity());
+    }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup8.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup8.java
@@ -33,8 +33,17 @@ public class UniAndGroup8<T1, T2, T3, T4, T5, T6, T7, T8> extends UniAndGroupIte
         return combine(Tuple8::of);
     }
 
+    /**
+     * @deprecated use {@link #with(Functions.Function8)} instead
+     */
+    @Deprecated
     @CheckReturnValue
     public <O> Uni<O> combinedWith(Functions.Function8<T1, T2, T3, T4, T5, T6, T7, T8, O> combinator) {
+        return with(combinator);
+    }
+
+    @CheckReturnValue
+    public <O> Uni<O> with(Functions.Function8<T1, T2, T3, T4, T5, T6, T7, T8, O> combinator) {
         Functions.Function8<T1, T2, T3, T4, T5, T6, T7, T8, O> actual = Infrastructure
                 .decorate(nonNull(combinator, "combinator"));
         return combine(actual);
@@ -54,7 +63,31 @@ public class UniAndGroup8<T1, T2, T3, T4, T5, T6, T7, T8> extends UniAndGroupIte
                     (T7) list.get(6),
                     (T8) list.get(7));
         };
-        return super.combinedWith(function);
+        return super.with(function);
+    }
+
+    @CheckReturnValue
+    public <O> Uni<O> withUni(Functions.Function8<T1, T2, T3, T4, T5, T6, T7, T8, Uni<O>> combinator) {
+        Functions.Function8<T1, T2, T3, T4, T5, T6, T7, T8, Uni<O>> actual = Infrastructure
+                .decorate(nonNull(combinator, "combinator"));
+        return combineUni(actual);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <O> Uni<O> combineUni(Functions.Function8<T1, T2, T3, T4, T5, T6, T7, T8, Uni<O>> combinator) {
+        Function<List<?>, Uni<O>> function = list -> {
+            Tuples.ensureArity(list, 8);
+            return combinator.apply(
+                    (T1) list.get(0),
+                    (T2) list.get(1),
+                    (T3) list.get(2),
+                    (T4) list.get(3),
+                    (T5) list.get(4),
+                    (T6) list.get(5),
+                    (T7) list.get(6),
+                    (T8) list.get(7));
+        };
+        return super.with(function).flatMap(Function.identity());
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup9.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup9.java
@@ -33,8 +33,17 @@ public class UniAndGroup9<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends UniAndGrou
         return combine(Tuple9::of);
     }
 
+    /**
+     * @deprecated use {@link #with(Functions.Function9)} instead
+     */
+    @Deprecated
     @CheckReturnValue
     public <O> Uni<O> combinedWith(Functions.Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, O> combinator) {
+        return with(combinator);
+    }
+
+    @CheckReturnValue
+    public <O> Uni<O> with(Functions.Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, O> combinator) {
         Functions.Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, O> actual = Infrastructure
                 .decorate(nonNull(combinator, "combinator"));
         return combine(actual);
@@ -56,7 +65,33 @@ public class UniAndGroup9<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends UniAndGrou
                     (T8) list.get(7),
                     (T9) list.get(8));
         };
-        return super.combinedWith(function);
+        return super.with(function);
+    }
+
+    @CheckReturnValue
+    public <O> Uni<O> withUni(Functions.Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, Uni<O>> combinator) {
+        Functions.Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, Uni<O>> actual = Infrastructure
+                .decorate(nonNull(combinator, "combinator"));
+        return combineUni(actual);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <O> Uni<O> combineUni(Functions.Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, Uni<O>> combinator) {
+        Function<List<?>, Uni<O>> function = list -> {
+            Tuples.ensureArity(list, 9);
+
+            return combinator.apply(
+                    (T1) list.get(0),
+                    (T2) list.get(1),
+                    (T3) list.get(2),
+                    (T4) list.get(3),
+                    (T5) list.get(4),
+                    (T6) list.get(5),
+                    (T7) list.get(6),
+                    (T8) list.get(7),
+                    (T9) list.get(8));
+        };
+        return super.with(function).flatMap(Function.identity());
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroupIterable.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroupIterable.java
@@ -72,19 +72,72 @@ public class UniAndGroupIterable<T1> {
      * @param function the combination function
      * @param <O> the combination value type
      * @return the new {@link Uni}
+     * @deprecated use {{@link #with(Function)}} instead
      */
+    @Deprecated
     @CheckReturnValue
     public <O> Uni<O> combinedWith(Function<List<?>, O> function) {
+        return with(function);
+    }
+
+    /**
+     * Combine the items emitted by the {@link Uni unis}, and emit the result when all {@link Uni unis} have
+     * successfully completed. In case of failure, the failure is propagated.
+     *
+     * @param function the combination function
+     * @param <O> the combination value type
+     * @return the new {@link Uni}
+     */
+    @CheckReturnValue
+    public <O> Uni<O> with(Function<List<?>, O> function) {
         Function<List<?>, O> actual = Infrastructure.decorate(nonNull(function, "function"));
         return Infrastructure
                 .onUniCreation(new UniAndCombination<>(source, unis, actual, collectFailures, concurrency));
     }
 
     /**
+     * Combine the items emitted by the {@link Uni unis} to a new Uni, and emit the result when all
+     * {@link Uni unis} (including the one returned from {@code function} have successfully completed.
+     * In case of failure, the failure is propagated.
+     *
+     * @param function the combination function
+     * @param <O> the combination value type
+     * @return the new {@link Uni}
+     */
+    @CheckReturnValue
+    public <O> Uni<O> withUni(Function<List<?>, Uni<O>> function) {
+        Function<List<?>, Uni<O>> actual = Infrastructure.decorate(nonNull(function, "function"));
+        return Infrastructure
+                .onUniCreation(new UniAndCombination<>(source, unis, actual, collectFailures, concurrency))
+                .flatMap(Function.identity());
+    }
+
+    /**
      * Combine the items emitted by the {@link Uni unis}, and emit the result when all {@link Uni unis} have
      * successfully completed. In case of failure, the failure is propagated.
      * <p>
-     * This method is a convenience wrapper for {@link #combinedWith(Function)} but with the assumption that all items
+     * This method is a convenience wrapper for {@link #with(Function)} but with the assumption that all items
+     * have {@code I} as a super type, which saves you a cast in the combination function.
+     * If the cast fails then the returned {@link Uni} fails with a {@link ClassCastException}.
+     *
+     * @param superType the super type of all items
+     * @param function the combination function
+     * @param <O> the combination value type
+     * @param <I> the super type of all items
+     * @return the new {@link Uni}
+     * @deprecated use {@link #with(Class, Function)} instead
+     */
+    @Deprecated
+    @CheckReturnValue
+    public <O, I> Uni<O> combinedWith(Class<I> superType, Function<List<I>, O> function) {
+        return with(superType, function);
+    }
+
+    /**
+     * Combine the items emitted by the {@link Uni unis}, and emit the result when all {@link Uni unis} have
+     * successfully completed. In case of failure, the failure is propagated.
+     * <p>
+     * This method is a convenience wrapper for {@link #with(Function)} but with the assumption that all items
      * have {@code I} as a super type, which saves you a cast in the combination function.
      * If the cast fails then the returned {@link Uni} fails with a {@link ClassCastException}.
      *
@@ -94,10 +147,30 @@ public class UniAndGroupIterable<T1> {
      * @param <I> the super type of all items
      * @return the new {@link Uni}
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
-    public <O, I> Uni<O> combinedWith(Class<I> superType, Function<List<I>, O> function) {
-        return combinedWith((Function) function);
+    public <O, I> Uni<O> with(Class<I> superType, Function<List<I>, O> function) {
+        return with((Function) function);
+    }
+
+    /**
+     * Combine the items emitted by the {@link Uni unis}, and emit the result when all {@link Uni unis} have
+     * successfully completed. In case of failure, the failure is propagated.
+     * <p>
+     * This method is a convenience wrapper for {@link #withUni(Function)} but with the assumption that
+     * all items have {@code I} as a super type, which saves you a cast in the combination function.
+     * If the cast fails then the returned {@link Uni} fails with a {@link ClassCastException}.
+     *
+     * @param superType the super type of all items
+     * @param function the combination function
+     * @param <O> the combination value type
+     * @param <I> the super type of all items
+     * @return the new {@link Uni}
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @CheckReturnValue
+    public <O, I> Uni<O> withUni(Class<I> superType, Function<List<I>, Uni<O>> function) {
+        return withUni((Function) function);
     }
 
     /**

--- a/implementation/src/test/java/io/smallrye/mutiny/infrastructure/MutinySchedulerTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/infrastructure/MutinySchedulerTest.java
@@ -205,7 +205,7 @@ public class MutinySchedulerTest {
                     .onItem().invoke(s -> threads.add(Thread.currentThread().getName())));
         }
 
-        Uni.combine().all().unis(list).combinedWith(x -> null).await().indefinitely();
+        Uni.combine().all().unis(list).with(x -> null).await().indefinitely();
         assertThat(threads).allSatisfy(s -> assertThat(s).startsWith("my-thread-"));
         assertThat(threads).hasSizeLessThanOrEqualTo(4);
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAndTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAndTest.java
@@ -75,7 +75,7 @@ public class UniAndTest {
         Uni<Integer> uni2 = Uni.createFrom().item(2);
         Uni<Integer> uni3 = Uni.createFrom().item(3);
         UniAssertSubscriber<Integer> subscriber = Uni.combine().all().unis(uni1, uni2, uni3)
-                .combinedWith((i1, i2, i3) -> i1 + i2 + i3)
+                .with((i1, i2, i3) -> i1 + i2 + i3)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber.awaitItem().assertItem(6);
     }
@@ -208,7 +208,7 @@ public class UniAndTest {
 
         UniAssertSubscriber<Integer> subscriber = Uni
                 .combine().all().unis(list)
-                .combinedWith(items -> items.stream().mapToInt(i -> (Integer) i).sum())
+                .with(items -> items.stream().mapToInt(i -> (Integer) i).sum())
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -228,7 +228,7 @@ public class UniAndTest {
 
         UniAssertSubscriber<List<Long>> subscriber = Uni
                 .combine().all().unis(list)
-                .combinedWith(Number.class, numbers -> numbers.stream().map(Number::longValue).collect(Collectors.toList()))
+                .with(Number.class, numbers -> numbers.stream().map(Number::longValue).collect(Collectors.toList()))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber
@@ -247,7 +247,7 @@ public class UniAndTest {
 
         UniAssertSubscriber<String> subscriber = Uni
                 .combine().all().unis(list)
-                .combinedWith(String.class, strings -> String.join("", strings))
+                .with(String.class, strings -> String.join("", strings))
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber
@@ -265,7 +265,7 @@ public class UniAndTest {
 
         UniAssertSubscriber<List<Number>> subscriber = Uni
                 .combine().all().unis(list)
-                .combinedWith(Number.class, Function.identity())
+                .with(Number.class, Function.identity())
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         List<Number> result = subscriber.assertCompleted().getItem();
@@ -289,7 +289,7 @@ public class UniAndTest {
 
         UniAssertSubscriber<Integer> subscriber = Uni
                 .combine().all().unis(set)
-                .combinedWith(items -> items.stream().mapToInt(i -> (Integer) i).sum())
+                .with(items -> items.stream().mapToInt(i -> (Integer) i).sum())
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
@@ -52,7 +52,7 @@ public class UniZipTest {
 
         UniAssertSubscriber<Integer> subscriber = Uni.combine().all().unis(uni, uni2)
                 .collectFailures()
-                .combinedWith(Integer::sum)
+                .with(Integer::sum)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -97,7 +97,7 @@ public class UniZipTest {
         Uni<Integer> uni2 = Uni.createFrom().item(2);
         Uni<Integer> uni3 = Uni.createFrom().item(3);
         UniAssertSubscriber<Integer> subscriber = Uni.combine().all().unis(uni1, uni2, uni3)
-                .combinedWith((i1, i2, i3) -> i1 + i2 + i3)
+                .with((i1, i2, i3) -> i1 + i2 + i3)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber.awaitItem().assertItem(6);
     }
@@ -229,11 +229,11 @@ public class UniZipTest {
         Uni<String> uni3 = Uni.createFrom().item("!");
 
         String r = Uni.combine().all().unis(uni1, uni2, uni3)
-                .combinedWith((s1, s2, s3) -> s1 + " " + s2 + " " + s3).await().indefinitely();
+                .with((s1, s2, s3) -> s1 + " " + s2 + " " + s3).await().indefinitely();
         assertThat(r).isEqualTo("hello world !");
 
         List<Uni<String>> list = Arrays.asList(uni1, uni2, uni3);
-        r = Uni.combine().all().unis(list).combinedWith(l -> l.get(0) + " " + l.get(1) + " " + l.get(2)).await()
+        r = Uni.combine().all().unis(list).with(l -> l.get(0) + " " + l.get(1) + " " + l.get(2)).await()
                 .indefinitely();
         assertThat(r).isEqualTo("hello world !");
     }
@@ -282,7 +282,7 @@ public class UniZipTest {
         Uni<Integer> uni10 = Uni.createFrom().item(10);
 
         int sum = Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9, uni10)
-                .combinedWith(l -> l.stream().mapToInt(o -> (Integer) o).sum())
+                .with(l -> l.stream().mapToInt(o -> (Integer) o).sum())
                 .await().indefinitely();
 
         assertThat(sum).isEqualTo(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10);
@@ -304,7 +304,7 @@ public class UniZipTest {
         Uni<Integer> uni10 = Uni.createFrom().item(10);
 
         assertThatThrownBy(() -> Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9, uni10)
-                .combinedWith(l -> l.stream().mapToInt(o -> (Integer) o).sum())
+                .with(l -> l.stream().mapToInt(o -> (Integer) o).sum())
                 .await().indefinitely()).isInstanceOf(ArithmeticException.class).hasMessageContaining("boom");
 
     }
@@ -324,7 +324,7 @@ public class UniZipTest {
         Uni<Integer> uni10 = Uni.createFrom().failure(new IllegalStateException("state"));
 
         assertThatThrownBy(() -> Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9, uni10)
-                .combinedWith(l -> l.stream().mapToInt(o -> (Integer) o).sum())
+                .with(l -> l.stream().mapToInt(o -> (Integer) o).sum())
                 .await().indefinitely()).isInstanceOf(UncheckedIOException.class).hasMessageContaining("io");
 
     }
@@ -345,7 +345,7 @@ public class UniZipTest {
 
         assertThatThrownBy(() -> Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9, uni10)
                 .collectFailures()
-                .combinedWith(l -> l.stream().mapToInt(o -> (Integer) o).sum())
+                .with(l -> l.stream().mapToInt(o -> (Integer) o).sum())
                 .await().indefinitely()).isInstanceOfSatisfying(CompositeException.class, t -> {
                     assertThat(t.getCauses()).hasSize(3);
                     assertThat(t.getSuppressed()).hasSize(2);
@@ -372,7 +372,7 @@ public class UniZipTest {
 
         assertThatThrownBy(() -> Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9, uni10)
                 .collectFailures()
-                .combinedWith(l -> l.stream().mapToInt(o -> (Integer) o).sum())
+                .with(l -> l.stream().mapToInt(o -> (Integer) o).sum())
                 .await().indefinitely()).isInstanceOfSatisfying(CompositeException.class, t -> {
                     assertThat(t.getCauses()).hasSize(10);
                     assertThat(t.getSuppressed()).hasSize(9);
@@ -425,7 +425,7 @@ public class UniZipTest {
                 .onCancellation().invoke(() -> cancellations[9].set(true));
 
         Uni<Integer> all = Uni.combine().all().unis(uni1, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9, uni10)
-                .combinedWith(l -> l.stream().mapToInt(o -> (Integer) o).sum());
+                .with(l -> l.stream().mapToInt(o -> (Integer) o).sum());
 
         assertThat(subscriptions).allSatisfy(bool -> assertThat(bool).isFalse());
         assertThat(cancellations).allSatisfy(bool -> assertThat(bool).isFalse());
@@ -448,7 +448,7 @@ public class UniZipTest {
 
         UniAssertSubscriber<Integer> subscriber = Uni.combine().all().unis(uni, uni2, uni3)
                 .collectFailures()
-                .combinedWith((a, b, c) -> a + b + c)
+                .with((a, b, c) -> a + b + c)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -464,7 +464,7 @@ public class UniZipTest {
 
         UniAssertSubscriber<Integer> subscriber = Uni.combine().all().unis(uni, uni2, uni3, uni4)
                 .collectFailures()
-                .combinedWith((a, b, c, d) -> a + b + c + d)
+                .with((a, b, c, d) -> a + b + c + d)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -481,7 +481,7 @@ public class UniZipTest {
 
         UniAssertSubscriber<Integer> subscriber = Uni.combine().all().unis(uni, uni2, uni3, uni4, uni5)
                 .collectFailures()
-                .combinedWith((a, b, c, d, e) -> a + b + c + d + e)
+                .with((a, b, c, d, e) -> a + b + c + d + e)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -499,7 +499,7 @@ public class UniZipTest {
 
         UniAssertSubscriber<Integer> subscriber = Uni.combine().all().unis(uni, uni2, uni3, uni4, uni5, uni6)
                 .collectFailures()
-                .combinedWith((a, b, c, d, e, f) -> a + b + c + d + e + f)
+                .with((a, b, c, d, e, f) -> a + b + c + d + e + f)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -518,7 +518,7 @@ public class UniZipTest {
 
         UniAssertSubscriber<Integer> subscriber = Uni.combine().all().unis(uni, uni2, uni3, uni4, uni5, uni6, uni7)
                 .collectFailures()
-                .combinedWith((a, b, c, d, e, f, g) -> a + b + c + d + e + f + g)
+                .with((a, b, c, d, e, f, g) -> a + b + c + d + e + f + g)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -538,7 +538,7 @@ public class UniZipTest {
 
         UniAssertSubscriber<Integer> subscriber = Uni.combine().all().unis(uni, uni2, uni3, uni4, uni5, uni6, uni7, uni8)
                 .collectFailures()
-                .combinedWith((a, b, c, d, e, f, g, h) -> a + b + c + d + e + f + g + h)
+                .with((a, b, c, d, e, f, g, h) -> a + b + c + d + e + f + g + h)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -559,7 +559,7 @@ public class UniZipTest {
 
         UniAssertSubscriber<Integer> subscriber = Uni.combine().all().unis(uni, uni2, uni3, uni4, uni5, uni6, uni7, uni8, uni9)
                 .collectFailures()
-                .combinedWith((a, b, c, d, e, f, g, h, i) -> a + b + c + d + e + f + g + h + i)
+                .with((a, b, c, d, e, f, g, h, i) -> a + b + c + d + e + f + g + h + i)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -629,7 +629,7 @@ public class UniZipTest {
 
             UniAssertSubscriber<? extends List<?>> sub = Uni.combine().all().unis(a, b, c, d)
                     .usingConcurrencyOf(1)
-                    .combinedWith(unis -> unis)
+                    .with(unis -> unis)
                     .subscribe().withSubscriber(UniAssertSubscriber.create());
 
             sub.assertCompleted();
@@ -655,7 +655,7 @@ public class UniZipTest {
 
             UniAssertSubscriber<? extends List<?>> sub = Uni.combine().all().unis(a, b, c, d)
                     .usingConcurrencyOf(concurrency)
-                    .combinedWith(unis -> unis)
+                    .with(unis -> unis)
                     .subscribe().withSubscriber(UniAssertSubscriber.create());
 
             sub.awaitItem();
@@ -687,7 +687,7 @@ public class UniZipTest {
 
             UniAssertSubscriber<? extends List<?>> sub = Uni.combine().all().unis(a, b, c, d)
                     .usingConcurrencyOf(concurrency)
-                    .combinedWith(unis -> unis)
+                    .with(unis -> unis)
                     .subscribe().withSubscriber(UniAssertSubscriber.create());
 
             sub.awaitFailure();
@@ -720,7 +720,7 @@ public class UniZipTest {
 
             Uni.combine().all().unis(a, b)
                     .usingConcurrencyOf(1)
-                    .combinedWith(list -> list)
+                    .with(list -> list)
                     .onSubscription().invoke(box::set)
                     .subscribe().withSubscriber(UniAssertSubscriber.create());
 


### PR DESCRIPTION
- Replaces combinedWith by with((a,b,c) -> d).
- Introduces withUni((a,b,c) -> Uni).