### PR TITLE
fix(ci): do not check conventional commits with dependabot

### DIFF
--- a/.github/workflows/build-pull.yml
+++ b/.github/workflows/build-pull.yml
@@ -41,6 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wagoid/commitlint-github-action@v6
+        if: (github.actor!= 'dependabot[bot]') && (contains(github.head_ref, 'dependabot/') == false)
 
   compatibility:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The reason is that dependabot easily creates long commit lines due to the artifact names, breaking rules.

Inspired by https://github.com/felipecrs/bindl/commit/f7de680e7bf39dde5e524dca0a0a13deb4c32574