### PR TITLE
build: introduce a skip-rs-operators-tests profile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,7 @@ There are 2 Maven profiles that you can activate to speed up the build of the Mu
 
 - `-Pskip-rs-tck` to avoid running the Reactive Streams TCK
 - `-Pparallel-tests` to run the JUnit5 tests in parallel
+- `-Pskip-rs-operators-tests` to avoid running the Reactive Streams Operators tests
 
 The 2 profiles can be activated at the same time if you want to benefit from parallel tests and skip the Reactive Streams TCK.
 This is mostly useful to have fast development feedback loops.

--- a/justfile
+++ b/justfile
@@ -10,7 +10,6 @@ quick-build:
 install:
     ./mvnw clean install
 
-
 # Run all the tests
 verify:
     ./mvnw verify -Pparallel-tests -T8

--- a/reactive-streams-operators-jakarta/pom.xml
+++ b/reactive-streams-operators-jakarta/pom.xml
@@ -139,6 +139,23 @@
 
     <profiles>
         <profile>
+            <id>skip-rs-operators-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>coverage</id>
             <activation>
                 <property>

--- a/reactive-streams-operators/pom.xml
+++ b/reactive-streams-operators/pom.xml
@@ -139,6 +139,23 @@
 
     <profiles>
         <profile>
+            <id>skip-rs-operators-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>coverage</id>
             <properties>
                 <argLine>@{jacocoArgLine}</argLine>


### PR DESCRIPTION
This bypasses the Reactive Streams Operators tests