### PR TITLE
Reworked the docs for contexts

### DIFF
--- a/documentation/docs/guides/context-passing.md
+++ b/documentation/docs/guides/context-passing.md
@@ -37,6 +37,29 @@ You can see `Context` as a glorified `ConcurrentHashMap` delegate, although this
 
     They should not be used as general-purpose data structures that are frequently updated and that hold large amounts of data.
 
+## How to create a context?
+
+The `Context` type has static methods to create contexts:
+
+```java linenums="1"
+{{ insert('java/guides/ContextPassingTest.java', 'contextCreation') }}
+```
+
+## How to attach a context to the pipeline?
+
+The only way you can attach a context to the pipeline is by supplying the context upon subscription:
+
+```java linenums="1"
+{{ insert('java/guides/ContextPassingTest.java', 'contextAttach') }}
+```
+
+Note that you can also override the context for any part of your pipeline, which is useful if all you want to do
+is modify a pipeline, not explicitly subscribe to it:
+
+```java linenums="1"
+{{ insert('java/guides/ContextPassingTest.java', 'contextModify') }}
+```
+
 ## How to access a context?
 
 Given a `Uni` or a `Multi`, a context can be accessed using the `withContext` operator, as in:


### PR DESCRIPTION
Let me try to sum up what I think we can do to improve from the context docs:

# Terminology

The terminology is confusing to me. This is more about the API names, because the names chosen `attachContext` and `withContext` are either ambiguous or do the opposite of what people expect.

Normally, `attaching` is the operation of taking something from outside and tacking it on to something. In this scenario, it should mean taking a context and binding it to a pipeline. So, attaching it to the pipeline.

It does not, in most people's mind, imply that this is how you access a previously attached/bound context from a pipeline.

So, `attachContext` should be renamed something like `accessContext` or `reifyContext` (although nobody knows that correct term), or even `materializeContext` (as you use that term sometimes, which is probably correct, but just like _reify_ I suppose most people won't understand that it means, for all intends and purposes here: _access_ a context). It could be `getContext`, `readContext`, `accessContext`, `obtainContext`…

Now, `withContext` is also problematic because it's ambiguous: there's one interpretation of it that does exactly what it currently does, which is "pair/bundle/wrap the item _with_ the context". But there's also a much more commonly used interpretation where it means exactly the opposite: "attach a context to this pipeline / run this pipeline with this context".

In fact, I was convinced this was how to attach a context. Case in point, `subscribe().with` uses the same verb.

So the `withContext` operation also allows people to access the context. The difference with `attachContext` is that one is called during subscription and the other during item production.

I am not sure how it should be named, but I am 100% sure that the current names are confusing. I guess we should discuss this to see if a better name emerges.

# What contexts do and are used for

I think there's a blob of text missing that explains that the contexts flow from subscription to the entire Uni pipeline and that this is useful to propagate contexts from one end of the pipeline to another.

There's probably a section missing about how people should use this, as evidenced by our Zulip discussion, about either modifying the context, or creating subcontexs, and how these contexts work with `Uni.combine`.

I suppose the question ultimately is about branches (`Uni.combine`) but also _scopes_: how do you deal with contexts that span from one part of the pipeline until another part?

I suppose one example would help. I bet this is a common use-case.

# Missing operation?

I think we should add an API for switching the context as part of the pipeline, like the one I documented:

```java
        Uni<String> uniWithContext = Uni.createFrom().emitter(emitter -> {
            uni.subscribe().with(newContext, emitter::complete, emitter::fail);
        });
```

I suppose this could be `Uni<T> Uni.switchContext(Context)` or `overrideContext` or `withContext` depending on what we do with the "access context on subscription" operation that is currently using that name.

This might depend on the discussion above about scopes of contexts and how to modify or override them.

# What this PR already contains

- Added a section on how to build the context: if you define the operations and how to access it, it made sense to me to also define how to create contexts.
- Added a section on how to attach a context: given my intuition for what is "attaching a context", I've added a section explicitly about attaching contexts, and…
- Removed context attachment from docs about accessing the context:  Given the new attachment section, removed those operations from the docs on how to access a context because that confused both operations.
- Simplified the Multi docs with Uni: the `transformToUniAndMerge` operations were adding complexity that I felt were not relevant to the docs. Unis are just simpler to use as examples.
- Reworked indentation so it fits: hidden long lines of code that require scrolling leads to people not reading the docs.
- Removed "pipeline" names in favour of uni/multi: I had the hardest time guessing the type of the object that was documented, because its definition was not shown in the docs. Using `uni` makes it simpler and obvious what we're talking about.

This PR is not complete, I figured it's a good start and we can start discussing it next year and I can continue working on it after we hit some consensus :)

