### PR TITLE
fix: properly remove subscriptions in ReplayOperator

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/replay/AppendOnlyReplayList.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/replay/AppendOnlyReplayList.java
@@ -60,6 +60,10 @@ public class AppendOnlyReplayList {
             return current.value instanceof Completion;
         }
 
+        public boolean willReachCompletion() {
+            return !hasReachedCompletion() && current.next.value instanceof Completion;
+        }
+
         public boolean hasReachedFailure() {
             return current.value instanceof Failure;
         }

--- a/implementation/src/test/java/io/smallrye/mutiny/groups/MultiReplayTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/MultiReplayTest.java
@@ -9,8 +9,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -62,6 +67,17 @@ class MultiReplayTest {
         sub.request(4);
         assertThat(sub.getItems()).containsExactly(1, 2, 3, 4);
         sub.request(Long.MAX_VALUE);
+        assertThat(sub.getItems()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        sub.assertCompleted();
+    }
+
+    @Test
+    void shouldCompleteWhenRequestEqualsMax() {
+        Multi<Integer> upstream = Multi.createFrom().range(1, 10);
+        Multi<Integer> replay = Multi.createBy().replaying().upTo(9).ofMulti(upstream);
+
+        AssertSubscriber<Integer> sub = replay.subscribe().withSubscriber(AssertSubscriber.create());
+        sub.request(9);
         assertThat(sub.getItems()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9);
         sub.assertCompleted();
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/replay/ReplayOperatorTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/replay/ReplayOperatorTest.java
@@ -1,0 +1,27 @@
+package io.smallrye.mutiny.operators.multi.replay;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+
+public class ReplayOperatorTest {
+
+    @Test
+    public void shouldRemoveSubscriptionAfterCompletion() {
+        // given
+        var upstream = Multi.createFrom().range(0, 3);
+        var operator = new ReplayOperator<>(upstream, 3);
+
+        // when
+        var subscriber = operator.subscribe().withSubscriber(AssertSubscriber.create(3));
+        var subscriber2 = operator.subscribe().withSubscriber(AssertSubscriber.create(3));
+
+        // then
+        subscriber.assertItems(0, 1, 2).assertCompleted();
+        subscriber2.assertItems(0, 1, 2).assertCompleted();
+        assertEquals(0, operator.subscriptions.size());
+    }
+}


### PR DESCRIPTION
Fixes a memory leak caused by old subscriptions not being removed properly. In addition, this fixes the edge case where no completion event would be sent for replay subscriptions if the number of requested items was exactly equal to the number of available items.

Fixes #1482