### PR TITLE
Align the Uni::eventually operators to onTermination() semantics

### DIFF
--- a/documentation/docs/guides/shortcut-methods.md
+++ b/documentation/docs/guides/shortcut-methods.md
@@ -28,16 +28,16 @@ This is useful to execute an asynchronous action without modifying incoming item
 
 The following table lists the available shortcuts available by the `Uni` class:
 
-| Shortcut                                                 | Equivalent                                                                                          |
-|----------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
-| `uni.map(x -> y)`                                        | `uni.onItem().transform(x -> y)`                                                                    |
-| `uni.flatMap(x -> uni2)`                                 | `uni.onItem().transformToUni(x -> uni2)`                                                            |
-| `uni.chain(x -> uni2)`                                   | `uni.onItem().transformToUni(x -> uni2)`                                                            |
-| `uni.invoke(x -> System.out.println(x))`                 | `uni.onItem().invoke(x -> System.out.println(x))`                                                   |
-| `uni.call(x -> uni2)`                                    | `uni.onItem().call(x -> uni2)`                                                                      |
-| `uni.eventually(() -> System.out.println("eventually"))` | `uni.onItemOrFailure().invoke((ignoredItem, ignoredException) -> System.out.println("eventually"))` |
-| `uni.eventually(() -> uni2)`                             | `uni.onItemOrFailure().call((ignoredItem, ignoredException) -> uni2)`                               |
-| `uni.replaceWith(x)`                                     | `uni.onItem().transform(ignored -> x)`                                                              |
-| `uni.replaceWith(uni2)`                                  | `uni.onItem().transformToUni(ignored -> uni2)`                                                      |
-| `uni.replaceIfNullWith(x)`                               | `uni.onItem().ifNull().continueWith(x)`                                                             |
+| Shortcut                                                 | Equivalent                                                                           |
+|----------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `uni.map(x -> y)`                                        | `uni.onItem().transform(x -> y)`                                                     |
+| `uni.flatMap(x -> uni2)`                                 | `uni.onItem().transformToUni(x -> uni2)`                                             |
+| `uni.chain(x -> uni2)`                                   | `uni.onItem().transformToUni(x -> uni2)`                                             |
+| `uni.invoke(x -> System.out.println(x))`                 | `uni.onItem().invoke(x -> System.out.println(x))`                                    |
+| `uni.call(x -> uni2)`                                    | `uni.onItem().call(x -> uni2)`                                                       |
+| `uni.eventually(() -> System.out.println("eventually"))` | `uni.onTermination().invoke(() -> System.out.println("eventually"))`                 |
+| `uni.eventually(() -> uni2)`                             | `uni.onTermination().call((ignoredItem, ignoredError, ignoredCancellation) -> uni2)` |
+| `uni.replaceWith(x)`                                     | `uni.onItem().transform(ignored -> x)`                                               |
+| `uni.replaceWith(uni2)`                                  | `uni.onItem().transformToUni(ignored -> uni2)`                                       |
+| `uni.replaceIfNullWith(x)`                               | `uni.onItem().ifNull().continueWith(x)`                                              |
 

--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -13,6 +13,7 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.UniEmitter;
 import io.smallrye.mutiny.subscription.UniSubscriber;
 import io.smallrye.mutiny.subscription.UniSubscription;
+import io.smallrye.mutiny.tuples.Functions;
 
 /**
  * A {@link Uni} represents a lazy asynchronous action. It follows the subscription pattern, meaning that the action
@@ -551,7 +552,8 @@ public interface Uni<T> {
     }
 
     /**
-     * When this {@link Uni} emits an item or a failure, invoke a {@link Uni} supplier then invoke the supplied {@link Uni}.
+     * When this {@link Uni} emits an item, a failure or is being cancelled, invoke a {@link Uni} supplier then invoke the
+     * supplied {@link Uni}.
      * When the supplied {@link Uni} emits an item then it is ignored, and when it emits a failure it is reported.
      * <p>
      * This is equivalent to a {@code finally} block in Java.
@@ -566,8 +568,8 @@ public interface Uni<T> {
      * }
      * </pre>
      * <p>
-     * This method is a shortcut for {@link UniOnItemOrFailure#call(BiFunction)}:
-     * {@code onItemOrFailure().call((item, err) -> supplier.get())}
+     * This method is a shortcut for {@link UniOnTerminate#call(Functions.Function3)}:
+     * {@code onTermination().call((item, err, cancelled) -> actual.get())}
      *
      * @param supplier a {@link Uni} supplier, cannot be {@code null} and cannot return {@code null}.
      * @param <O> the type of the item
@@ -577,7 +579,7 @@ public interface Uni<T> {
     @CheckReturnValue
     default <O> Uni<T> eventually(Supplier<Uni<? extends O>> supplier) {
         Supplier<Uni<? extends O>> actual = nonNull(supplier, "supplier");
-        return onItemOrFailure().call((item, err) -> actual.get());
+        return onTermination().call((item, err, cancelled) -> actual.get());
     }
 
     /**


### PR DESCRIPTION
The Uni::eventually(Runnable) operator had been previously moved from onItemOrFailure() to onTermination() semantics so as to handle cancellation on top of already handling items and failures.

This aligns the `eventually(Supplier<Uni<T>>)` variant with its `eventually(Runnable)` counterpart.

Fixes #1742.

BREAKING CHANGE: this may break code bases where onItemOrFailure() semantics were correctly assumed and cancellation was handled separately.