### PR TITLE
fix: disable the Maven compiler plugin in the Kotlin module

### DIFF
--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -72,6 +72,14 @@
         <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                    <skipMain>true</skipMain>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>
@@ -147,5 +155,5 @@
             </build>
         </profile>
     </profiles>
-    
+
 </project>


### PR DESCRIPTION
This fixes a compilation failure when upgrading to version 3.12.0
of the maven-compiler-plugin.

Fixes #1470
