### PR TITLE
Support Java 25

### DIFF
--- a/.github/workflows/build-pull.yml
+++ b/.github/workflows/build-pull.yml
@@ -17,7 +17,7 @@ jobs:
         java: [
           { 'version': '17', 'opts': '' },
           { 'version': '21', 'opts': '' },
-          { 'version': '24', 'opts': '' }
+          { 'version': '25', 'opts': '' }
         ]
     name: Build with Java ${{ matrix.java.version }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <kotlin.compiler.languageVersion>1.8</kotlin.compiler.languageVersion>
         <coroutines.version>1.10.2</coroutines.version>
         <kotlin.compiler.jvmTarget>${maven.compiler.target}</kotlin.compiler.jvmTarget>
-        <dokka.version>2.0.0</dokka.version>
+        <dokka.version>2.1.0-Beta</dokka.version>
 
         <jandex-maven-plugin.version>3.5.0</jandex-maven-plugin.version>
         <find-and-replace-maven-plugin.version>1.2.0</find-and-replace-maven-plugin.version>


### PR DESCRIPTION
- Use Dokka 2.1.0-beta because earlier versions do not support Java 25
- Bump the CI to test for Java 25 on pull requests