### PR TITLE
fix: race condition in MultiCombineLatestOp

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCombineLatestOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiCombineLatestOp.java
@@ -225,7 +225,11 @@ public class MultiCombineLatestOp<I, O> extends MultiOperator<I, O> {
                         break;
                     }
 
-                    I[] va = (I[]) q.poll();
+                    I[] va;
+                    do {
+                        // There is a possible race-condition due to double stacking in the queue
+                        va = (I[]) q.poll();
+                    } while (va == null);
 
                     O resultOfCombination;
                     try {


### PR DESCRIPTION
A race condition existed due to double-stacking in a queue.

Fixes: #1891