### PR TITLE
Additional overload of distinct using a key extractor

### DIFF
--- a/documentation/docs/guides/eliminate-duplicates-and-repetitions.md
+++ b/documentation/docs/guides/eliminate-duplicates-and-repetitions.md
@@ -29,6 +29,11 @@ If you have a stream emitting the `{1, 1, 2, 3, 4, 5, 5, 6, 1, 4, 4}` items, the
     By default, `select().distinct()` uses the `hashCode` method from the item's class.
     You can pass a custom comparator for more advanced checks.
 
+If you have a stream emitting items of type `T`, where duplicates can be identified through an attribute of `T` of type `K`,
+then an `extractor` of type `Function<T, K>` can be defined. Applying `.select().distinct(extractor)` on such a stream will
+eliminate duplicates but have a lesser memory overhead as only the references to the extracted keys need to be kept, not the whole object.
+A typical usage of this might be for a stream of records where uniqueness is determined by a UUID assigned to every record.
+
 ## Skipping repetitions
 
 The `.skip().repetitions()` operator removes subsequent repetitions of an item:

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDistinctByKeyOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiDistinctByKeyOp.java
@@ -1,0 +1,83 @@
+package io.smallrye.mutiny.operators.multi;
+
+import java.util.*;
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.ParameterValidation;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+/**
+ * Eliminates the duplicated items from the upstream.
+ *
+ * @param <T> the type of items
+ * @param <K> the type of key, used to identify duplicates
+ */
+public final class MultiDistinctByKeyOp<T, K> extends AbstractMultiOperator<T, T> {
+
+    private final Function<T, K> keyExtractor;
+
+    public MultiDistinctByKeyOp(Multi<? extends T> upstream, Function<T, K> keyExtractor) {
+        super(upstream);
+        this.keyExtractor = keyExtractor;
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super T> subscriber) {
+        upstream.subscribe(
+                new DistinctByKeyProcessor<>(ParameterValidation.nonNullNpe(subscriber, "subscriber"), keyExtractor));
+    }
+
+    static final class DistinctByKeyProcessor<T, K> extends MultiOperatorProcessor<T, T> {
+
+        private final Collection<K> foundKeys = new HashSet<>();
+        private final Function<T, K> keyExtractor;
+
+        DistinctByKeyProcessor(MultiSubscriber<? super T> downstream,
+                Function<T, K> keyExtractor) {
+            super(downstream);
+            this.keyExtractor = keyExtractor;
+        }
+
+        @Override
+        public void onItem(T t) {
+            if (isDone()) {
+                return;
+            }
+
+            boolean added;
+            try {
+                added = foundKeys.add(keyExtractor.apply(t));
+            } catch (Throwable e) {
+                // catch exception thrown by the equals / comparator
+                failAndCancel(e);
+                return;
+            }
+
+            if (added) {
+                downstream.onItem(t);
+            } else {
+                request(1);
+            }
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            super.onFailure(t);
+            foundKeys.clear();
+        }
+
+        @Override
+        public void onCompletion() {
+            super.onCompletion();
+            foundKeys.clear();
+        }
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            foundKeys.clear();
+        }
+    }
+
+}

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiDistinctTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiDistinctTest.java
@@ -529,10 +529,12 @@ public class MultiDistinctTest {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o)
+            if (this == o) {
                 return true;
-            if (o == null || getClass() != o.getClass())
+            }
+            if (o == null || getClass() != o.getClass()) {
                 return false;
+            }
             KeyTester keyTester = (KeyTester) o;
             return id == keyTester.id && Objects.equals(text, keyTester.text);
         }

