### PR TITLE
feat: improve type safety when combining unis with limited concurrency

### DIFF
--- a/implementation/revapi.json
+++ b/implementation/revapi.json
@@ -51,7 +51,64 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+      {
+        "ignore": true,
+        "code": "java.method.returnTypeChangedCovariantly",
+        "old": "method io.smallrye.mutiny.groups.UniAndGroupIterable<T1> io.smallrye.mutiny.groups.UniAndGroupIterable<T1>::usingConcurrencyOf(int) @ io.smallrye.mutiny.groups.UniAndGroup2<T1, T2>",
+        "new": "method io.smallrye.mutiny.groups.UniAndGroup2<T1, T2> io.smallrye.mutiny.groups.UniAndGroup2<T1, T2>::usingConcurrencyOf(int)",
+        "justification": "Override `usingConcurrencyOf` in `UniAndGroup2` for improved type safety"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.returnTypeChangedCovariantly",
+        "old": "method io.smallrye.mutiny.groups.UniAndGroupIterable<T1> io.smallrye.mutiny.groups.UniAndGroupIterable<T1>::usingConcurrencyOf(int) @ io.smallrye.mutiny.groups.UniAndGroup3<T1, T2, T3>",
+        "new": "method io.smallrye.mutiny.groups.UniAndGroup3<T1, T2, T3> io.smallrye.mutiny.groups.UniAndGroup3<T1, T2, T3>::usingConcurrencyOf(int)",
+        "justification": "Override `usingConcurrencyOf` in `UniAndGroup3` for improved type safety"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.returnTypeChangedCovariantly",
+        "old": "method io.smallrye.mutiny.groups.UniAndGroupIterable<T1> io.smallrye.mutiny.groups.UniAndGroupIterable<T1>::usingConcurrencyOf(int) @ io.smallrye.mutiny.groups.UniAndGroup4<T1, T2, T3, T4>",
+        "new": "method io.smallrye.mutiny.groups.UniAndGroup4<T1, T2, T3, T4> io.smallrye.mutiny.groups.UniAndGroup4<T1, T2, T3, T4>::usingConcurrencyOf(int)",
+        "justification": "Override `usingConcurrencyOf` in `UniAndGroup4` for improved type safety"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.returnTypeChangedCovariantly",
+        "old": "method io.smallrye.mutiny.groups.UniAndGroupIterable<T1> io.smallrye.mutiny.groups.UniAndGroupIterable<T1>::usingConcurrencyOf(int) @ io.smallrye.mutiny.groups.UniAndGroup5<T1, T2, T3, T4, T5>",
+        "new": "method io.smallrye.mutiny.groups.UniAndGroup5<T1, T2, T3, T4, T5> io.smallrye.mutiny.groups.UniAndGroup5<T1, T2, T3, T4, T5>::usingConcurrencyOf(int)",
+        "justification": "Override `usingConcurrencyOf` in `UniAndGroup5` for improved type safety"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.returnTypeChangedCovariantly",
+        "old": "method io.smallrye.mutiny.groups.UniAndGroupIterable<T1> io.smallrye.mutiny.groups.UniAndGroupIterable<T1>::usingConcurrencyOf(int) @ io.smallrye.mutiny.groups.UniAndGroup6<T1, T2, T3, T4, T5, T6>",
+        "new": "method io.smallrye.mutiny.groups.UniAndGroup6<T1, T2, T3, T4, T5, T6> io.smallrye.mutiny.groups.UniAndGroup6<T1, T2, T3, T4, T5, T6>::usingConcurrencyOf(int)",
+        "justification": "Override `usingConcurrencyOf` in `UniAndGroup6` for improved type safety"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.returnTypeChangedCovariantly",
+        "old": "method io.smallrye.mutiny.groups.UniAndGroupIterable<T1> io.smallrye.mutiny.groups.UniAndGroupIterable<T1>::usingConcurrencyOf(int) @ io.smallrye.mutiny.groups.UniAndGroup7<T1, T2, T3, T4, T5, T6, T7>",
+        "new": "method io.smallrye.mutiny.groups.UniAndGroup7<T1, T2, T3, T4, T5, T6, T7> io.smallrye.mutiny.groups.UniAndGroup7<T1, T2, T3, T4, T5, T6, T7>::usingConcurrencyOf(int)",
+        "justification": "Override `usingConcurrencyOf` in `UniAndGroup7` for improved type safety"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.returnTypeChangedCovariantly",
+        "old": "method io.smallrye.mutiny.groups.UniAndGroupIterable<T1> io.smallrye.mutiny.groups.UniAndGroupIterable<T1>::usingConcurrencyOf(int) @ io.smallrye.mutiny.groups.UniAndGroup8<T1, T2, T3, T4, T5, T6, T7, T8>",
+        "new": "method io.smallrye.mutiny.groups.UniAndGroup8<T1, T2, T3, T4, T5, T6, T7, T8> io.smallrye.mutiny.groups.UniAndGroup8<T1, T2, T3, T4, T5, T6, T7, T8>::usingConcurrencyOf(int)",
+        "justification": "Override `usingConcurrencyOf` in `UniAndGroup8` for improved type safety"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.returnTypeChangedCovariantly",
+        "old": "method io.smallrye.mutiny.groups.UniAndGroupIterable<T1> io.smallrye.mutiny.groups.UniAndGroupIterable<T1>::usingConcurrencyOf(int) @ io.smallrye.mutiny.groups.UniAndGroup9<T1, T2, T3, T4, T5, T6, T7, T8, T9>",
+        "new": "method io.smallrye.mutiny.groups.UniAndGroup9<T1, T2, T3, T4, T5, T6, T7, T8, T9> io.smallrye.mutiny.groups.UniAndGroup9<T1, T2, T3, T4, T5, T6, T7, T8, T9>::usingConcurrencyOf(int)",
+        "justification": "Override `usingConcurrencyOf` in `UniAndGroup9` for improved type safety"
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup2.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup2.java
@@ -48,6 +48,23 @@ public class UniAndGroup2<T1, T2> extends UniAndGroupIterable<T1> {
     }
 
     /**
+     * Limit the number of concurrent upstream subscriptions.
+     * <p>
+     * When not specified all upstream {@link Uni} are being subscribed when the combining {@link Uni} is subscribed.
+     * <p>
+     * Setting a limit is useful when you have a large number of {@link Uni} to combine and their simultaneous
+     * subscriptions might overwhelm resources (e.g., database connections, etc).
+     *
+     * @param level the concurrency level, must be strictly positive
+     * @return an object to configure the combination logic
+     */
+    @CheckReturnValue
+    public UniAndGroup2<T1, T2> usingConcurrencyOf(int level) {
+        super.usingConcurrencyOf(level);
+        return this;
+    }
+
+    /**
      * Creates the resulting {@link Uni}. The items are combined using the given combinator function.
      *
      * @param combinator the combinator function, must not be {@code null}

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup3.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup3.java
@@ -31,6 +31,23 @@ public class UniAndGroup3<T1, T2, T3> extends UniAndGroupIterable<T1> {
     }
 
     /**
+     * Limit the number of concurrent upstream subscriptions.
+     * <p>
+     * When not specified all upstream {@link Uni} are being subscribed when the combining {@link Uni} is subscribed.
+     * <p>
+     * Setting a limit is useful when you have a large number of {@link Uni} to combine and their simultaneous
+     * subscriptions might overwhelm resources (e.g., database connections, etc).
+     *
+     * @param level the concurrency level, must be strictly positive
+     * @return an object to configure the combination logic
+     */
+    @CheckReturnValue
+    public UniAndGroup3<T1, T2, T3> usingConcurrencyOf(int level) {
+        super.usingConcurrencyOf(level);
+        return this;
+    }
+
+    /**
      * @deprecated use {@link #with(Functions.Function3)} instead
      */
     @Deprecated(forRemoval = true)

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup4.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup4.java
@@ -31,6 +31,23 @@ public class UniAndGroup4<T1, T2, T3, T4> extends UniAndGroupIterable<T1> {
     }
 
     /**
+     * Limit the number of concurrent upstream subscriptions.
+     * <p>
+     * When not specified all upstream {@link Uni} are being subscribed when the combining {@link Uni} is subscribed.
+     * <p>
+     * Setting a limit is useful when you have a large number of {@link Uni} to combine and their simultaneous
+     * subscriptions might overwhelm resources (e.g., database connections, etc).
+     *
+     * @param level the concurrency level, must be strictly positive
+     * @return an object to configure the combination logic
+     */
+    @CheckReturnValue
+    public UniAndGroup4<T1, T2, T3, T4> usingConcurrencyOf(int level) {
+        super.usingConcurrencyOf(level);
+        return this;
+    }
+
+    /**
      * @deprecated use {@link #with(Functions.Function4)} instead
      */
     @Deprecated(forRemoval = true)

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup5.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup5.java
@@ -32,6 +32,23 @@ public class UniAndGroup5<T1, T2, T3, T4, T5> extends UniAndGroupIterable<T1> {
     }
 
     /**
+     * Limit the number of concurrent upstream subscriptions.
+     * <p>
+     * When not specified all upstream {@link Uni} are being subscribed when the combining {@link Uni} is subscribed.
+     * <p>
+     * Setting a limit is useful when you have a large number of {@link Uni} to combine and their simultaneous
+     * subscriptions might overwhelm resources (e.g., database connections, etc).
+     *
+     * @param level the concurrency level, must be strictly positive
+     * @return an object to configure the combination logic
+     */
+    @CheckReturnValue
+    public UniAndGroup5<T1, T2, T3, T4, T5> usingConcurrencyOf(int level) {
+        super.usingConcurrencyOf(level);
+        return this;
+    }
+
+    /**
      * @deprecated use {@link #with(Functions.Function5)} instead
      */
     @Deprecated(forRemoval = true)

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup6.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup6.java
@@ -32,6 +32,23 @@ public class UniAndGroup6<T1, T2, T3, T4, T5, T6> extends UniAndGroupIterable<T1
     }
 
     /**
+     * Limit the number of concurrent upstream subscriptions.
+     * <p>
+     * When not specified all upstream {@link Uni} are being subscribed when the combining {@link Uni} is subscribed.
+     * <p>
+     * Setting a limit is useful when you have a large number of {@link Uni} to combine and their simultaneous
+     * subscriptions might overwhelm resources (e.g., database connections, etc).
+     *
+     * @param level the concurrency level, must be strictly positive
+     * @return an object to configure the combination logic
+     */
+    @CheckReturnValue
+    public UniAndGroup6<T1, T2, T3, T4, T5, T6> usingConcurrencyOf(int level) {
+        super.usingConcurrencyOf(level);
+        return this;
+    }
+
+    /**
      * @deprecated use {@link #with(Functions.Function6)} instead
      */
     @Deprecated(forRemoval = true)

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup7.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup7.java
@@ -32,6 +32,23 @@ public class UniAndGroup7<T1, T2, T3, T4, T5, T6, T7> extends UniAndGroupIterabl
     }
 
     /**
+     * Limit the number of concurrent upstream subscriptions.
+     * <p>
+     * When not specified all upstream {@link Uni} are being subscribed when the combining {@link Uni} is subscribed.
+     * <p>
+     * Setting a limit is useful when you have a large number of {@link Uni} to combine and their simultaneous
+     * subscriptions might overwhelm resources (e.g., database connections, etc).
+     *
+     * @param level the concurrency level, must be strictly positive
+     * @return an object to configure the combination logic
+     */
+    @CheckReturnValue
+    public UniAndGroup7<T1, T2, T3, T4, T5, T6, T7> usingConcurrencyOf(int level) {
+        super.usingConcurrencyOf(level);
+        return this;
+    }
+
+    /**
      * @deprecated use {@link #with(Functions.Function7)} instead
      */
     @Deprecated(forRemoval = true)

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup8.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup8.java
@@ -34,6 +34,23 @@ public class UniAndGroup8<T1, T2, T3, T4, T5, T6, T7, T8> extends UniAndGroupIte
     }
 
     /**
+     * Limit the number of concurrent upstream subscriptions.
+     * <p>
+     * When not specified all upstream {@link Uni} are being subscribed when the combining {@link Uni} is subscribed.
+     * <p>
+     * Setting a limit is useful when you have a large number of {@link Uni} to combine and their simultaneous
+     * subscriptions might overwhelm resources (e.g., database connections, etc).
+     *
+     * @param level the concurrency level, must be strictly positive
+     * @return an object to configure the combination logic
+     */
+    @CheckReturnValue
+    public UniAndGroup8<T1, T2, T3, T4, T5, T6, T7, T8> usingConcurrencyOf(int level) {
+        super.usingConcurrencyOf(level);
+        return this;
+    }
+
+    /**
      * @deprecated use {@link #with(Functions.Function8)} instead
      */
     @Deprecated(forRemoval = true)

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup9.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniAndGroup9.java
@@ -34,6 +34,23 @@ public class UniAndGroup9<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends UniAndGrou
     }
 
     /**
+     * Limit the number of concurrent upstream subscriptions.
+     * <p>
+     * When not specified all upstream {@link Uni} are being subscribed when the combining {@link Uni} is subscribed.
+     * <p>
+     * Setting a limit is useful when you have a large number of {@link Uni} to combine and their simultaneous
+     * subscriptions might overwhelm resources (e.g., database connections, etc).
+     *
+     * @param level the concurrency level, must be strictly positive
+     * @return an object to configure the combination logic
+     */
+    @CheckReturnValue
+    public UniAndGroup9<T1, T2, T3, T4, T5, T6, T7, T8, T9> usingConcurrencyOf(int level) {
+        super.usingConcurrencyOf(level);
+        return this;
+    }
+
+    /**
      * @deprecated use {@link #with(Functions.Function9)} instead
      */
     @Deprecated(forRemoval = true)

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniZipTest.java
@@ -636,6 +636,138 @@ public class UniZipTest {
             assertThat(sub.getItem()).asInstanceOf(LIST).containsExactly(1, 2, 3, 4);
         }
 
