### PR TITLE
fix: ensure Uni blocking await cancels the upstream on timeout

### DIFF
--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAwaitTest.java
@@ -156,6 +156,23 @@ public class UniAwaitTest {
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("duration");
     }
 
+    @Test
+    public void testCancellationOnTimeout() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        AtomicBoolean terminated = new AtomicBoolean();
+        try {
+            Uni.createFrom().item(63)
+                    .onItem().delayIt().by(Duration.ofMillis(1_000))
+                    .onTermination().invoke(() -> terminated.set(true))
+                    .onCancellation().invoke(() -> cancelled.set(true))
+                    .await().atMost(Duration.ofMillis(50));
+            fail("A TimeException was expected");
+        } catch (TimeoutException e) {
+            assertThat(cancelled).isTrue();
+            assertThat(terminated).isTrue();
+        }
+    }
+
     @Nested
     @ResourceLock(value = InfrastructureResource.NAME, mode = ResourceAccessMode.READ_WRITE)
     class ThreadBlockingTest {


### PR DESCRIPTION
A timeout would previously discard any emitted value, but the upstream subscription was still active due to a lack of cancellation.

See also: https://github.com/quarkusio/quarkus/issues/48428