### PR TITLE
feat: introduction of a Multi gathering operator

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/Gatherer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/Gatherer.java
@@ -9,7 +9,6 @@ import java.util.function.Supplier;
 
 import io.smallrye.common.annotation.CheckReturnValue;
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.tuples.Tuple2;
 
 /**
  * A Gatherer operator transforms a stream of items by accumulating them into an accumulator and extracting
@@ -42,10 +41,11 @@ public interface Gatherer<I, ACC, O> {
      *
      * @param accumulator the current accumulator
      * @param upstreamCompleted whether the upstream has completed
-     * @return an Optional containing a Tuple2 with the updated accumulator and the extracted item, or an empty Optional if no
+     * @return an Optional containing a Extraction with the updated accumulator and the extracted item, or an empty Optional if
+     *         no
      *         item can be extracted
      */
-    Optional<Tuple2<ACC, O>> extract(ACC accumulator, boolean upstreamCompleted);
+    Optional<Extraction<ACC, O>> extract(ACC accumulator, boolean upstreamCompleted);
 
     /**
      * Finalizes the accumulator and extracts the final item, if any.
@@ -55,6 +55,30 @@ public interface Gatherer<I, ACC, O> {
      * @return an Optional containing the final item, or an empty Optional if no final item can be extracted
      */
     Optional<O> finalize(ACC accumulator);
+
+    /**
+     * An extraction result containing the next accumulator and the next item to emit.
+     *
+     * @param nextAccumulator the next accumulator
+     * @param nextItem the next item to emit
+     * @param <ACC> the type of the accumulator
+     * @param <O> the type of the item to emit
+     */
+    record Extraction<ACC, O>(ACC nextAccumulator, O nextItem) {
+
+        /**
+         * Creates a new {@link Extraction} instance.
+         *
+         * @param nextAccumulator the next accumulator
+         * @param nextItem the next item to emit
+         * @return a new {@link Extraction} instance
+         * @param <ACC> the type of the accumulator
+         * @param <O> the type of the item to emit
+         */
+        public static <ACC, O> Extraction<ACC, O> of(ACC nextAccumulator, O nextItem) {
+            return new Extraction<>(nextAccumulator, nextItem);
+        }
+    }
 
     /**
      * Builder for creating a {@link Gatherer}.
@@ -130,15 +154,15 @@ public interface Gatherer<I, ACC, O> {
          * When the extractor function returns an empty {@link Optional}, no value is emitted.
          * When the extractor function returns a non-empty {@link Optional}, the value is emitted, and the accumulator is
          * updated.
-         * This is done by returning a {@link Tuple2} containing the new accumulator and the value to emit.
+         * This is done by returning a {@link Extraction} containing the new accumulator and the value to emit.
          *
          * @param extractor the extractor function, which takes the current accumulator and returns an {@link Optional}
-         *        containing a {@link Tuple2} with the new accumulator and the value to emit
+         *        containing a {@link Extraction} with the new accumulator and the value to emit
          * @param <O> the type of the value to emit
          * @return the next step in the builder
          */
         @CheckReturnValue
