### PR TITLE
add function interface to assertItem

### DIFF
--- a/documentation/src/test/java/guides/TestSubscribersTest.java
+++ b/documentation/src/test/java/guides/TestSubscribersTest.java
@@ -54,19 +54,16 @@ public class TestSubscribersTest {
 
     @Test
     void uniFunction() {
-        // <uni-function>
         Uni<Integer> uni = Uni.createFrom().item(63);
 
         UniAssertSubscriber<Integer> subscriber = uni
             .subscribe().withSubscriber(UniAssertSubscriber.create());
 
         subscriber.assertSubscribed().assertItem(String::valueOf, "63");
-        // </uni-function>
     }
 
     @Test
     void uniFunctionWithObjects() {
-        // <uni-function-with-objects>
         class Person {
             String name;
             int age;
@@ -82,6 +79,5 @@ public class TestSubscribersTest {
 
         subscriber.assertSubscribed().assertItem(p -> p.name, person.name);
         subscriber.assertSubscribed().assertItem(p -> p.age, person.age);
-        // </uni-function-with-objects>
     }
 }

--- a/documentation/src/test/java/guides/TestSubscribersTest.java
+++ b/documentation/src/test/java/guides/TestSubscribersTest.java
@@ -51,4 +51,37 @@ public class TestSubscribersTest {
                 .assertFailedWith(IOException.class, "Boom");
         // </failing>
     }
+
+    @Test
+    void uniFunction() {
+        // <uni-function>
+        Uni<Integer> uni = Uni.createFrom().item(63);
+
+        UniAssertSubscriber<Integer> subscriber = uni
+            .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertSubscribed().assertItem(String::valueOf, "63");
+        // </uni-function>
+    }
+
+    @Test
+    void uniFunctionWithObjects() {
+        // <uni-function-with-objects>
+        class Person {
+            String name;
+            int age;
+        }
+
+        Person person = new Person();
+        person.name = "John";
+        person.age = 42;
+        Uni<Person> uni = Uni.createFrom().item(person);
+
+        UniAssertSubscriber<Person> subscriber = uni
+            .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertSubscribed().assertItem(p -> p.name, person.name);
+        subscriber.assertSubscribed().assertItem(p -> p.age, person.age);
+        // </uni-function-with-objects>
+    }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/helpers/test/UniAssertSubscriber.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/helpers/test/UniAssertSubscriber.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.subscription.UniSubscriber;
@@ -339,6 +340,17 @@ public class UniAssertSubscriber<T> implements UniSubscriber<T> {
         shouldHaveCompleted(hasCompletedSuccessfully, failure, null);
         shouldHaveReceived(getItem(), expected);
         return this;
+    }
+
+    /**
+     * Assert that the {@link io.smallrye.mutiny.Uni} has received an item.
+     * @param function the function to apply the item to assert on
+     * @param expected the expected item
+     * @param <R> the return type of the item
+     */
+    public <R> void assertItem(Function<T, R> function, R expected) {
+        shouldHaveCompleted(hasCompletedSuccessfully, failure, null);
+        shouldHaveReceived(function.apply(getItem()), expected);
     }
 
     /**


### PR DESCRIPTION
Hi all,

This PR is a small add-on on top of the existing methods to make assertions easier.

With this we are allowed to transform and assert as we please instead of the full item and the equals equivalency of the item.

Example
```
class Person {
    int age;
    String name;
}

UniAssertSubscriber<Person> subscriber = uni
    .subscribe().withSubscriber(UniAssertSubscriber.create());
subscriber.assertSubscribed().assertItem(p -> p.name, person.name);
```
