### PR TITLE
feat(operators)!: introduce a buffer size parameter to Multi::emitOn

### DIFF
--- a/implementation/revapi.json
+++ b/implementation/revapi.json
@@ -51,7 +51,21 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+      {
+        "ignore": true,
+        "code": "java.method.addedToInterface",
+        "new": "method io.smallrye.mutiny.Multi<T> io.smallrye.mutiny.Multi<T>::emitOn(java.util.concurrent.Executor, int)",
+        "justification": "The emitOn() internal buffer size must be configurable"
+      },
+      {
+        "ignore": true,
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void io.smallrye.mutiny.operators.multi.MultiEmitOnOp<T>::<init>(io.smallrye.mutiny.Multi<? extends T>, java.util.concurrent.Executor)",
+        "new": "method void io.smallrye.mutiny.operators.multi.MultiEmitOnOp<T>::<init>(io.smallrye.mutiny.Multi<? extends T>, java.util.concurrent.Executor, int)",
+        "justification": "The emitOn() internal buffer size must be configurable"
+      }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/AbstractMulti.java
@@ -29,6 +29,7 @@ import io.smallrye.mutiny.groups.MultiOverflow;
 import io.smallrye.mutiny.groups.MultiSelect;
 import io.smallrye.mutiny.groups.MultiSkip;
 import io.smallrye.mutiny.groups.MultiSubscribe;
+import io.smallrye.mutiny.helpers.ParameterValidation;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.operators.multi.MultiCacheOp;
 import io.smallrye.mutiny.operators.multi.MultiDemandCapping;
@@ -102,7 +103,16 @@ public abstract class AbstractMulti<T> implements Multi<T> {
 
     @Override
     public Multi<T> emitOn(Executor executor) {
-        return Infrastructure.onMultiCreation(new MultiEmitOnOp<>(this, nonNull(executor, "executor")));
+        return emitOn(executor, Infrastructure.getBufferSizeS());
+    }
+
+    @Override
+    public Multi<T> emitOn(Executor executor, int bufferSize) {
+        return Infrastructure.onMultiCreation(
+                new MultiEmitOnOp<>(
+                        this,
+                        nonNull(executor, "executor"),
+                        ParameterValidation.positive(bufferSize, "bufferSize")));
     }
 
     @Override


### PR DESCRIPTION
The operator was previously using a hard-coded buffer size of 16 elements which was also used to batch upstream demand.
This was a performance bottleneck for large streams as observed in the field.

The existing Multi::emitOn(executor) method remains, but it now uses Infrastructure.getBufferSizeS() as a default buffer size instead of 16.

We do not expect existing usages of emitOn(executor) to be affected by this internal change.

Fixes: #1758
See-Also: https://github.com/quarkusio/quarkus/issues/36177