### PR TITLE
make Uni.join().all(...) accept an empty list

### DIFF
--- a/documentation/src/test/java/guides/operators/UniJoinTest.java
+++ b/documentation/src/test/java/guides/operators/UniJoinTest.java
@@ -1,28 +1,38 @@
 package guides.operators;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniJoin;
-import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
 
 class UniJoinTest {
 
     @Test
     void joinAll() {
-        // <join-all>
+        // <join-all-ff>
         Uni<Integer> a = Uni.createFrom().item(1);
         Uni<Integer> b = Uni.createFrom().item(2);
         Uni<Integer> c = Uni.createFrom().item(3);
 
-        Uni<List<Integer>> res = Uni.join().all(a, b, c).andCollectFailures();
-        // </join-all>
-
-        // <join-all-ff>
-        res = Uni.join().all(a, b, c).andFailFast();
+        Uni<List<Integer>> res = Uni.join().all(a, b, c).andFailFast();
         // </join-all-ff>
+
+        assertThat(res.await().atMost(Duration.ofSeconds(3)))
+            .containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void joinAllEmpty() {
+        // <join-all-ff>
+        Uni<List<Object>> res = Uni.join().all().andFailFast();
+        // </join-all-ff>
+
+        assertThat(res.await().atMost(Duration.ofSeconds(3)))
+            .isEmpty();
     }
 
     void joinFirst(Uni<Integer> a, Uni<Integer> b, Uni<Integer> c) {


### PR DESCRIPTION
I believe there is no good reason why UniJoin.all() does not accept an empty list as an input. It is a frequent situation when you have arbitrary number of items to process and the number happens to be zero. The reasonable thing to do is to return the empty list.

As of right now it is responsibility of the caller to check that the list is not empty before calling and it is an inconvenience and a bug waiting to happen at runtime if you forget.

Since it is strictly widening the acceptable inputs it should be a safe backwards-compatible change.