### PR TITLE
fix: context context propagation in Uni-calling operators

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnCancellationCall.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnCancellationCall.java
@@ -40,6 +40,7 @@ public class MultiOnCancellationCall<T> extends AbstractMultiOperator<T, T> {
         @Override
         public void cancel() {
             execute().subscribe().with(
+                    context(),
                     ignoredItem -> super.cancel(),
                     ignoredFailure -> super.cancel());
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnCompletionCall.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnCompletionCall.java
@@ -36,6 +36,7 @@ public class MultiOnCompletionCall<T> extends AbstractMultiOperator<T, T> {
         @Override
         public void onCompletion() {
             cancellable = execute().subscribe().with(
+                    context(),
                     ignored -> super.onCompletion(),
                     super::onFailure);
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnRequestCall.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnRequestCall.java
@@ -40,6 +40,7 @@ public class MultiOnRequestCall<T> extends AbstractMultiOperator<T, T> {
                 return;
             }
             cancellable.set(execute(numberOfItems).subscribe().with(
+                    context(),
                     ignored -> {
                         cancellable.set(null);
                         super.request(numberOfItems);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnSubscribeCall.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnSubscribeCall.java
@@ -56,6 +56,7 @@ public final class MultiOnSubscribeCall<T> extends AbstractMultiOperator<T, T> {
                 try {
                     Uni<?> uni = Objects.requireNonNull(onSubscribe.apply(s), "The produced Uni must not be `null`");
                     uni.subscribe().with(
+                            context(),
                             ignored -> uniCompleted(),
                             err -> uniFailed(err));
                 } catch (Throwable e) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnTerminationCall.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiOnTerminationCall.java
@@ -43,6 +43,7 @@ public class MultiOnTerminationCall<T> extends AbstractMultiOperator<T, T> {
                 super.cancel();
             } else {
                 execute(null, true).subscribe().with(
+                        context(),
                         ignored -> super.cancel(),
                         ignored -> {
                             Infrastructure.handleDroppedException(ignored);
@@ -54,6 +55,7 @@ public class MultiOnTerminationCall<T> extends AbstractMultiOperator<T, T> {
         @Override
         public void onFailure(Throwable failure) {
             cancellable = execute(failure, false).subscribe().with(
+                    context(),
                     ignored -> super.onFailure(failure),
                     err -> super.onFailure(new CompositeException(failure, err)));
         }
@@ -61,6 +63,7 @@ public class MultiOnTerminationCall<T> extends AbstractMultiOperator<T, T> {
         @Override
         public void onCompletion() {
             cancellable = execute(null, false).subscribe().with(
+                    context(),
                     ignored -> super.onCompletion(),
                     super::onFailure);
         }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRepeatUntilOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiRepeatUntilOp.java
@@ -65,6 +65,7 @@ public class MultiRepeatUntilOp<T> extends AbstractMultiOperator<T, T> implement
                 drainLoop();
             } else {
                 delay.subscribe().with(
+                        context(),
                         ignored -> drainLoop(),
                         f -> {
                             cancel();

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/ResourceMulti.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/builders/ResourceMulti.java
@@ -51,6 +51,13 @@ public class ResourceMulti<R, I> extends AbstractMulti<I> {
             return;
         }
 
+        Context context;
+        if (subscriber instanceof ContextSupport) {
+            context = ((ContextSupport) subscriber).context();
+        } else {
+            context = Context.empty();
+        }
+
         Publisher<? extends I> stream;
         try {
             stream = streamSupplier.apply(resource);
@@ -65,6 +72,7 @@ public class ResourceMulti<R, I> extends AbstractMulti<I> {
                             new NullPointerException("Unable to call the finalizer - it returned `null`"));
                 } else {
                     uni.subscribe().with(
+                            context,
                             completed -> Subscriptions.fail(subscriber, e),
                             failed -> Subscriptions.fail(subscriber, new CompositeException(e, failed)));
                 }
@@ -137,6 +145,7 @@ public class ResourceMulti<R, I> extends AbstractMulti<I> {
                 downstream.onFailure(new CompositeException(failure, innerError));
             } else if (uni != null) {
                 uni.subscribe().with(
+                        context(),
                         completed -> downstream.onFailure(failure),
                         failed -> downstream.onFailure(new CompositeException(failure, failed)));
             }
@@ -162,6 +171,7 @@ public class ResourceMulti<R, I> extends AbstractMulti<I> {
                 downstream.onFailure(innerError);
             } else if (uni != null) {
                 uni.subscribe().with(
+                        context(),
                         completed -> downstream.onCompletion(),
                         downstream::onFailure);
             }
@@ -192,6 +202,7 @@ public class ResourceMulti<R, I> extends AbstractMulti<I> {
                 downstream.onFailure(innerError);
             } else if (uni != null) {
                 uni.subscribe().with(
+                        context(),
                         completed -> {
                         },
                         Infrastructure::handleDroppedException // ignore the failure, we have cancelled anyway.

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowBufferOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowBufferOp.java
@@ -101,6 +101,7 @@ public class MultiOnOverflowBufferOp<T> extends AbstractMultiOperator<T, T> {
             try {
                 Uni<?> uni = nonNull(dropUniMapper.apply(t), "uni");
                 uni.subscribe().with(
+                        context(),
                         ignored -> subscriber.onFailure(bpf),
                         failure -> {
                             bpf.addSuppressed(failure);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowDropItemsOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowDropItemsOp.java
@@ -88,6 +88,7 @@ public class MultiOnOverflowDropItemsOp<T> extends AbstractMultiOperator<T, T> {
             try {
                 Uni<?> uni = nonNull(dropUniMapper.apply(item), "uni");
                 uni.subscribe().with(
+                        context(),
                         ignored -> {
                             // Just drop and ignore
                         },

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowKeepLastOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/overflow/MultiOnOverflowKeepLastOp.java
@@ -164,6 +164,7 @@ public class MultiOnOverflowKeepLastOp<T> extends AbstractMultiOperator<T, T> {
             try {
                 Uni<?> uni = nonNull(dropUniMapper.apply(possiblyDropped), "uni");
                 uni.subscribe().with(
+                        context(),
                         ignored -> {
                             // Nothing to do
                         }, super::onFailure);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniDelayUntil.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniDelayUntil.java
@@ -39,7 +39,10 @@ public class UniDelayUntil<T> extends UniOperator<T, T> {
                         super.onFailure(new NullPointerException("The function returned `null` instead of a valid `Uni`"));
                         return;
                     }
-                    uni.runSubscriptionOn(executor).subscribe().with(ignored -> super.onItem(item), super::onFailure);
+                    uni.runSubscriptionOn(executor).subscribe().with(
+                            context(),
+                            ignored -> super.onItem(item),
+                            super::onFailure);
                 } catch (Throwable err) {
                     super.onFailure(err);
                 }

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnCancellationCall.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnCancellationCall.java
@@ -65,6 +65,7 @@ public class UniOnCancellationCall<I> extends UniOperator<I, I> {
             if (stateUpdater.compareAndSet(this, State.INIT, State.CANCELLED)) {
                 UniSubscription sub = getAndSetUpstreamSubscription(CANCELLED);
                 execute().subscribe().with(
+                        context(),
                         ignoredItem -> {
                             if (sub != null) {
                                 sub.cancel();

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnSubscribeCall.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnSubscribeCall.java
@@ -56,6 +56,7 @@ public class UniOnSubscribeCall<T> extends UniOperator<T, T> {
             }
 
             uni.subscribe().with(
+                    context(),
                     ignored -> {
                         // Once the uni produces its item, propagates the subscription downstream
                         downstream.onSubscribe(subscription);

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnTerminationCall.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniOnTerminationCall.java
@@ -52,6 +52,7 @@ public class UniOnTerminationCall<I> extends UniOperator<I, I> {
                 } else {
                     // Cancellation happens while we haven't executed the mapper: invoke it and cancel.
                     execute(null, null, true).subscribe().with(
+                            context(),
                             ignored -> {
                                 super.cancel();
                             },
@@ -67,6 +68,7 @@ public class UniOnTerminationCall<I> extends UniOperator<I, I> {
         public void onItem(I item) {
             if (!isCancelled()) {
                 cancellable = execute(item, null, false).subscribe().with(
+                        context(),
                         ignored -> downstream.onItem(item),
                         downstream::onFailure);
             }
@@ -76,6 +78,7 @@ public class UniOnTerminationCall<I> extends UniOperator<I, I> {
         public void onFailure(Throwable failure) {
             if (!isCancelled()) {
                 cancellable = execute(null, failure, false).subscribe().with(
+                        context(),
                         ignored -> downstream.onFailure(failure),
                         ignored -> downstream.onFailure(new CompositeException(failure, ignored)));
             } else {


### PR DESCRIPTION
Those operators would subscribe to a Uni, but the current operator context would not be forwarded.

Fixes #1984