### PR TITLE
Do not use subclasses of CompletableFuture to catch cancel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 
         <microprofile-reactive-streams.version>3.0.1</microprofile-reactive-streams.version>
         <microprofile-context-propagation.version>1.3</microprofile-context-propagation.version>
-        <smallrye-context-propagation.version>2.2.1</smallrye-context-propagation.version>
+        <smallrye-context-propagation.version>2.3.0</smallrye-context-propagation.version>
         <smallrye-config.version>3.14.1</smallrye-config.version>
         <smallrye-common-annotation.version>2.13.9</smallrye-common-annotation.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>


### PR DESCRIPTION
We can catch it via normal callbacks, this lets us use the proper wrapped CF from SR-CP.

Draft because SR-CP has not been released yet.