### PR TITLE
fix(build): skip cyclonedx-maven-plugin when not deploying

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -396,6 +397,9 @@
                             <goals>
                                 <goal>makeBom</goal>
                             </goals>
+                            <configuration>
+                                <skipNotDeployed>false</skipNotDeployed>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>


### PR DESCRIPTION
Fixes a potential issue for pushing to Maven Central and the new process.

See: https://github.com/camel-tooling/camel-language-server/commit/173be5f1b7a471865fcc39f758161ac197368f6f