### PR TITLE
perf: optimize Uni.await() for known item/failure

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniBlockingAwait.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/UniBlockingAwait.java
@@ -27,7 +27,7 @@ public class UniBlockingAwait {
         validate(duration);
 
         if (!Infrastructure.canCallerThreadBeBlocked()) {
-            throw new IllegalStateException("The current thread cannot be blocked: " + Thread.currentThread().getName());
+            throw currentThreadCannotBeBlocked();
         }
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -85,6 +85,10 @@ public class UniBlockingAwait {
         } else {
             return reference.get();
         }
+    }
+
+    public static IllegalStateException currentThreadCannotBeBlocked() {
+        return new IllegalStateException("The current thread cannot be blocked: " + Thread.currentThread().getName());
     }
 
     private static void validate(Duration duration) {

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromKnownFailure.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromKnownFailure.java
@@ -23,6 +23,10 @@ public class UniCreateFromKnownFailure<T> extends AbstractUni<T> {
         new KnownFailureSubscription(subscriber).forward();
     }
 
+    public Throwable getFailure() {
+        return failure;
+    }
+
     private class KnownFailureSubscription implements UniSubscription {
 
         private final UniSubscriber<? super T> subscriber;

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromKnownItem.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/uni/builders/UniCreateFromKnownItem.java
@@ -23,6 +23,10 @@ public class UniCreateFromKnownItem<T> extends AbstractUni<T> {
         new KnownItemSubscription(subscriber).forward();
     }
 
+    public T getItem() {
+        return item;
+    }
+
     private class KnownItemSubscription implements UniSubscription {
 
         private final UniSubscriber<? super T> subscriber;


### PR DESCRIPTION
- optimize the case where the item/failure is known and subscription/synchronization is not needed

### Background

In Quarkus, we often design non-blocking APIs with Mutiny. We also provide a blocking variant of the API that usually defaults to `Uni.await().indefinitely()`. However, `UniBlockingAwait` is fairly expensive in terms of performance.

It's not unusual that some parts of the API return `Uni.createFrom().item()`; i.e. if the default implementation is blocking.

In this pull request, we try to optimize this path and bypass the subscription/synchronization unless really needed.

I've created a simple benchmark for [quarkus-flags](https://github.com/quarkiverse/quarkus-flags): https://github.com/mkouba/quarkus-flags-benchmarks and the results are really good.