--- a/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/MultiSelectDistinctByKeyTckTest.java
+++ b/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/MultiSelectDistinctByKeyTckTest.java
@@ -1,0 +1,94 @@
+package io.smallrye.mutiny.tcktests;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
+import java.util.function.Function;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.Subscriptions;
+
+public class MultiSelectDistinctByKeyTckTest extends AbstractPublisherTck<Long> {
+    @Test
+    public void distinctStageShouldReturnDistinctElements() {
+        Assert.assertEquals(
+                Await.await(
+                        Multi.createFrom().items(1, 2, 2, 3, 2, 1, 3)
+                                .select().distinct(Function.identity())
+                                .collect().asList()
+                                .subscribeAsCompletionStage()),
+                Arrays.asList(1, 2, 3));
+    }
+
+    @Test
+    public void distinctStageShouldReturnAnEmptyStreamWhenCalledOnEmptyStreams() {
+        Assert.assertEquals(
+                Await.await(Multi.createFrom().empty()
+                        .select().distinct(Function.identity())
+                        .collect().asList()
+                        .subscribeAsCompletionStage()),
+                Collections.emptyList());
+    }
+
+    @Test
+    public void distinctStageShouldPropagateUpstreamExceptions() {
+        Assert.assertThrows(QuietRuntimeException.class,
+                () -> Await.await(Multi.createFrom().failure(new QuietRuntimeException("failed"))
+                        .select().distinct(Function.identity())
+                        .collect().asList()
+                        .subscribeAsCompletionStage()));
+    }
+
+    @Test
+    public void distinctStageShouldPropagateExceptionsThrownByEquals() {
+        Assert.assertThrows(QuietRuntimeException.class, () -> {
+            CompletableFuture<Void> cancelled = new CompletableFuture<>();
+            class ObjectThatThrowsFromEquals {
+                @Override
+                public int hashCode() {
+                    return 1;
+                }
+
+                @Override
+                public boolean equals(Object obj) {
+                    throw new QuietRuntimeException("failed");
+                }
+            }
+            CompletionStage<List<ObjectThatThrowsFromEquals>> result = Multi.createFrom().items(
+                    new ObjectThatThrowsFromEquals(), new ObjectThatThrowsFromEquals())
+                    .onTermination().invoke(() -> cancelled.complete(null))
+                    .select().distinct(Function.identity())
+                    .collect().asList().subscribeAsCompletionStage();
+            Await.await(cancelled);
+            Await.await(result);
+        });
+    }
+
+    @Test
+    public void distinctStageShouldPropagateCancel() {
+        CompletableFuture<Void> cancelled = new CompletableFuture<>();
+        infiniteStream()
+                .onTermination().invoke(() -> cancelled.complete(null))
+                .select().distinct(Function.identity()).subscribe()
+                .withSubscriber(new Subscriptions.CancelledSubscriber<>());
+        Await.await(cancelled);
+    }
+
+    @Override
+    public Flow.Publisher<Long> createFlowPublisher(long elements) {
+        return upstream(elements)
+                .select().distinct(Function.identity());
+    }
+
+    @Override
+    public Flow.Publisher<Long> createFailedFlowPublisher() {
+        return failedUpstream()
+                .select().distinct(Function.identity());
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/smallrye/smallrye-mutiny/discussions/1729, this PR adds an overload to `distinct` in `MultiSelect` so that a function can be provided to extract a key which is used to eliminate duplicates. This can provide a lower memory footprint than the 2 existing methods as only references to simpler key objects need to be kept rather than the objects themselves. An typical usage would be for cases the stream consists of large, complex objects but where a integer id can be used to identify duplicates.

This PR adds a new `AbstractMultiOperator` - `MultiDistinctByKeyOp` which is more or less the same as `MultiDistinctOp` with the addition of the extractor function and removal of the comparator. I think it would be possible to combine these classes, but as there is an additional types parameter involved (for the type of the extracted keys) it would require either a `Function.identity()` to be used (for the existing operations) or some casting in order to keep the types aligned. I wasn't prepared to go down that route without some discussions.

Unit tests and TCK tests have been added as well. The TCK could probably be improved as at the moment they just use `Function.identity`, but wasn't quite sure what would make sense to do.