### PR TITLE
docs: stay on the same page when switching website versions

### DIFF
--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: SmallRye Mutiny
 repo_url: https://github.com/smallrye/smallrye-mutiny
+site_url: https://smallrye.io/smallrye-mutiny/
 docs_dir: docs
 edit_uri: edit/main/documentation/docs
 


### PR DESCRIPTION
See https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/#stay-on-the-same-page-when-switching-versions

Note that this won't fix older published releases.
