### PR TITLE
fix: deadlock in Uni memoization

### DIFF
--- a/implementation/src/test/java/io/smallrye/mutiny/groups/UniMemoizeTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/groups/UniMemoizeTest.java
@@ -8,7 +8,16 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -548,5 +557,37 @@ class UniMemoizeTest {
         uni.await().atMost(Duration.ofSeconds(5));
         assertThat(res).isEqualTo(58);
         assertThat(log).containsExactly("sub", "58", "sub", "58");
+    }
+
+    @RepeatedTest(10)
+    void reproducer_1910() {
+        // Adapted from https://github.com/smallrye/smallrye-mutiny/issues/1910 (deadlock)
+        var executor = ForkJoinPool.commonPool();
+        var future = CompletableFuture.failedFuture(new RuntimeException("Woops"));
+        var cf = CompletableFuture.supplyAsync(() -> {
+            try {
+                return future.get(100, TimeUnit.MILLISECONDS);
+            } catch (Throwable err) {
+                throw new CompletionException(err);
+            }
+        }, executor);
+
+        var nodesUni = Uni.createFrom().completionStage(cf)
+                .memoize().indefinitely();
+
+        var topicListingsUni = nodesUni.map(ignored -> null);
+
+        var combined = Uni
+                .combine().all().unis(nodesUni, topicListingsUni).asTuple()
+                .memoize().indefinitely();
+
+        var resultFuture = combined.runSubscriptionOn(executor).subscribeAsCompletionStage();
+        try {
+            resultFuture.get(100, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException | InterruptedException | java.util.concurrent.TimeoutException e) {
+            // Ok
+        } finally {
+            resultFuture.cancel(true);
+        }
     }
 }


### PR DESCRIPTION
There was a possibility for pipelines having multiple memoized Unis to cause a deadlock. This is due to the usage of an internal reeentrant lock that was held even when forwarding upstream and downstream signals, which is bad because this exposes to deadlocks by design, and this may also involved I/O operations.

Lock access has been rewritten to focus on short, purely state-affecting critical sections, and signals forwarding happens in a looser fashion.

Note that there is still a cancel() signal that can be forwarded under lock, but this should be a non-blocking operation as per Reactive Streams semantics and it shouldn't cause any other signal to back-propagate and deadlock.

Fixes: #1910