### PR TITLE
Allow Uni.join.all() empty lists

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniJoin.java
@@ -17,9 +17,9 @@ import io.smallrye.mutiny.operators.uni.builders.UniJoinFirst;
 /**
  * Join multiple {@link Uni Unis}.
  * <p>
- * <strong>Note about emptiness:</strong> If the set of Unis is empty, the set is rejected. Joining an empty set would
- * not propagate any event as it would not subscribe to anything. As a result, you cannot join empty sets of Unis. An
- * {@link IllegalArgumentException} will be thrown in this case.
+ * <strong>Note about emptiness in {@code Uni.join().first(...)}:</strong> If the set of Unis is empty, the set is rejected.
+ * Joining an empty set would not propagate any event as it would not subscribe to anything.
+ * As a result, you cannot join empty sets of Unis. An {@link IllegalArgumentException} will be thrown in this case.
  * </p>
  */
 public class UniJoin {
@@ -34,10 +34,9 @@ public class UniJoin {
      * Join multiple {@link Uni} references and emit a list of values, this is a convenience delegate method for
      * {@link #all(List)}.
      * <p>
-     * The list of {@code Unis} must not be {@code null}, empty, or contain {@code null} objects.
+     * The list of {@code Unis} must not be {@code null} or contain {@code null} objects.
      *
-     * @param unis the list of {@link Uni} to join, must not be {@code null} or empty, must not contain any {@code null}
-     *        reference.
+     * @param unis the list of {@link Uni} to join, must not be {@code null}, must not contain any {@code null} reference.
      * @param <T> the type of the {@link Uni} values
      * @return the object to configure the failure management strategy
      */
@@ -54,7 +53,7 @@ public class UniJoin {
      * What happens when any of the {@link Uni} emits a failure rather than a value is specified by a subsequent call
      * to any of the methods in {@link JoinAllStrategy}.
      * <p>
-     * The list of {@code Unis} must not be {@code null}, empty, or contain {@code null} objects.
+     * The list of {@code Unis} must not be {@code null} or contain {@code null} objects.
      *
      * @param unis the list of {@link Uni} to join, must not be {@code null}, must not contain any {@code null} reference
      * @param <T> the type of the {@link Uni} values
@@ -63,7 +62,6 @@ public class UniJoin {
     @CheckReturnValue
     public final <T> JoinAllStrategy<T> all(List<Uni<T>> unis) {
         doesNotContainNull(unis, "unis");
-        isNotEmpty(unis, "unis");
         return new JoinAllStrategy<>(unis);
     }
 
@@ -129,7 +127,11 @@ public class UniJoin {
          */
         @CheckReturnValue
         public Uni<List<T>> andCollectFailures() {
-            return Infrastructure.onUniCreation(new UniJoinAll<>(unis, UniJoinAll.Mode.COLLECT_FAILURES, concurrency));
+            if (unis.isEmpty()) {
+                return Uni.createFrom().item(List.of());
+            } else {
+                return Infrastructure.onUniCreation(new UniJoinAll<>(unis, UniJoinAll.Mode.COLLECT_FAILURES, concurrency));
+            }
         }
 
         /**
@@ -137,7 +139,11 @@ public class UniJoin {
          */
         @CheckReturnValue
         public Uni<List<T>> andFailFast() {
-            return Infrastructure.onUniCreation(new UniJoinAll<>(unis, UniJoinAll.Mode.FAIL_FAST, concurrency));
+            if (unis.isEmpty()) {
+                return Uni.createFrom().item(List.of());
+            } else {
+                return Infrastructure.onUniCreation(new UniJoinAll<>(unis, UniJoinAll.Mode.FAIL_FAST, concurrency));
+            }
         }
     }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/uni/UniJoinTest.java
@@ -73,27 +73,31 @@ class UniJoinTest {
 
     @Nested
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    class Empty {
+    class Emptyness {
         @Test
-        void emptyArrays() {
-            assertThatThrownBy(() -> Uni.join().all(new Uni[0]))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .satisfies(e -> assertThat(e.getMessage()).contains("empty"));
-
+        void emptyArraysJoinFirst() {
             assertThatThrownBy(() -> Uni.join().first(new Uni[0]))
                     .isInstanceOf(IllegalArgumentException.class)
                     .satisfies(e -> assertThat(e.getMessage()).contains("empty"));
         }
 
         @Test
-        void emptyLists() {
-            assertThatThrownBy(() -> Uni.join().all(Collections.emptyList()))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .satisfies(e -> assertThat(e.getMessage()).contains("empty"));
-
+        void emptyListsJoinFirst() {
             assertThatThrownBy(() -> Uni.join().first(Collections.emptyList()))
                     .isInstanceOf(IllegalArgumentException.class)
                     .satisfies(e -> assertThat(e.getMessage()).contains("empty"));
+        }
+
+        @Test
+        void emptyArraysJoinAll() {
+            List<Integer> res = Uni.join().<Integer> all().andFailFast().await().atMost(Duration.ofSeconds(1));
+            assertThat(res).isEmpty();
+        }
+
+        @Test
+        void emptyListsJoinAll() {
+            List<Integer> res = Uni.join().<Integer> all(List.of()).andCollectFailures().await().atMost(Duration.ofSeconds(1));
+            assertThat(res).isEmpty();
         }
     }
 


### PR DESCRIPTION
Relaxing the emptiness check allows `Uni.join.all()` to emit an empty list in the resulting `Uni<List<T>>`.

Joining on an empty list previously threw an `IllegalArgumentException`, hence this is a breaking change.