### PR TITLE
fix(ci): Allow commit messages to start with a capital

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "subject-case": [
+      2,
+      "never",
+      ["upper-case", "pascal-case", "start-case"]
+    ]
+  }
+}


### PR DESCRIPTION
This relaxes the commit linter checks, otherwise this very commit would fail.

Fixes: #2044