### PR TITLE
docs: UniMemoize - remove outdated javadoc

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/Uni.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/Uni.java
@@ -344,7 +344,6 @@ public interface Uni<T> {
      * Configure memoization of the {@link Uni} item or failure.
      *
      * @return the object to configure memoization
-     * @apiNote This is an experimental API
      */
     @CheckReturnValue
     UniMemoize<T> memoize();

--- a/implementation/src/main/java/io/smallrye/mutiny/groups/UniMemoize.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/groups/UniMemoize.java
@@ -31,7 +31,6 @@ public class UniMemoize<T> {
      * @param invalidationGuard the invalidation guard, which evaluates to {@code false} for as long as the item or failure must
      *        be memoized, must not be {@code null}
      * @return a new {@link Uni}
-     * @apiNote This is an experimental API
      */
     @CheckReturnValue
     public Uni<T> until(BooleanSupplier invalidationGuard) {
@@ -49,7 +48,6 @@ public class UniMemoize<T> {
      * @param duration the memoization duration after having received the subscription from upstream, must not be
      *        {@code null}, must be strictly positive
      * @return a new {@link Uni}
-     * @apiNote This is an experimental API
      * @deprecated use {@link #forFixedDuration(Duration)} instead.
      */
     @Deprecated(forRemoval = true)
@@ -68,7 +66,6 @@ public class UniMemoize<T> {
      * @param duration the memoization duration after having received the subscription from upstream, must not be
      *        {@code null}, must be strictly positive
      * @return a new {@link Uni}
-     * @apiNote This is an experimental API
      */
     @CheckReturnValue
     public Uni<T> forFixedDuration(Duration duration) {
@@ -102,7 +99,6 @@ public class UniMemoize<T> {
      * Memoize the received item or failure indefinitely.
      *
      * @return a new {@link Uni}
-     * @apiNote This is an experimental API
      */
     @CheckReturnValue
     public Uni<T> indefinitely() {


### PR DESCRIPTION
- if I understand it correctly UniMemoize was marked as stable in Mutiny 1.3.0