### PR TITLE
build: explicit JVM settings for Jacoco and Mockito agents

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <site.dir>${project.build.directory}/generated-docs/</site.dir>
         <format.skip>true</format.skip>
-        <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
         <logback-classic.version>1.5.18</logback-classic.version>
     </properties>
 
@@ -89,7 +88,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven-dependency-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>unpack</id>

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -69,6 +69,17 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <executions>
                     <execution>
@@ -87,6 +98,7 @@
                                     junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$Random
                                 </configurationParameters>
                             </properties>
+                            <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} @{jacocoArgLine}</argLine>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,9 @@
     </modules>
 
     <properties>
+        <argLine/>
+        <jacocoArgLine/>
+
         <jctools-core.version>4.0.5</jctools-core.version>
         <mutiny-zero.version>1.1.1</mutiny-zero.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
@@ -127,6 +130,8 @@
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
+        <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -290,12 +295,18 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.surefire.plugin}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>prepare-agent</id>
@@ -461,10 +472,6 @@
 
         <profile>
             <id>coverage</id>
-            <properties>
-                <argLine>@{jacocoArgLine}</argLine>
-            </properties>
-
             <build>
                 <plugins>
                     <plugin>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -33,4 +33,28 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} @{jacocoArgLine}</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
This ensures proper support for Java 24 and beyond, ahead of further restrictions on agent loading in future Java releases.