### PR TITLE
fix: removing a (maybe unnecessary) upstream request on group emission

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiGroupByOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiGroupByOp.java
@@ -234,7 +234,6 @@ public final class MultiGroupByOp<T, K, V> extends AbstractMultiOperator<T, Grou
                     if (requests != Long.MAX_VALUE) {
                         requested.addAndGet(-emitted);
                     }
-                    super.request(emitted);
                 }
 
                 missed = wip.addAndGet(-missed);


### PR DESCRIPTION
each emitted item already requests upstream items