### PR TITLE
Release CI enhancements after 2.5.0-M1

### DIFF
--- a/.build/justfile-for-release
+++ b/.build/justfile-for-release
@@ -29,7 +29,7 @@ init-gpg:
 # Initialize Git
 init-git:
     @echo "Git setup"
-    git config --global user.name "${GITHUB_ACTOR}"
+    git config --global user.name "smallrye-ci"
     git config --global user.email "smallrye@googlegroups.com"
 
 # Steps before releasing

--- a/.build/justfile-for-release
+++ b/.build/justfile-for-release
@@ -56,13 +56,16 @@ release: pre-release
     git push
     @echo "Call JReleaser"
     ./mvnw -settings .build/maven-ci-settings.xml --batch-mode --no-transfer-progress -Pjreleaser jreleaser:full-release -pl :mutiny-project
-    @echo "Deploy to Maven Central"
-    -./mvnw --settings maven-settings.xml --batch-mode --no-transfer-progress deploy -Prelease -DskipTests
     @echo "Bump to 999-SNAPSHOT and push upstream"
     ./mvnw --settings .build/maven-ci-settings.xml --batch-mode --no-transfer-progress versions:set -DnewVersion=999-SNAPSHOT -DgenerateBackupPoms=false
     ./mvnw --settings .build/maven-ci-settings.xml --batch-mode --no-transfer-progress versions:set -DnewVersion=999-SNAPSHOT -DgenerateBackupPoms=false -pl bom
     git commit -am "chore(release): set development version to 999-SNAPSHOT"
     git push
+
+# Deploy to Maven Central
+deploy-to-maven-central: decrypt-secrets init-gpg
+    @echo "Deploy to Maven Central"
+    ./mvnw --settings maven-settings.xml --batch-mode --no-transfer-progress deploy -Prelease -DskipTests
 
 # Steps post-release
 post-release:

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -20,12 +20,12 @@ jobs:
           java-version: 11
           distribution: temurin
           cache: maven
+      - name: Install just
+        uses: taiki-e/install-action@just
       - name: Build with Maven
         run: ./mvnw --no-transfer-progress -s .build/maven-ci-settings.xml -B clean verify
       - name: Deploy snapshots
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SECRET_FILES_PASSPHRASE: ${{ secrets.SECRET_FILES_PASSPHRASE }}
-        run: |
-          .build/decrypt-secrets.sh
-          .build/deploy-snapshot.sh
+        run: just -f .build/justfile-for-release -d . deploy-to-maven-central

--- a/.github/workflows/push-release-to-maven-central.yml
+++ b/.github/workflows/push-release-to-maven-central.yml
@@ -1,0 +1,25 @@
+name: Push a release to Maven Central
+
+on:
+  push:
+    tags:
+      - '2.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      SECRET_FILES_PASSPHRASE: ${{ secrets.SECRET_FILES_PASSPHRASE }}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+      - name: Java setup
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+      - name: Install just
+        uses: taiki-e/install-action@just
+      - name: Deploy tp Maven Central
+        run: just -f .build/justfile-for-release -d . deploy-to-maven-central

--- a/pom.xml
+++ b/pom.xml
@@ -547,6 +547,7 @@
                                                     <contributor>dependabot[bot]</contributor>
                                                     <contributor>bot</contributor>
                                                     <contributor>jreleaserbot</contributor>
+                                                    <contributor>smallrye-ci</contributor>
                                                 </contributors>
                                             </hide>
                                         </changelog>


### PR DESCRIPTION
A few fixes based on observations of what worked, what didn't, and what can be improved.

We're essentially back to a separate workflow to deploy to Maven Central, given how unreliable the gateway can be.
The deployment of 2.5.0-M1 had failed in CI on the Maven side due to a gateway error, but the artifacts actually made it to Maven Central.