### PR TITLE
CI Fixes after 2.5.0-M2

### DIFF
--- a/.build/justfile-for-release
+++ b/.build/justfile-for-release
@@ -53,7 +53,6 @@ release: pre-release
     @echo "🚀 Release steps..."
     @echo "Commit release version and push upstream"
     git commit -am "chore(release): release Mutiny ${RELEASE_VERSION}"
-    git push
     @echo "Call JReleaser"
     ./mvnw -settings .build/maven-ci-settings.xml --batch-mode --no-transfer-progress -Pjreleaser jreleaser:full-release -pl :mutiny-project
     @echo "Bump to 999-SNAPSHOT and push upstream"

--- a/.github/workflows/push-release-to-maven-central.yml
+++ b/.github/workflows/push-release-to-maven-central.yml
@@ -21,5 +21,5 @@ jobs:
           cache: maven
       - name: Install just
         uses: taiki-e/install-action@just
-      - name: Deploy tp Maven Central
+      - name: Deploy to Maven Central
         run: just -f .build/justfile-for-release -d . deploy-to-maven-central

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       DEPLOY_WEBSITE: ${{ github.event.inputs.deployWebsite }}
       CLEAR_REVAPI: ${{ github.event.inputs.clearRevAPI }}
       JRELEASER_TAG_NAME: ${{ github.event.inputs.version }}
+      JRELEASER_PREVIOUS_TAG_NAME: ${{ github.event.inputs.previousVersion }}
       JRELEASER_GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
     steps:


### PR DESCRIPTION
- Typo in a workflow step
- Delay git push
- Ensure JReleaser has a reference to the previous release