### PR TITLE
fix: do not interrupt threads on cancellation in UniDelayOnItem

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOp.java
@@ -236,7 +236,7 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
         public void onCompletion() {
             if (terminated.compareAndSet(RUNNING, SUCCEED)) {
                 if (task != null) {
-                    task.cancel(true);
+                    task.cancel(false);
                     task = null;
                 }
                 checkedComplete();

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDemandPacer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDemandPacer.java
@@ -136,7 +136,7 @@ public class MultiDemandPacer<T> extends AbstractMultiOperator<T, T> {
         @Override
         public void cancel() {
             if (scheduledFuture != null) {
-                scheduledFuture.cancel(true);
+                scheduledFuture.cancel(false);
             }
             super.cancel();
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOnDurationOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiWindowOnDurationOp.java
@@ -267,7 +267,7 @@ public class MultiWindowOnDurationOp<T> extends AbstractMultiOperator<T, Multi<T
                 Future current = container.get();
                 if (current == NONE) {
                     if (task != null) {
-                        task.cancel(true);
+                        task.cancel(false);
                     }
                     return false;
                 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiReferenceCount.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/multicast/MultiReferenceCount.java
@@ -75,7 +75,7 @@ public class MultiReferenceCount<T> extends AbstractMulti<T> implements Multi<T>
         }
 
         ScheduledFuture<?> future = executor.schedule(connection, duration.toMillis(), TimeUnit.MILLISECONDS);
-        connection.setTimer(() -> future.cancel(true));
+        connection.setTimer(() -> future.cancel(false));
     }
 
     void terminated(ConnectableMultiConnection connection) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniDelayOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniDelayOnItem.java
@@ -41,7 +41,7 @@ public class UniDelayOnItem<T> extends UniOperator<T, T> {
             if (!isCancelled()) {
                 super.cancel();
                 if (scheduledFuture != null) {
-                    scheduledFuture.cancel(true);
+                    scheduledFuture.cancel(false);
                 }
             }
         }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIgnoreTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiIgnoreTest.java
@@ -69,7 +69,7 @@ public class MultiIgnoreTest {
                 .onItem().ignoreAsUni().subscribeAsCompletionStage();
 
         assertThat(future).isNotCompleted();
-        future.cancel(true);
+        future.cancel(false);
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromFutureTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniCreateFromFutureTest.java
@@ -371,7 +371,7 @@ public class UniCreateFromFutureTest {
         UniAssertSubscriber<String> subscriber = UniAssertSubscriber.create();
         CompletableFuture<String> cs = new CompletableFuture<>();
         Uni.createFrom().future(cs).subscribe().withSubscriber(subscriber);
-        cs.cancel(true);
+        cs.cancel(false);
         subscriber
                 .awaitFailure()
                 .assertFailedWith(CancellationException.class, null);


### PR DESCRIPTION
This causes spurious interrupt signals in failure retry with exponential backoff that get propagated downstream.

Also https://twitter.com/relizarov/status/1184460504238100480

Fixes #1436