### PR TITLE
build(maven): use the Jandex Maven plugin from SmallRye rather than JBoss

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -116,7 +116,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
             </plugin>
             <plugin>

--- a/math/pom.xml
+++ b/math/pom.xml
@@ -72,7 +72,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <kotlin.compiler.jvmTarget>${maven.compiler.target}</kotlin.compiler.jvmTarget>
         <dokka.version>1.7.20</dokka.version>
 
-        <jandex-maven-plugin.version>1.2.3</jandex-maven-plugin.version>
+        <jandex-maven-plugin.version>3.1.5</jandex-maven-plugin.version>
         <find-and-replace-maven-plugin.version>1.1.0</find-and-replace-maven-plugin.version>
         <jreleaser-maven-plugin.version>1.8.0</jreleaser-maven-plugin.version>
     </properties>
@@ -323,7 +323,7 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.jboss.jandex</groupId>
+                    <groupId>io.smallrye</groupId>
                     <artifactId>jandex-maven-plugin</artifactId>
                     <version>${jandex-maven-plugin.version}</version>
                     <executions>


### PR DESCRIPTION
This relocation had gone un-noticed, causing Mutiny to use an older Jandex.