### PR TITLE
fix: allow Multi ranges to be empty

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/MultiCreate.java
@@ -579,8 +579,8 @@ public class MultiCreate {
      */
     @CheckReturnValue
     public Multi<Integer> range(int startInclusive, int endExclusive) {
-        if (endExclusive <= startInclusive) {
-            throw new IllegalArgumentException("end must be greater than start");
+        if (endExclusive < startInclusive) {
+            throw new IllegalArgumentException("end must be strictly greater than start");
         }
         return Multi.createFrom().iterable(() -> IntStream.range(startInclusive, endExclusive).iterator());
     }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromRangeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiCreateFromRangeTest.java
@@ -37,4 +37,13 @@ public class MultiCreateFromRangeTest {
         assertThrows(IllegalArgumentException.class, () -> Multi.createFrom().range(1, -1));
     }
 
+    @Test
+    public void emptyRange() {
+        AssertSubscriber<Integer> subscriber = AssertSubscriber.create();
+        Multi.createFrom().range(1, 1).subscribe().withSubscriber(subscriber)
+                .request(Long.MAX_VALUE)
+                .assertCompleted()
+                .assertHasNotReceivedAnyItem();
+    }
+
 }


### PR DESCRIPTION
Multi.createFrom().range(n, n) is now allowed instead of throwing an IllegalArgumentException.

Fixes #1901