### PR TITLE
Reproducer and fix for the groupBy operator upstream requests

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiGroupByOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiGroupByOp.java
@@ -417,8 +417,6 @@ public final class MultiGroupByOp<T, K, V> extends AbstractMultiOperator<T, Grou
                             requested.addAndGet(-e);
                         }
                         parent.getUpstreamSubscription().request(e);
-                    } else {
-                        parent.getUpstreamSubscription().request(parent.prefetch);
                     }
                 }
 


### PR DESCRIPTION
 It makes prefetch amount of request each time drain loop does not emit any items

Seen in testing a solution for https://github.com/quarkusio/quarkus/issues/50595