### PR TITLE
build(deps): bump kotlin to 1.9.10 and dokka to 1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,12 +108,12 @@
         <maven-compiler-plugin.release>11</maven-compiler-plugin.release>
 
         <!-- Configuration of mutiny-kotlin module -->
-        <kotlin.version>1.7.20</kotlin.version>
+        <kotlin.version>1.9.10</kotlin.version>
         <kotlin.compiler.apiVersion>1.5</kotlin.compiler.apiVersion>
         <kotlin.compiler.languageVersion>1.5</kotlin.compiler.languageVersion>
         <coroutines.version>1.7.3</coroutines.version>
         <kotlin.compiler.jvmTarget>${maven.compiler.target}</kotlin.compiler.jvmTarget>
-        <dokka.version>1.7.20</dokka.version>
+        <dokka.version>1.9.0</dokka.version>
 
         <jandex-maven-plugin.version>3.1.5</jandex-maven-plugin.version>
         <find-and-replace-maven-plugin.version>1.1.0</find-and-replace-maven-plugin.version>


### PR DESCRIPTION
Replaces
* https://github.com/smallrye/smallrye-mutiny/pull/1395
* https://github.com/smallrye/smallrye-mutiny/pull/1399

Kotlin 1.9.10 and coroutine 1.7.3 is also used in Quarkus BOM, so no compatibility issues should occur.