### PR TITLE
fix: race condition in Uni.combine().all()

### DIFF
--- a/implementation/src/test/java/io/smallrye/mutiny/operators/UniAndTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/UniAndTest.java
@@ -297,5 +297,4 @@ public class UniAndTest {
                 .assertCompleted()
                 .assertItem(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9);
     }
-
 }


### PR DESCRIPTION
There was a race condition in `UniAndCombination` due to concurrent threads calling `AndSupervisor::check`, but the `item` and `failure` fields in `UniHandler` were not `volatile`, hence the count of incomplete inner results could be wrong with no further signal to make another check.

An easy fix was to make them `volatile`, but a work-in-progress guard is more efficient, and cleaner.

Fixes #1993