-        public <O> FinalizerStep<I, ACC, O> extract(BiFunction<ACC, Boolean, Optional<Tuple2<ACC, O>>> extractor) {
+        public <O> FinalizerStep<I, ACC, O> extract(BiFunction<ACC, Boolean, Optional<Extraction<ACC, O>>> extractor) {
             nonNull(extractor, "extractor");
             return new FinalizerStep<>(initialAccumulatorSupplier, accumulator, extractor);
         }
@@ -154,11 +178,11 @@ public interface Gatherer<I, ACC, O> {
     class FinalizerStep<I, ACC, O> {
         private final Supplier<ACC> initialAccumulatorSupplier;
         private final BiFunction<ACC, I, ACC> accumulator;
-        private final BiFunction<ACC, Boolean, Optional<Tuple2<ACC, O>>> extractor;
+        private final BiFunction<ACC, Boolean, Optional<Extraction<ACC, O>>> extractor;
 
         private FinalizerStep(Supplier<ACC> initialAccumulatorSupplier,
                 BiFunction<ACC, I, ACC> accumulator,
-                BiFunction<ACC, Boolean, Optional<Tuple2<ACC, O>>> extractor) {
+                BiFunction<ACC, Boolean, Optional<Extraction<ACC, O>>> extractor) {
             this.initialAccumulatorSupplier = initialAccumulatorSupplier;
             this.accumulator = accumulator;
             this.extractor = extractor;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/Gatherer.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/Gatherer.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
 import io.smallrye.mutiny.Multi;
 
 /**
@@ -18,6 +19,7 @@ import io.smallrye.mutiny.Multi;
  * @param <ACC> the type of the accumulator
  * @param <O> the type of the items emitted to the downstream
  */
+@Experimental("This API is still being designed and may change in the future")
 public interface Gatherer<I, ACC, O> {
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/Gatherers.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/Gatherers.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.smallrye.common.annotation.Experimental;
 import io.smallrye.mutiny.groups.Gatherer.Extraction;
 
 /**
@@ -15,6 +16,7 @@ import io.smallrye.mutiny.groups.Gatherer.Extraction;
  * <p>
  * This interface provides various static methods to create different types of gatherers.
  */
+@Experimental("This API is still being designed and may change in the future")
 public interface Gatherers {
 
     /**

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/Gatherers.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/Gatherers.java
@@ -1,0 +1,175 @@
+package io.smallrye.mutiny.groups;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import io.smallrye.mutiny.tuples.Tuple2;
+
+/**
+ * Factory interface for creating {@link Gatherer} instances.
+ * This interface provides various static methods to create different types of gatherers.
+ */
+public interface Gatherers {
+
+    /**
+     * Creates a new {@link Gatherer} with the specified components.
+     *
+     * @param initialAccumulatorSupplier the supplier for the initial accumulator
+     * @param accumulatorFunction the function to accumulate items into the accumulator
+     * @param extractor the function to extract items from the accumulator
+     * @param finalizer the function to extract the final item from the accumulator
+     * @param <I> the type of the items emitted by the upstream
+     * @param <ACC> the type of the accumulator
+     * @param <O> the type of the items emitted to the downstream
+     * @return a new {@link Gatherer}
+     */
+    static <I, ACC, O> Gatherer<I, ACC, O> of(Supplier<ACC> initialAccumulatorSupplier,
+            BiFunction<ACC, I, ACC> accumulatorFunction,
+            BiFunction<ACC, Boolean, Optional<Tuple2<ACC, O>>> extractor,
+            Function<ACC, Optional<O>> finalizer) {
+        return new DefaultGatherer<>(initialAccumulatorSupplier, accumulatorFunction, extractor, finalizer);
+    }
+
+    /**
+     * Creates a new {@link Gatherer} that performs a scan operation.
+     * The scan operation applies a function to each item emitted by the upstream, using the result of the previous
+     * application as the first argument to the function. The initial value is provided by the initialAccumulatorSupplier.
+     * <p>
+     * Each intermediate result is emitted downstream.
+     *
+     * @param initialAccumulatorSupplier the supplier for the initial accumulator
+     * @param accumulatorFunction the function to accumulate items
+     * @param <I> the type of the items emitted by the upstream and downstream
+     * @return a new {@link Gatherer} that performs a scan operation
+     */
+    static <I> Gatherer<I, I, I> scan(Supplier<I> initialAccumulatorSupplier, BiFunction<I, I, I> accumulatorFunction) {
+        return of(initialAccumulatorSupplier, accumulatorFunction,
+                (acc, done) -> done ? Optional.empty() : Optional.of(Tuple2.of(acc, acc)), Optional::of);
+    }
+
+    /**
+     * Creates a new {@link Gatherer} that performs a fold operation.
+     * The fold operation applies a function to each item emitted by the upstream, using the result of the previous
+     * application as the first argument to the function. The initial value is provided by the initialAccumulatorSupplier.
+     * <p>
+     * Only emits the final result when the upstream completes.
+     *
+     * @param initialAccumulatorSupplier the supplier for the initial accumulator
+     * @param accumulatorFunction the function to accumulate items
+     * @param <I> the type of the items emitted by the upstream and downstream
+     * @return a new {@link Gatherer} that performs a fold operation
+     */
+    static <I> Gatherer<I, I, I> fold(Supplier<I> initialAccumulatorSupplier, BiFunction<I, I, I> accumulatorFunction) {
+        return of(initialAccumulatorSupplier, accumulatorFunction, (acc, done) -> Optional.empty(), Optional::of);
+    }
+
+    /**
+     * Creates a new {@link Gatherer} that performs a windowing operation.
+     * The windowing operation collects items emitted by the upstream into non-overlapping windows of the specified size.
+     * When a window is full, it is emitted downstream and a new window is started.
+     * If the upstream completes before a window is full, the current window is emitted if it is not empty.
+     *
+     * @param size the size of the window
+     * @param <I> the type of the items emitted by the upstream
+     * @return a new {@link Gatherer} that performs a windowing operation
+     */
+    static <I> Gatherer<I, List<I>, List<I>> window(int size) {
+        return of(ArrayList::new, (acc, next) -> {
+            acc.add(next);
+            return acc;
+        }, (acc, completed) -> {
+            if (acc.size() == size) {
+                return Optional.of(Tuple2.of(new ArrayList<>(), new ArrayList<>(acc)));
+            }
+            return Optional.empty();
+        }, acc -> acc.isEmpty()
+                ? Optional.empty()
+                : Optional.of(acc));
+    }
+
+    /**
+     * Creates a new {@link Gatherer} that performs a sliding window operation.
+     * The sliding window operation collects items emitted by the upstream into overlapping windows of the specified size.
+     * When a window is full, it is emitted downstream and a new window is started with all but the first item from the previous
+     * window.
+     * If the upstream completes before a window is full, the current window is emitted if it is not empty.
+     *
+     * @param size the size of the window
+     * @param <I> the type of the items emitted by the upstream
+     * @return a new {@link Gatherer} that performs a sliding window operation
+     */
+    static <I> Gatherer<I, List<I>, List<I>> slidingWindow(int size) {
+        return of(ArrayList::new, (acc, item) -> {
+            acc.add(item);
+            return acc;
+        }, (acc, completed) -> {
+            if (acc.size() == size) {
+                return Optional.of(Tuple2.of(acc.stream().skip(1).collect(Collectors.toList()), new ArrayList<>(acc)));
+            }
+            return Optional.empty();
+        }, acc -> acc.isEmpty()
+                ? Optional.empty()
+                : Optional.of(acc));
+    }
+
+    /**
+     * Default implementation of the {@link Gatherer} interface.
+     *
+     * @param <I> the type of the items emitted by the upstream
+     * @param <ACC> the type of the accumulator
+     * @param <O> the type of the items emitted to the downstream
+     */
+    class DefaultGatherer<I, ACC, O> implements Gatherer<I, ACC, O> {
+
+        private final Supplier<ACC> initialAccumulatorSupplier;
+        private final BiFunction<ACC, I, ACC> accumulatorFunction;
+        private final BiFunction<ACC, Boolean, Optional<Tuple2<ACC, O>>> extractor;
+        private final Function<ACC, Optional<O>> finalizer;
+
+        public DefaultGatherer(Supplier<ACC> initialAccumulatorSupplier,
+                BiFunction<ACC, I, ACC> accumulatorFunction,
+                BiFunction<ACC, Boolean, Optional<Tuple2<ACC, O>>> extractor,
+                Function<ACC, Optional<O>> finalizer) {
+            this.initialAccumulatorSupplier = initialAccumulatorSupplier;
+            this.accumulatorFunction = accumulatorFunction;
+            this.extractor = extractor;
+            this.finalizer = finalizer;
+        }
+
+        @Override
+        public ACC accumulator() {
+            return initialAccumulatorSupplier.get();
+        }
+
+        @Override
+        public ACC accumulate(ACC accumulator, I item) {
+            return accumulatorFunction.apply(accumulator, item);
+        }
+
+        @Override
+        public Optional<Tuple2<ACC, O>> extract(ACC accumulator, boolean upstreamCompleted) {
+            return extractor.apply(accumulator, upstreamCompleted);
+        }
+
+        @Override
+        public Optional<O> finalize(ACC accumulator) {
+            return finalizer.apply(accumulator);
+        }
+    }
+
+    /**
+     * Creates a new {@link Gatherer} builder.
+     *
+     * @param <I> the type of the items emitted by the upstream
+     * @return the builder
+     */
+    static <I> Gatherer.Builder<I> builder() {
+        return new Gatherer.Builder<>();
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItem.java
@@ -4,13 +4,22 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.*;
 
 import java.util.Objects;
 import java.util.concurrent.Flow.Publisher;
-import java.util.function.*;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
-import io.smallrye.mutiny.operators.multi.*;
+import io.smallrye.mutiny.operators.multi.MultiIgnoreOp;
+import io.smallrye.mutiny.operators.multi.MultiMapOp;
+import io.smallrye.mutiny.operators.multi.MultiOnItemInvoke;
+import io.smallrye.mutiny.operators.multi.MultiScanOp;
+import io.smallrye.mutiny.operators.multi.MultiScanWithSeedOp;
 
 public class MultiOnItem<T> {
 
@@ -442,4 +451,15 @@ public class MultiOnItem<T> {
         }));
     }
 
+    /**
+     * Gather each item into an accumulator, and emit new items based on an extractor function.
+     * <p>
+     *
+     * @return a new {@link MultiOnItemGather} that lets you configure the gathering of items emitted by the upstream
+     */
+    @Experimental("This API is still being designed and may change in the future")
+    @CheckReturnValue
+    public MultiOnItemGather<T> gather() {
+        return new MultiOnItemGather<>(upstream);
+    }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItem.java
@@ -15,6 +15,7 @@ import io.smallrye.common.annotation.Experimental;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.operators.multi.MultiGather;
 import io.smallrye.mutiny.operators.multi.MultiIgnoreOp;
 import io.smallrye.mutiny.operators.multi.MultiMapOp;
 import io.smallrye.mutiny.operators.multi.MultiOnItemInvoke;
@@ -461,5 +462,17 @@ public class MultiOnItem<T> {
     @CheckReturnValue
     public MultiOnItemGather<T> gather() {
         return new MultiOnItemGather<>(upstream);
+    }
+
+    /**
+     * Gather each item into an accumulator, and emit new items based on an extractor function.
+     * <p>
+     *
+     * @return a new {@link MultiOnItemGather} that lets you configure the gathering of items emitted by the upstream
+     */
+    @Experimental("This API is still being designed and may change in the future")
+    @CheckReturnValue
+    public <ACC, O> Multi<O> gather(Gatherer<T, ACC, O> gatherer) {
+        return new MultiGather<>(upstream, gatherer);
     }
 }

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItemGather.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItemGather.java
@@ -10,8 +10,8 @@ import java.util.function.Supplier;
 import io.smallrye.common.annotation.CheckReturnValue;
 import io.smallrye.common.annotation.Experimental;
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.groups.Gatherer.Extraction;
 import io.smallrye.mutiny.operators.multi.MultiGather;
-import io.smallrye.mutiny.tuples.Tuple2;
 
 /**
  * A builder to gather items emitted by a {@link Multi} into an accumulator.
@@ -97,15 +97,15 @@ public class MultiOnItemGather<I> {
          * When the extractor function returns an empty {@link Optional}, no value is emitted.
          * When the extractor function returns a non-empty {@link Optional}, the value is emitted, and the accumulator is
          * updated.
-         * This is done by returning a {@link Tuple2} containing the new accumulator and the value to emit.
+         * This is done by returning a {@link Extraction} containing the new accumulator and the value to emit.
          *
          * @param extractor the extractor function, which takes the current accumulator and returns an {@link Optional}
-         *        containing a {@link Tuple2} with the new accumulator and the value to emit
+         *        containing a {@link Extraction} with the new accumulator and the value to emit
          * @param <O> the type of the value to emit
          * @return the next step in the builder
          */
         @CheckReturnValue
-        public <O> FinalizerStep<I, ACC, O> extract(BiFunction<ACC, Boolean, Optional<Tuple2<ACC, O>>> extractor) {
+        public <O> FinalizerStep<I, ACC, O> extract(BiFunction<ACC, Boolean, Optional<Extraction<ACC, O>>> extractor) {
             nonNull(extractor, "extractor");
             return new FinalizerStep<>(upstream, initialAccumulatorSupplier, accumulator, extractor);
         }
@@ -122,12 +122,12 @@ public class MultiOnItemGather<I> {
         private final Multi<I> upstream;
         private final Supplier<ACC> initialAccumulatorSupplier;
         private final BiFunction<ACC, I, ACC> accumulator;
-        private final BiFunction<ACC, Boolean, Optional<Tuple2<ACC, O>>> extractor;
+        private final BiFunction<ACC, Boolean, Optional<Extraction<ACC, O>>> extractor;
 
         private FinalizerStep(Multi<I> upstream,
                 Supplier<ACC> initialAccumulatorSupplier,
                 BiFunction<ACC, I, ACC> accumulator,
-                BiFunction<ACC, Boolean, Optional<Tuple2<ACC, O>>> extractor) {
+                BiFunction<ACC, Boolean, Optional<Extraction<ACC, O>>> extractor) {
             this.upstream = upstream;
             this.initialAccumulatorSupplier = initialAccumulatorSupplier;
             this.accumulator = accumulator;

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItemGather.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiOnItemGather.java
@@ -1,0 +1,155 @@
+package io.smallrye.mutiny.groups;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.operators.multi.MultiGather;
+import io.smallrye.mutiny.tuples.Tuple2;
+
+/**
+ * A builder to gather items emitted by a {@link Multi} into an accumulator.
+ *
+ * @param <I> the type of the items emitted by the upstream {@link Multi}
+ */
+@Experimental("This API is still being designed and may change in the future")
+public class MultiOnItemGather<I> {
+
+    private final Multi<I> upstream;
+
+    public MultiOnItemGather(Multi<I> upstream) {
+        this.upstream = upstream;
+    }
+
+    /**
+     * Specifies the initial accumulator supplier.
+     * <p>
+     * The accumulator is used to accumulate the items emitted by the upstream.
+     *
+     * @param initialAccumulatorSupplier the initial accumulator supplier, the returned value cannot be {@code null}
+     * @param <ACC> the type of the accumulator
+     * @return the next step in the builder
+     */
+    @CheckReturnValue
+    public <ACC> InitialAccumulatorStep<I, ACC> into(Supplier<ACC> initialAccumulatorSupplier) {
+        nonNull(initialAccumulatorSupplier, "initialAccumulatorSupplier");
+        return new InitialAccumulatorStep<>(upstream, initialAccumulatorSupplier);
+    }
+
+    /**
+     * The first step in the builder to gather items emitted by a {@link Multi} into an accumulator.
+     *
+     * @param <I> the type of the items emitted by the upstream {@link Multi}
+     * @param <ACC> the type of the accumulator
+     */
+    public static class InitialAccumulatorStep<I, ACC> {
+        private final Multi<I> upstream;
+        private final Supplier<ACC> initialAccumulatorSupplier;
+
+        private InitialAccumulatorStep(Multi<I> upstream, Supplier<ACC> initialAccumulatorSupplier) {
+            this.upstream = upstream;
+            this.initialAccumulatorSupplier = initialAccumulatorSupplier;
+        }
+
+        /**
+         * Specifies the accumulator function.
+         * <p>
+         * The accumulator function is used to accumulate the items emitted by the upstream.
+         *
+         * @param accumulator the accumulator function, which takes the current accumulator and the item emitted by the
+         *        upstream, and returns the new accumulator
+         * @return the next step in the builder
+         */
+        @CheckReturnValue
+        public ExtractStep<I, ACC> accumulate(BiFunction<ACC, I, ACC> accumulator) {
+            nonNull(accumulator, "accumulator");
+            return new ExtractStep<>(upstream, initialAccumulatorSupplier, accumulator);
+        }
+    }
+
+    /**
+     * The second step in the builder to gather items emitted by a {@link Multi} into an accumulator.
+     *
+     * @param <I> the type of the items emitted by the upstream {@link Multi}
+     * @param <ACC> the type of the accumulator
+     */
+    public static class ExtractStep<I, ACC> {
+        private final Multi<I> upstream;
+        private final Supplier<ACC> initialAccumulatorSupplier;
+        private final BiFunction<ACC, I, ACC> accumulator;
+
+        private ExtractStep(Multi<I> upstream, Supplier<ACC> initialAccumulatorSupplier, BiFunction<ACC, I, ACC> accumulator) {
+            this.upstream = upstream;
+            this.initialAccumulatorSupplier = initialAccumulatorSupplier;
+            this.accumulator = accumulator;
+        }
+
+        /**
+         * Specifies the extractor function.
+         * <p>
+         * The extractor function is used to extract the items from the accumulator.
+         * When the extractor function returns an empty {@link Optional}, no value is emitted.
+         * When the extractor function returns a non-empty {@link Optional}, the value is emitted, and the accumulator is
+         * updated.
+         * This is done by returning a {@link Tuple2} containing the new accumulator and the value to emit.
+         *
+         * @param extractor the extractor function, which takes the current accumulator and returns an {@link Optional}
+         *        containing a {@link Tuple2} with the new accumulator and the value to emit
+         * @param <O> the type of the value to emit
+         * @return the next step in the builder
+         */
+        @CheckReturnValue
+        public <O> FinalizerStep<I, ACC, O> extract(Function<ACC, Optional<Tuple2<ACC, O>>> extractor) {
+            nonNull(extractor, "extractor");
+            return new FinalizerStep<>(upstream, initialAccumulatorSupplier, accumulator, extractor);
+        }
+    }
+
+    /**
+     * The last step in the builder to gather items emitted by a {@link Multi} into an accumulator.
+     *
+     * @param <I> the type of the items emitted by the upstream {@link Multi}
+     * @param <ACC> the type of the accumulator
+     * @param <O> the type of the values to emit
+     */
+    public static class FinalizerStep<I, ACC, O> {
+        private final Multi<I> upstream;
+        private final Supplier<ACC> initialAccumulatorSupplier;
+        private final BiFunction<ACC, I, ACC> accumulator;
+        private final Function<ACC, Optional<Tuple2<ACC, O>>> extractor;
+
+        private FinalizerStep(Multi<I> upstream,
+                Supplier<ACC> initialAccumulatorSupplier,
+                BiFunction<ACC, I, ACC> accumulator,
+                Function<ACC, Optional<Tuple2<ACC, O>>> extractor) {
+            this.upstream = upstream;
+            this.initialAccumulatorSupplier = initialAccumulatorSupplier;
+            this.accumulator = accumulator;
+            this.extractor = extractor;
+        }
+
+        /**
+         * Specifies the finalizer function.
+         * <p>
+         * The finalizer function is used to emit the final value upon completion of the upstream and when there are no more
+         * items that can be extracted from the accumulator.
+         * When the finalizer function returns an empty {@link Optional}, no value is emitted before the completion signal.
+         * When the finalizer function returns a non-empty {@link Optional}, the value is emitted before the completion signal.
+         *
+         * @param finalizer the finalizer function, which takes the current accumulator and returns an {@link Optional}
+         *        containing the value to emit before the completion signal, if any
+         * @return the gathering {@link Multi}
+         */
+        @CheckReturnValue
+        public Multi<O> finalize(Function<ACC, Optional<O>> finalizer) {
+            nonNull(finalizer, "finalizer");
+            return new MultiGather<>(upstream, initialAccumulatorSupplier, accumulator, extractor, finalizer);
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiGather.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiGather.java
@@ -7,9 +7,9 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.groups.Gatherer;
+import io.smallrye.mutiny.groups.Gatherer.Extraction;
 import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
-import io.smallrye.mutiny.tuples.Tuple2;
 
 public class MultiGather<I, ACC, O> extends AbstractMultiOperator<I, O> {
 
@@ -77,14 +77,14 @@ public class MultiGather<I, ACC, O> extends AbstractMultiOperator<I, O> {
                 if (acc == null) {
                     throw new NullPointerException("The accumulator returned a null value");
                 }
-                Optional<Tuple2<ACC, O>> mapping = gatherer.extract(acc, false);
+                Optional<Extraction<ACC, O>> mapping = gatherer.extract(acc, false);
                 if (mapping == null) {
                     throw new NullPointerException("The extractor returned a null value");
                 }
                 if (mapping.isPresent()) {
-                    Tuple2<ACC, O> tuple = mapping.get();
-                    acc = tuple.getItem1();
-                    O value = tuple.getItem2();
+                    Extraction<ACC, O> result = mapping.get();
+                    acc = result.nextAccumulator();
+                    O value = result.nextItem();
                     if (acc == null) {
                         throw new NullPointerException("The extractor returned a null accumulator value");
                     }
@@ -125,14 +125,14 @@ public class MultiGather<I, ACC, O> extends AbstractMultiOperator<I, O> {
                         return;
                     }
                     try {
-                        Optional<Tuple2<ACC, O>> mapping = gatherer.extract(acc, true);
+                        Optional<Extraction<ACC, O>> mapping = gatherer.extract(acc, true);
                         if (mapping == null) {
                             throw new NullPointerException("The extractor returned a null value");
                         }
                         if (mapping.isPresent()) {
-                            Tuple2<ACC, O> tuple = mapping.get();
-                            acc = tuple.getItem1();
-                            O value = tuple.getItem2();
+                            Extraction<ACC, O> result = mapping.get();
+                            acc = result.nextAccumulator();
+                            O value = result.nextItem();
                             if (acc == null) {
                                 throw new NullPointerException("The extractor returned a null accumulator value");
                             }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiGatherTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiGatherTest.java
@@ -1,0 +1,313 @@
+package io.smallrye.mutiny.operators.multi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.tuples.Tuple2;
+
+class MultiGatherTest {
+
+    @Test
+    void gatherToLists() {
+        AssertSubscriber<ArrayList<Integer>> sub = Multi.createFrom().range(1, 100)
+                .onItem().gather()
+                .into(ArrayList<Integer>::new)
+                .accumulate((list, next) -> {
+                    list.add(next);
+                    return list;
+                })
+                .extract(list -> list.size() > 5
+                        ? Optional.of(Tuple2.of(new ArrayList<>(), list))
+                        : Optional.empty())
+                .finalize(list -> list.isEmpty()
+                        ? Optional.empty()
+                        : Optional.of(list))
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        sub.awaitNextItems(2);
+        assertThat(sub.getItems()).hasSize(2)
+                .anySatisfy(list -> assertThat(list).containsExactly(1, 2, 3, 4, 5, 6))
+                .anySatisfy(list -> assertThat(list).containsExactly(7, 8, 9, 10, 11, 12));
+
+        sub.request(Long.MAX_VALUE);
+        sub.awaitCompletion();
+        assertThat(sub.getItems()).hasSize(17)
+                .anySatisfy(list -> assertThat(list).containsExactly(91, 92, 93, 94, 95, 96))
+                .anySatisfy(list -> assertThat(list).containsExactly(97, 98, 99));
+
+    }
+
+    @Test
+    void gatherLinesOfText() {
+        List<String> chunks = List.of(
+                "Hello", " ", "world!\n",
+                "This is a test\n",
+                "==\n==",
+                "\n\nThis", " is", " ", "amazing\n\n");
+        AssertSubscriber<String> sub = Multi.createFrom().iterable(chunks)
+                .onItem().gather()
+                .into(StringBuilder::new)
+                .accumulate(StringBuilder::append)
+                .extract(sb -> {
+                    String str = sb.toString();
+                    if (str.contains("\n")) {
+                        String[] lines = str.split("\n", 2);
+                        return Optional.of(Tuple2.of(new StringBuilder(lines[1]), lines[0]));
+                    }
+                    return Optional.empty();
+                })
+                .finalize(sb -> Optional.of(sb.toString()))
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        sub.awaitNextItems(2);
+        assertThat(sub.getItems()).containsExactly("Hello world!", "This is a test");
+
+        sub.request(Long.MAX_VALUE);
+        assertThat(sub.getItems()).containsExactly(
+                "Hello world!",
+                "This is a test",
+                "==",
+                "==",
+                "",
+                "This is amazing",
+                "",
+                "");
+    }
+
+    @Test
+    void checkCompletionCorrectness() {
+        List<String> chunks = List.of(
+                "a", "1,b1,c1,d1");
+        AssertSubscriber<String> sub = Multi.createFrom().iterable(chunks)
+                .onItem().gather()
+                .into(StringBuilder::new)
+                .accumulate(StringBuilder::append)
+                .extract(sb -> {
+                    String str = sb.toString();
+                    if (str.contains(",")) {
+                        String[] lines = str.split(",", 2);
+                        return Optional.of(Tuple2.of(new StringBuilder(lines[1]), lines[0]));
+                    }
+                    return Optional.empty();
+                })
+                .finalize(sb -> Optional.of(sb.toString()))
+                .subscribe().withSubscriber(AssertSubscriber.create());
+
+        sub.awaitNextItem().assertNotTerminated();
+        assertThat(sub.getItems()).containsExactly("a1");
+
+        sub.awaitNextItem().assertNotTerminated();
+        assertThat(sub.getItems()).containsExactly("a1", "b1");
+
+        sub.awaitNextItem().assertNotTerminated();
+        assertThat(sub.getItems()).containsExactly("a1", "b1", "c1");
+
+        sub.awaitNextItem().assertCompleted();
+        assertThat(sub.getItems()).containsExactly("a1", "b1", "c1", "d1");
+    }
+
+    @Test
+    void rejectNullParamsInApi() {
+        Multi<Integer> multi = Multi.createFrom().range(1, 100);
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> multi.onItem().gather().into(null))
+                .withMessageContaining("initialAccumulatorSupplier");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> multi.onItem().gather().into(ArrayList<Integer>::new).accumulate(null))
+                .withMessageContaining("accumulator");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> multi.onItem().gather().into(ArrayList<Integer>::new).accumulate((a, b) -> a).extract(null))
+                .withMessageContaining("extractor");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> multi.onItem().gather().into(ArrayList<Integer>::new).accumulate((a, b) -> a)
+                        .extract(a -> Optional.empty()).finalize(null))
+                .withMessageContaining("finalizer");
+    }
+
+    @Test
+    void rejectNullInInitialAccumulatorSupplier() {
+        AssertSubscriber<Object> sub = Multi.createFrom().range(1, 100)
+                .onItem().gather()
+                .into(() -> null)
+                .accumulate((acc, next) -> "")
+                .extract(acc -> Optional.empty())
+                .finalize(acc -> Optional.empty())
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        sub.assertFailedWith(NullPointerException.class, "The initial accumulator cannot be null");
+    }
+
+    @Test
+    void rejectNullInAccumulator() {
+        AssertSubscriber<Object> sub = Multi.createFrom().range(1, 100)
+                .onItem().gather()
+                .into(ArrayList::new)
+                .accumulate((acc, next) -> null)
+                .extract(acc -> Optional.empty())
+                .finalize(acc -> Optional.empty())
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        sub.assertFailedWith(NullPointerException.class, "The accumulator returned a null value");
+    }
+
+    @Test
+    void rejectNullInExtractor() {
+        AssertSubscriber<Object> sub = Multi.createFrom().range(1, 100)
+                .onItem().gather()
+                .into(ArrayList::new)
+                .accumulate((acc, next) -> {
+                    acc.add(next);
+                    return acc;
+                })
+                .extract(acc -> null)
+                .finalize(acc -> Optional.empty())
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        sub.assertFailedWith(NullPointerException.class, "The extractor returned a null value");
+    }
+
+    @Test
+    void rejectNullInExtractorOptionalTupleLeft() {
+        AssertSubscriber<Object> sub = Multi.createFrom().range(1, 100)
+                .onItem().gather()
+                .into(ArrayList::new)
+                .accumulate((acc, next) -> {
+                    acc.add(next);
+                    return acc;
+                })
+                .extract(acc -> Optional.of(Tuple2.of(null, "ok")))
+                .finalize(acc -> Optional.empty())
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        sub.assertFailedWith(NullPointerException.class, "The extractor returned a null accumulator value");
+    }
+
+    @Test
+    void rejectNullInExtractorOptionalTupleRight() {
+        AssertSubscriber<Object> sub = Multi.createFrom().range(1, 100)
+                .onItem().gather()
+                .into(ArrayList::new)
+                .accumulate((acc, next) -> {
+                    acc.add(next);
+                    return acc;
+                })
+                .extract(acc -> Optional.of(Tuple2.of(new ArrayList<>(), null)))
+                .finalize(acc -> Optional.empty())
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        sub.assertFailedWith(NullPointerException.class, "The extractor returned a null value to emit");
+    }
+
+    @Test
+    void rejectNullInFinalizer() {
+        AssertSubscriber<Object> sub = Multi.createFrom().range(1, 100)
+                .onItem().gather()
+                .into(ArrayList::new)
+                .accumulate((acc, next) -> {
+                    acc.add(next);
+                    return acc;
+                })
+                .extract(acc -> Optional.empty())
+                .finalize(acc -> null)
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        sub.assertFailedWith(NullPointerException.class, "The finalizer returned a null value");
+    }
+
+    @Test
+    void rejectExceptionInInitialAccumulatorSupplier() {
+        AssertSubscriber<Object> sub = Multi.createFrom().range(1, 100)
+                .onItem().gather()
+                .into(() -> {
+                    throw new RuntimeException("boom");
+                })
+                .accumulate((acc, next) -> "")
+                .extract(acc -> Optional.empty())
+                .finalize(acc -> Optional.empty())
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        sub.assertFailedWith(RuntimeException.class, "boom");
+    }
+
+    @Test
+    void rejectExceptionInAccumulator() {
+        AssertSubscriber<Object> sub = Multi.createFrom().range(1, 100)
+                .onItem().gather()
+                .into(ArrayList::new)
+                .accumulate((acc, next) -> {
+                    throw new RuntimeException("boom");
+                })
+                .extract(acc -> Optional.empty())
+                .finalize(acc -> Optional.empty())
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        sub.assertFailedWith(RuntimeException.class, "boom");
+    }
+
+    @Test
+    void rejectExceptionInExtractor() {
+        AssertSubscriber<Object> sub = Multi.createFrom().range(1, 100)
+                .onItem().gather()
+                .into(ArrayList::new)
+                .accumulate((acc, next) -> {
+                    acc.add(next);
+                    return acc;
+                })
+                .extract(acc -> {
+                    throw new RuntimeException("boom");
+                })
+                .finalize(acc -> Optional.empty())
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        sub.assertFailedWith(RuntimeException.class, "boom");
+    }
+
+    @Test
+    void rejectExceptionInFinalizer() {
+        AssertSubscriber<Object> sub = Multi.createFrom().range(1, 100)
+                .onItem().gather()
+                .into(ArrayList::new)
+                .accumulate((acc, next) -> {
+                    acc.add(next);
+                    return acc;
+                })
+                .extract(acc -> Optional.empty())
+                .finalize(acc -> {
+                    throw new RuntimeException("boom");
+                })
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        sub.assertFailedWith(RuntimeException.class, "boom");
+    }
+
+    @Test
+    void errorHandling() {
+        AssertSubscriber<Object> sub = Multi.createFrom().items("foo", "bar")
+                .onItem().transformToMultiAndConcatenate(s -> Multi.createFrom().failure(() -> new RuntimeException("boom")))
+                .onItem().gather()
+                .into(StringBuilder::new)
+                .accumulate(StringBuilder::append)
+                .extract(sb -> Optional.empty())
+                .finalize(acc -> Optional.of(acc.toString()))
+                .subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+        sub.assertFailedWith(RuntimeException.class, "boom");
+        sub.request(Long.MAX_VALUE);
+        sub.assertHasNotReceivedAnyItem();
+    }
+
+    @Test
+    void rejectBadRequests() {
+        Multi<Object> multi = Multi.createFrom().items("foo", "bar")
+                .onItem().gather()
+                .into(StringBuilder::new)
+                .accumulate(StringBuilder::append)
+                .extract(sb -> Optional.empty())
+                .finalize(acc -> Optional.of(acc.toString()));
+
+        AssertSubscriber<Object> sub = multi.subscribe().withSubscriber(AssertSubscriber.create());
+        sub.request(0L).assertFailedWith(IllegalArgumentException.class,
+                "The number of items requested must be strictly positive");
+
+        sub = multi.subscribe().withSubscriber(AssertSubscriber.create());
+        sub.request(-10L).assertFailedWith(IllegalArgumentException.class,
+                "The number of items requested must be strictly positive");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <testng.version>7.11.0</testng.version>
         <testng-junit5-engine.version>1.0.6</testng-junit5-engine.version>
 
-        <mockito-core.version>5.17.0</mockito-core.version>
+        <mockito-core.version>5.16.1</mockito-core.version>
         <byte-buddy.version>1.17.5</byte-buddy.version>
 
         <revapi-maven-plugin.version>0.15.0</revapi-maven-plugin.version>

--- a/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/MultiGatherTckTest.java
+++ b/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/MultiGatherTckTest.java
@@ -6,7 +6,7 @@ import java.util.concurrent.Flow;
 import java.util.stream.LongStream;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.tuples.Tuple2;
+import io.smallrye.mutiny.groups.Gatherer.Extraction;
 
 public class MultiGatherTckTest extends AbstractPublisherTck<Long> {
 
@@ -24,7 +24,7 @@ public class MultiGatherTckTest extends AbstractPublisherTck<Long> {
                     if (list.isEmpty()) {
                         return Optional.empty();
                     } else {
-                        return Optional.of(Tuple2.of(new ArrayList<>(), list.get(0)));
+                        return Optional.of(Extraction.of(new ArrayList<>(), list.get(0)));
                     }
                 })
                 .finalize(list -> Optional.empty());

--- a/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/MultiGatherTckTest.java
+++ b/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/MultiGatherTckTest.java
@@ -1,0 +1,32 @@
+package io.smallrye.mutiny.tcktests;
+
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.concurrent.Flow;
+import java.util.stream.LongStream;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.tuples.Tuple2;
+
+public class MultiGatherTckTest extends AbstractPublisherTck<Long> {
+
+    @Override
+    public Flow.Publisher<Long> createFlowPublisher(long elements) {
+        return Multi.createFrom().iterable(() -> LongStream.rangeClosed(1, elements).boxed().iterator())
+                .onItem().gather()
+                .into(ArrayList<Long>::new)
+                .accumulate((list, next) -> {
+                    list.add(next);
+                    return list;
+                })
+                .extract(list -> {
+                    // Note: it might not be obvious at first sight, but with an early completion the list might be empty
+                    if (list.isEmpty()) {
+                        return Optional.empty();
+                    } else {
+                        return Optional.of(Tuple2.of(new ArrayList<>(), list.get(0)));
+                    }
+                })
+                .finalize(list -> Optional.empty());
+    }
+}

--- a/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/MultiGatherTckTest.java
+++ b/reactive-streams-tck-tests/src/test/java/io/smallrye/mutiny/tcktests/MultiGatherTckTest.java
@@ -19,7 +19,7 @@ public class MultiGatherTckTest extends AbstractPublisherTck<Long> {
                     list.add(next);
                     return list;
                 })
-                .extract(list -> {
+                .extract((list, completed) -> {
                     // Note: it might not be obvious at first sight, but with an early completion the list might be empty
                     if (list.isEmpty()) {
                         return Optional.empty();

--- a/workshop-examples/src/main/java/_03_composition_transformation/_22_Multi_Chunks_To_Sentence_Gather.java
+++ b/workshop-examples/src/main/java/_03_composition_transformation/_22_Multi_Chunks_To_Sentence_Gather.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.tuples.Tuple2;
+import io.smallrye.mutiny.groups.Gatherer.Extraction;
 
 public class _22_Multi_Chunks_To_Sentence_Gather {
 
@@ -34,7 +34,7 @@ public class _22_Multi_Chunks_To_Sentence_Gather {
                     String str = sb.toString();
                     if (str.contains("\n")) {
                         String[] lines = str.split("\n", 2);
-                        return Optional.of(Tuple2.of(new StringBuilder(lines[1]), lines[0]));
+                        return Optional.of(Extraction.of(new StringBuilder(lines[1]), lines[0]));
                     }
                     return Optional.empty();
                 })

--- a/workshop-examples/src/main/java/_03_composition_transformation/_22_Multi_Chunks_To_Sentence_Gather.java
+++ b/workshop-examples/src/main/java/_03_composition_transformation/_22_Multi_Chunks_To_Sentence_Gather.java
@@ -1,0 +1,58 @@
+/// usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS io.smallrye.reactive:mutiny:2.8.0
+package _03_composition_transformation;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.tuples.Tuple2;
+
+public class _22_Multi_Chunks_To_Sentence_Gather {
+
+    public static void main(String[] args) throws InterruptedException {
+        System.out.println("⚡️ Chunks of text to sentence stream");
+
+        List<String> chunks = List.of(
+                "Hel",
+                "lo ",
+                "world\n",
+                "Foo",
+                " B",
+                "ar ",
+                "Baz\n");
+
+        StringBuilder builder = new StringBuilder();
+        Multi.createFrom().iterable(chunks)
+                .onItem().gather()
+                .into(StringBuilder::new)
+                .accumulate(StringBuilder::append)
+                .extract(sb -> {
+                    String str = sb.toString();
+                    if (str.contains("\n")) {
+                        String[] lines = str.split("\n", 2);
+                        return Optional.of(Tuple2.of(new StringBuilder(lines[1]), lines[0]));
+                    }
+                    return Optional.empty();
+                })
+                .finalize(sb -> Optional.of(sb.toString()))
+                .onItem().transformToUniAndConcatenate(line -> sendText(line))
+                .subscribe().with(
+                        line -> System.out.println(">>> " + line),
+                        Throwable::printStackTrace,
+                        pool::shutdownNow);
+
+    }
+
+    static final ScheduledExecutorService pool = Executors.newSingleThreadScheduledExecutor();
+
+    static Uni<String> sendText(String text) {
+        return Uni.createFrom().item(text)
+                .onItem().delayIt().onExecutor(pool).by(Duration.ofMillis(300))
+                .onItem().invoke(txt -> System.out.println("[sendText] " + txt));
+    }
+}

--- a/workshop-examples/src/main/java/_03_composition_transformation/_22_Multi_Chunks_To_Sentence_Gather.java
+++ b/workshop-examples/src/main/java/_03_composition_transformation/_22_Multi_Chunks_To_Sentence_Gather.java
@@ -26,12 +26,11 @@ public class _22_Multi_Chunks_To_Sentence_Gather {
                 "ar ",
                 "Baz\n");
 
-        StringBuilder builder = new StringBuilder();
         Multi.createFrom().iterable(chunks)
                 .onItem().gather()
                 .into(StringBuilder::new)
                 .accumulate(StringBuilder::append)
-                .extract(sb -> {
+                .extract((sb, completed) -> {
                     String str = sb.toString();
                     if (str.contains("\n")) {
                         String[] lines = str.split("\n", 2);


### PR DESCRIPTION
The goal is to support cases where:
- the upstreams sends data in chunks
- chunks need to be assembled
- downstream items are extracted from the intermediary assembled chunks.

Examples include string chunks, network buffers, etc.

Fixes: #1597