### PR TITLE
fix: pass empty contexts rather than null to UniAwait

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractUni.java
@@ -81,7 +81,7 @@ public abstract class AbstractUni<T> implements Uni<T> {
 
     @Override
     public UniAwait<T> await() {
-        return awaitUsing(null);
+        return awaitUsing(Context.empty());
     }
 
     @Override

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
@@ -217,5 +217,20 @@ public class UniAwaitTest {
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("The current thread cannot be blocked: my-forbidden-thread");
         }
+
+        @Test
+        void checkImplicitContextPassing() {
+            AtomicBoolean contextPassed = new AtomicBoolean();
+            Integer res = Uni.createFrom().item(123)
+                    .withContext((uni, ctx) -> {
+                        ctx.put("foo", "bar");
+                        return uni;
+                    })
+                    .withContext((uni, ctx) -> uni.onItem()
+                            .invoke(() -> contextPassed.set(ctx.getOrElse("foo", () -> "n/a").equals("bar"))))
+                    .await().indefinitely();
+            assertThat(res).isEqualTo(123);
+            assertThat(contextPassed).isTrue();
+        }
     }
 }


### PR DESCRIPTION
When no context is specified, Context.empty() must be used rather than null.

Fixes #1457