### PR TITLE
fix: add an automatic module name to mutiny-smallrye-context-propagation

### DIFF
--- a/context-propagation/pom.xml
+++ b/context-propagation/pom.xml
@@ -81,6 +81,17 @@
                     <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.smallrye.mutiny.context</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Fixes: #1790