### PR TITLE
Fix javadoc for ifNoItem method

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -300,12 +300,12 @@ public interface Uni<T> {
      * This {@link Uni} detects if this {@link Uni} does not emit an item before the configured timeout.
      * <p>
      * Examples:
-     * <code>
-     * uni.ifNoItem().after(Duration.ofMillis(1000).fail() // Propagate a TimeOutException
-     * uni.ifNoItem().after(Duration.ofMillis(1000).recoverWithValue("fallback") // Inject a fallback item on timeout
-     * uni.ifNoItem().after(Duration.ofMillis(1000).on(myExecutor)... // Configure the executor calling on timeout actions
-     * uni.ifNoItem().after(Duration.ofMillis(1000).retry().atMost(5) // Retry five times
-     * </code>
+     * <pre>{@code
+     * uni.ifNoItem().after(Duration.ofMillis(1000)).fail() // Propagate a TimeOutException
+     * uni.ifNoItem().after(Duration.ofMillis(1000)).recoverWithValue("fallback") // Inject a fallback item on timeout
+     * uni.ifNoItem().after(Duration.ofMillis(1000)).on(myExecutor)... // Configure the executor calling on timeout actions
+     * uni.ifNoItem().after(Duration.ofMillis(1000)).fail().onFailure().retry().atMost(5) // Retry five times
+     * }</pre>
      *
      * @return the on timeout group
      */

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniIfNoItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniIfNoItem.java
@@ -20,7 +20,7 @@ public class UniIfNoItem<T> {
      * Configures the timeout duration.
      *
      * @param timeout the timeout, must not be {@code null}, must be strictly positive.
-     * @return a new {@link UniIfNoItem}
+     * @return a new {@link UniOnTimeout}
      */
     @CheckReturnValue
     public UniOnTimeout<T> after(Duration timeout) {


### PR DESCRIPTION
This pull request focuses on enhancing the documentation of the `after()` method within the `ifNoItem` chain in the `Uni` class, as well as correcting the return type documentation in the `UniIfNoItem` class. The changes are aimed at improving code 
readability and ensuring that the API documentation accurately reflects the expected behavior.

**Changes Made:**

1. **Improved Javadoc Formatting in `Uni.java`:**
   - Updated the examples provided for the `after()` method from using `<code>` tags to a more readable format using `<pre>` with `@code`.
   - This change enhances the clarity of the documentation, making it easier for developers to understand how to use the method effectively.

2. **Corrected Return Type in `UniIfNoItem.java`:**
   - Fixed the Javadoc comment for the `after()` method to correctly state that it returns a new instance of `UniOnTimeout` instead of `UniIfNoItem`.
   - Accurate documentation is crucial for maintaining clear and understandable APIs, ensuring that developers can rely on the information provided.

