### PR TITLE
fix: harmonize cancellation and termination callback orders

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnTermination.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnTermination.java
@@ -58,8 +58,8 @@ public class UniOnTermination<T> extends UniOperator<T, T> {
         @Override
         public void cancel() {
             if (!isCancelled()) {
-                super.cancel();
                 callback.accept(null, null, true);
+                super.cancel();
             }
         }
     }


### PR DESCRIPTION
This aligns with the other termination operators where the cancellation signal is sent upstream only after the callback / uni provider has completed.

Fixes #1843