+        @Test
+        void combineAllTypesafeWith2() {
+            Uni<String> a = Uni.createFrom().item("1");
+            Uni<Integer> b = Uni.createFrom().item(2);
+
+            UniAssertSubscriber<Integer> sub = Uni.combine().all().unis(a, b)
+                    .usingConcurrencyOf(1)
+                    .with((x1, x2) -> Integer.parseInt(x1) + x2)
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.awaitItem().assertItem(3);
+        }
+
+        @Test
+        void combineAllTypesafeWith3() {
+            Uni<String> a = Uni.createFrom().item("1");
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+
+            UniAssertSubscriber<Integer> sub = Uni.combine().all().unis(a, b, c)
+                    .usingConcurrencyOf(1)
+                    .with((x1, x2, x3) -> Integer.parseInt(x1) + x2 + x3)
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.awaitItem().assertItem(6);
+        }
+
+        @Test
+        void combineAllTypesafeWith4() {
+            Uni<String> a = Uni.createFrom().item("1");
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+            Uni<Integer> d = Uni.createFrom().item(4);
+
+            UniAssertSubscriber<Integer> sub = Uni.combine().all().unis(a, b, c, d)
+                    .usingConcurrencyOf(1)
+                    .with((x1, x2, x3, x4) -> Integer.parseInt(x1) + x2 + x3 + x4)
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.awaitItem().assertItem(10);
+        }
+
+        @Test
+        void combineAllTypesafeWith5() {
+            Uni<String> a = Uni.createFrom().item("1");
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+            Uni<Integer> d = Uni.createFrom().item(4);
+            Uni<Integer> e = Uni.createFrom().item(5);
+
+            UniAssertSubscriber<Integer> sub = Uni.combine().all().unis(a, b, c, d, e)
+                    .usingConcurrencyOf(1)
+                    .with((x1, x2, x3, x4, x5) -> Integer.parseInt(x1) + x2 + x3 + x4 + x5)
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.awaitItem().assertItem(15);
+        }
+
+        @Test
+        void combineAllTypesafeWith6() {
+            Uni<String> a = Uni.createFrom().item("1");
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+            Uni<Integer> d = Uni.createFrom().item(4);
+            Uni<Integer> e = Uni.createFrom().item(5);
+            Uni<Integer> f = Uni.createFrom().item(6);
+
+            UniAssertSubscriber<Integer> sub = Uni.combine().all().unis(a, b, c, d, e, f)
+                    .usingConcurrencyOf(1)
+                    .with((x1, x2, x3, x4, x5, x6) -> Integer.parseInt(x1) + x2 + x3 + x4 + x5 + x6)
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.awaitItem().assertItem(21);
+        }
+
+        @Test
+        void combineAllTypesafeWith7() {
+            Uni<String> a = Uni.createFrom().item("1");
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+            Uni<Integer> d = Uni.createFrom().item(4);
+            Uni<Integer> e = Uni.createFrom().item(5);
+            Uni<Integer> f = Uni.createFrom().item(6);
+            Uni<Integer> g = Uni.createFrom().item(7);
+
+            UniAssertSubscriber<Integer> sub = Uni.combine().all().unis(a, b, c, d, e, f, g)
+                    .usingConcurrencyOf(1)
+                    .with((x1, x2, x3, x4, x5, x6, x7) -> Integer.parseInt(x1) + x2 + x3 + x4 + x5 + x6 + x7)
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.awaitItem().assertItem(28);
+        }
+
+        @Test
+        void combineAllTypesafeWith8() {
+            Uni<String> a = Uni.createFrom().item("1");
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+            Uni<Integer> d = Uni.createFrom().item(4);
+            Uni<Integer> e = Uni.createFrom().item(5);
+            Uni<Integer> f = Uni.createFrom().item(6);
+            Uni<Integer> g = Uni.createFrom().item(7);
+            Uni<Integer> h = Uni.createFrom().item(8);
+
+            UniAssertSubscriber<Integer> sub = Uni.combine().all().unis(a, b, c, d, e, f, g, h)
+                    .usingConcurrencyOf(1)
+                    .with((x1, x2, x3, x4, x5, x6, x7, x8) -> Integer.parseInt(x1) + x2 + x3 + x4 + x5 + x6 + x7 + x8)
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.awaitItem().assertItem(36);
+        }
+
+        @Test
+        void combineAllTypesafeWith9() {
+            Uni<String> a = Uni.createFrom().item("1");
+            Uni<Integer> b = Uni.createFrom().item(2);
+            Uni<Integer> c = Uni.createFrom().item(3);
+            Uni<Integer> d = Uni.createFrom().item(4);
+            Uni<Integer> e = Uni.createFrom().item(5);
+            Uni<Integer> f = Uni.createFrom().item(6);
+            Uni<Integer> g = Uni.createFrom().item(7);
+            Uni<Integer> h = Uni.createFrom().item(8);
+            Uni<Integer> i = Uni.createFrom().item(9);
+
+            UniAssertSubscriber<Integer> sub = Uni.combine().all().unis(a, b, c, d, e, f, g, h, i)
+                    .usingConcurrencyOf(1)
+                    .with((x1, x2, x3, x4, x5, x6, x7, x8, x9) -> Integer.parseInt(x1) + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9)
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            sub.awaitItem().assertItem(45);
+        }
+
         @ParameterizedTest
         @CsvSource({
                 "1, 100, 1, 400",


### PR DESCRIPTION
As discussed in #1735, this PR adds method overriding of the `usingConcurrencyOf(int)` to the classes `UniAndGroup2` , `UniAndGroup3`, `UniAndGroup4` and similar classes. 

Currently, `usingConcurrencyOf(int)` is implemented only in their common parent class `UniAndGroupIterable` which return an `UniAndGroupIterable` object, resulting in a loss of type information.

For example:

```java
public Uni<Integer> sumFromUnis() {
  Uni<String> a = Uni.createFrom().item("1");
  Uni<Integer> b = Uni.createFrom().item(2);
  Uni<Float> c = Uni.createFrom().item(3.141);

  return Uni.combine().all().unis(a, b, c)
    .usingConcurrencyOf(1)
    .with(l -> Integer.parseInt((String) l.get(0)) + (Integer) l.get(1) + Math.round((Float) l.get(2));
}
```

In this example, we must use `.with(List<T1>)` of `UniAndGroupIterable` which lacks specific type information about each uni. As a result, we nee to cast each list element to its expected type, which may easily introduce new errors.

With this PR, the `usingConcurrencyOf` method in each typed `UniAndGroupX` class returns the appropriate typed `UniAndGroupX` instance. This allows the use of the corresponding `.with` method directly, simplifying the example as follows:

```java
public Uni<Integer> sumFromUnis() {
  Uni<String> a = Uni.createFrom().item("1");
  Uni<Integer> b = Uni.createFrom().item(2);
  Uni<Float> c = Uni.createFrom().item(3.141);

  return Uni.combine().all().unis(a, b, c)
    .usingConcurrencyOf(1)
    .with((x1, x2, x3) -> Integer.parseInt(x1) + x2 + Math.round(x3);
}
```

This solution maintains the source API without breaking any existing test. However, Revapi flags it as a binary incompatibility issue due to a covariant return type change (see https://revapi.org/revapi-java/0.28.1/differences.html#java.method.returnTypeChangedCovariantly).