### PR TITLE
build(deps): downgrade to JReleaser 1.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 
         <jandex-maven-plugin.version>3.2.7</jandex-maven-plugin.version>
         <find-and-replace-maven-plugin.version>1.2.0</find-and-replace-maven-plugin.version>
-        <jreleaser-maven-plugin.version>1.19.0</jreleaser-maven-plugin.version>
+        <jreleaser-maven-plugin.version>1.18.0</jreleaser-maven-plugin.version>
         <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>


### PR DESCRIPTION
Version 1.19.0 has a weird bug with BouncyCastle dependencies which I am going to report.