### PR TITLE
Kotlin API improvements

### DIFF
--- a/documentation/docs/guides/kotlin.md
+++ b/documentation/docs/guides/kotlin.md
@@ -83,6 +83,26 @@ Finally, creating a Multi from a Flow is also possible:
 {{ insert('kotlin/guides/Coroutines.kt', 'flowAsMulti') }}
 ```
 
+## Awaiting Multi results in coroutines
+
+You can consume `Multi` results directly from suspend functions without converting to `Flow` first:
+
+```kotlin linenums="1"
+{{ insert('kotlin/guides/MultiAwait.kt', 'multiAwaitList') }}
+```
+
+```kotlin linenums="1"
+{{ insert('kotlin/guides/MultiAwait.kt', 'multiAwaitFirst') }}
+```
+
+```kotlin linenums="1"
+{{ insert('kotlin/guides/MultiAwait.kt', 'multiAwaitLast') }}
+```
+
+```kotlin linenums="1"
+{{ insert('kotlin/guides/MultiAwait.kt', 'multiAwaitEach') }}
+```
+
 ## Language convenience
 
 ### Unit instead of Void (null) value
@@ -104,4 +124,44 @@ Building a `Uni` from Kotlin code can easily be achieved using the following bui
 
 ```kotlin linenums="1"
 {{ insert('kotlin/guides/Coroutines.kt', 'uniBuilder') }}
+```
+
+### Multi builder
+
+Building a `Multi` from Kotlin code can be achieved using the `multi` builder, available as regular or coroutine variant:
+
+```kotlin linenums="1"
+{{ insert('kotlin/guides/MultiExt.kt', 'multiBuilder') }}
+```
+
+The builder accepts an optional back-pressure strategy:
+
+```kotlin linenums="1"
+{{ insert('kotlin/guides/MultiExt.kt', 'multiBuilderBackPressure') }}
+```
+
+A coroutine variant allows suspend calls within the builder:
+
+```kotlin linenums="1"
+{{ insert('kotlin/guides/MultiExt.kt', 'multiBuilderSuspend') }}
+```
+
+### Tuple destructuring
+
+Mutiny's `Tuple2` through `Tuple9` support Kotlin destructuring declarations:
+
+```kotlin linenums="1"
+{{ insert('kotlin/guides/TupleExt.kt', 'tupleDestructuring') }}
+```
+
+### Typed failure handling
+
+Use reified generics for concise failure type matching on both `Uni` and `Multi`:
+
+```kotlin linenums="1"
+{{ insert('kotlin/guides/FailureExt.kt', 'uniReifiedOnFailure') }}
+```
+
+```kotlin linenums="1"
+{{ insert('kotlin/guides/FailureExt.kt', 'multiReifiedOnFailure') }}
 ```

--- a/documentation/src/test/kotlin/guides/Coroutines.kt
+++ b/documentation/src/test/kotlin/guides/Coroutines.kt
@@ -1,3 +1,5 @@
+package guides
+
 import io.smallrye.mutiny.Multi
 import io.smallrye.mutiny.Uni
 // <importStatements>

--- a/documentation/src/test/kotlin/guides/FailureExt.kt
+++ b/documentation/src/test/kotlin/guides/FailureExt.kt
@@ -1,0 +1,24 @@
+package guides
+
+import io.smallrye.mutiny.Multi
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.onFailure
+import java.io.IOException
+
+fun uniReifiedOnFailure() {
+    // <uniReifiedOnFailure>
+    // import io.smallrye.mutiny.onFailure
+    val uni = Uni.createFrom().failure<String>(IOException("disk full"))
+    val recovered: Uni<String> = uni.onFailure<String, IOException>()
+        .recoverWithItem("recovered")
+    // </uniReifiedOnFailure>
+}
+
+fun multiReifiedOnFailure() {
+    // <multiReifiedOnFailure>
+    // import io.smallrye.mutiny.onFailure
+    val multi = Multi.createFrom().failure<String>(IOException("disk full"))
+    val recovered: Multi<String> = multi.onFailure<String, IOException>()
+        .recoverWithItem("recovered")
+    // </multiReifiedOnFailure>
+}

--- a/documentation/src/test/kotlin/guides/MultiAwait.kt
+++ b/documentation/src/test/kotlin/guides/MultiAwait.kt
@@ -1,0 +1,41 @@
+package guides
+
+import io.smallrye.mutiny.Multi
+import io.smallrye.mutiny.coroutines.awaitList
+import io.smallrye.mutiny.coroutines.awaitFirst
+import io.smallrye.mutiny.coroutines.awaitFirstOrThrow
+import io.smallrye.mutiny.coroutines.awaitLast
+import io.smallrye.mutiny.coroutines.awaitLastOrThrow
+import io.smallrye.mutiny.coroutines.awaitEach
+
+suspend fun multiAwaitList() {
+    // <multiAwaitList>
+    val multi = Multi.createFrom().items("a", "b", "c")
+    val list: List<String> = multi.awaitList()
+    // </multiAwaitList>
+}
+
+suspend fun multiAwaitFirst() {
+    // <multiAwaitFirst>
+    val multi = Multi.createFrom().items(1, 2, 3)
+    val first: Int? = multi.awaitFirst()
+    val firstOrThrow: Int = multi.awaitFirstOrThrow()
+    // </multiAwaitFirst>
+}
+
+suspend fun multiAwaitLast() {
+    // <multiAwaitLast>
+    val multi = Multi.createFrom().items(1, 2, 3)
+    val last: Int? = multi.awaitLast()
+    val lastOrThrow: Int = multi.awaitLastOrThrow()
+    // </multiAwaitLast>
+}
+
+suspend fun multiAwaitEach() {
+    // <multiAwaitEach>
+    val multi = Multi.createFrom().items(1, 2, 3)
+    multi.awaitEach { item ->
+        println("Processing $item")
+    }
+    // </multiAwaitEach>
+}

--- a/documentation/src/test/kotlin/guides/MultiExt.kt
+++ b/documentation/src/test/kotlin/guides/MultiExt.kt
@@ -32,11 +32,19 @@ fun multiBuilderWithBackPressure() {
 suspend fun suspendMultiBuilder() {
     // <multiBuilderSuspend>
     // import io.smallrye.mutiny.coroutines.multi
+    val queryResult = fetchResults()
     coroutineScope {
-        val multi = multiSuspend<String>(context = this) {
-            emit("hello")
-            emit("world")
+        val multi = multiSuspend(context = this) {
+            queryResult.forEach { result -> emit(result.download()) }
         }
     }
     // </multiBuilderSuspend>
+}
+
+interface ResultHandle {
+    suspend fun download(): String
+}
+
+suspend fun fetchResults(): Iterable<ResultHandle> {
+    TODO("Not yet implemented")
 }

--- a/documentation/src/test/kotlin/guides/MultiExt.kt
+++ b/documentation/src/test/kotlin/guides/MultiExt.kt
@@ -1,0 +1,42 @@
+package guides
+
+import io.smallrye.mutiny.multi
+import io.smallrye.mutiny.subscription.BackPressureStrategy
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import io.smallrye.mutiny.coroutines.multi as multiSuspend
+
+fun regularMultiBuilder() {
+    // <multiBuilder>
+    // import io.smallrye.mutiny.multi
+    val multi = multi<Int> {
+        emit(1)
+        emit(2)
+        emit(3)
+    }
+    // </multiBuilder>
+}
+
+fun multiBuilderWithBackPressure() {
+    // <multiBuilderBackPressure>
+    // import io.smallrye.mutiny.multi
+    val multi = multi<Int>(backPressure = BackPressureStrategy.DROP) {
+        emit(1)
+        emit(2)
+        emit(3)
+    }
+    // </multiBuilderBackPressure>
+}
+
+@ExperimentalCoroutinesApi
+suspend fun suspendMultiBuilder() {
+    // <multiBuilderSuspend>
+    // import io.smallrye.mutiny.coroutines.multi
+    coroutineScope {
+        val multi = multiSuspend<String>(context = this) {
+            emit("hello")
+            emit("world")
+        }
+    }
+    // </multiBuilderSuspend>
+}

--- a/documentation/src/test/kotlin/guides/TupleExt.kt
+++ b/documentation/src/test/kotlin/guides/TupleExt.kt
@@ -1,0 +1,21 @@
+package guides
+
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.component1
+import io.smallrye.mutiny.component2
+
+fun tupleDestructuring() {
+    // <tupleDestructuring>
+    // import io.smallrye.mutiny.component1
+    // import io.smallrye.mutiny.component2
+    val uni = Uni.combine().all()
+        .unis(
+            Uni.createFrom().item("Alice"),
+            Uni.createFrom().item(30)
+        ).asTuple()
+
+    val (name, age) = uni.await().indefinitely()
+    assert(name == "Alice")
+    assert(age == 30)
+    // </tupleDestructuring>
+}

--- a/documentation/src/test/kotlin/guides/UniExt.kt
+++ b/documentation/src/test/kotlin/guides/UniExt.kt
@@ -1,3 +1,5 @@
+package guides
+
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.replaceWithUnit
 import io.smallrye.mutiny.uni

--- a/kotlin/src/main/kotlin/io/smallrye/mutiny/FailureExt.kt
+++ b/kotlin/src/main/kotlin/io/smallrye/mutiny/FailureExt.kt
@@ -1,0 +1,18 @@
+package io.smallrye.mutiny
+
+import io.smallrye.mutiny.groups.MultiOnFailure
+import io.smallrye.mutiny.groups.UniOnFailure
+
+/**
+ * Configures failure handling for failures of type [E].
+ * Kotlin-idiomatic alternative to `onFailure(E::class.java)`.
+ */
+inline fun <T, reified E : Throwable> Uni<T>.onFailure(): UniOnFailure<T, E> =
+    onFailure(E::class.java)
+
+/**
+ * Configures failure handling for failures of type [E].
+ * Kotlin-idiomatic alternative to `onFailure(E::class.java)`.
+ */
+inline fun <T, reified E : Throwable> Multi<T>.onFailure(): MultiOnFailure<T> =
+    onFailure(E::class.java)

--- a/kotlin/src/main/kotlin/io/smallrye/mutiny/MultiExt.kt
+++ b/kotlin/src/main/kotlin/io/smallrye/mutiny/MultiExt.kt
@@ -1,0 +1,45 @@
+package io.smallrye.mutiny
+
+import io.smallrye.mutiny.subscription.BackPressureStrategy
+import io.smallrye.mutiny.subscription.MultiEmitter
+
+/**
+ * Kotlin-friendly scope for emitting items into a [Multi].
+ * Wraps [MultiEmitter] with a more idiomatic Kotlin interface.
+ */
+interface MultiEmitterScope<T> {
+    fun emit(item: T)
+    fun complete()
+    fun fail(error: Throwable)
+    val isCancelled: Boolean
+}
+
+internal class MultiEmitterScopeAdapter<T>(private val emitter: MultiEmitter<in T>) : MultiEmitterScope<T> {
+    override fun emit(item: T) { emitter.emit(item) }
+    override fun complete() { emitter.complete() }
+    override fun fail(error: Throwable) { emitter.fail(error) }
+    override val isCancelled: Boolean get() = emitter.isCancelled
+}
+
+/**
+ * Build a [Multi] from a non-suspending block using [MultiEmitterScope].
+ *
+ * @param backPressure the back-pressure strategy, defaults to [BackPressureStrategy.BUFFER]
+ * @param supplier the block that emits items via [MultiEmitterScope]
+ */
+fun <T> multi(
+    backPressure: BackPressureStrategy = BackPressureStrategy.BUFFER,
+    supplier: MultiEmitterScope<T>.() -> Unit
+): Multi<T> = Multi.createFrom().emitter({ emitter ->
+    val scope = MultiEmitterScopeAdapter(emitter)
+    try {
+        scope.supplier()
+        if (!emitter.isCancelled) {
+            emitter.complete()
+        }
+    } catch (th: Throwable) {
+        if (!emitter.isCancelled) {
+            emitter.fail(th)
+        }
+    }
+}, backPressure)

--- a/kotlin/src/main/kotlin/io/smallrye/mutiny/TupleExt.kt
+++ b/kotlin/src/main/kotlin/io/smallrye/mutiny/TupleExt.kt
@@ -1,0 +1,70 @@
+package io.smallrye.mutiny
+
+import io.smallrye.mutiny.tuples.Tuple2
+import io.smallrye.mutiny.tuples.Tuple3
+import io.smallrye.mutiny.tuples.Tuple4
+import io.smallrye.mutiny.tuples.Tuple5
+import io.smallrye.mutiny.tuples.Tuple6
+import io.smallrye.mutiny.tuples.Tuple7
+import io.smallrye.mutiny.tuples.Tuple8
+import io.smallrye.mutiny.tuples.Tuple9
+
+// Tuple2
+operator fun <T1, T2> Tuple2<T1, T2>.component1(): T1 = item1
+operator fun <T1, T2> Tuple2<T1, T2>.component2(): T2 = item2
+
+// Tuple3
+operator fun <T1, T2, T3> Tuple3<T1, T2, T3>.component1(): T1 = item1
+operator fun <T1, T2, T3> Tuple3<T1, T2, T3>.component2(): T2 = item2
+operator fun <T1, T2, T3> Tuple3<T1, T2, T3>.component3(): T3 = item3
+
+// Tuple4
+operator fun <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4>.component1(): T1 = item1
+operator fun <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4>.component2(): T2 = item2
+operator fun <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4>.component3(): T3 = item3
+operator fun <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4>.component4(): T4 = item4
+
+// Tuple5
+operator fun <T1, T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5>.component1(): T1 = item1
+operator fun <T1, T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5>.component2(): T2 = item2
+operator fun <T1, T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5>.component3(): T3 = item3
+operator fun <T1, T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5>.component4(): T4 = item4
+operator fun <T1, T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5>.component5(): T5 = item5
+
+// Tuple6
+operator fun <T1, T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6>.component1(): T1 = item1
+operator fun <T1, T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6>.component2(): T2 = item2
+operator fun <T1, T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6>.component3(): T3 = item3
+operator fun <T1, T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6>.component4(): T4 = item4
+operator fun <T1, T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6>.component5(): T5 = item5
+operator fun <T1, T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6>.component6(): T6 = item6
+
+// Tuple7
+operator fun <T1, T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7>.component1(): T1 = item1
+operator fun <T1, T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7>.component2(): T2 = item2
+operator fun <T1, T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7>.component3(): T3 = item3
+operator fun <T1, T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7>.component4(): T4 = item4
+operator fun <T1, T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7>.component5(): T5 = item5
+operator fun <T1, T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7>.component6(): T6 = item6
+operator fun <T1, T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7>.component7(): T7 = item7
+
+// Tuple8
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>.component1(): T1 = item1
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>.component2(): T2 = item2
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>.component3(): T3 = item3
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>.component4(): T4 = item4
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>.component5(): T5 = item5
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>.component6(): T6 = item6
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>.component7(): T7 = item7
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>.component8(): T8 = item8
+
+// Tuple9
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>.component1(): T1 = item1
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>.component2(): T2 = item2
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>.component3(): T3 = item3
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>.component4(): T4 = item4
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>.component5(): T5 = item5
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>.component6(): T6 = item6
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>.component7(): T7 = item7
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>.component8(): T8 = item8
+operator fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9>.component9(): T9 = item9

--- a/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/MultiAwait.kt
+++ b/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/MultiAwait.kt
@@ -1,0 +1,44 @@
+package io.smallrye.mutiny.coroutines
+
+import io.smallrye.mutiny.Multi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.lastOrNull
+import kotlinx.coroutines.flow.toList
+
+/**
+ * Collect all items from this [Multi] into a [List], suspending until completion.
+ */
+suspend fun <T> Multi<T>.awaitList(): List<T> =
+    asFlow().toList()
+
+/**
+ * Await the first item from this [Multi], or `null` if the [Multi] completes empty.
+ */
+suspend fun <T> Multi<T>.awaitFirst(): T? =
+    asFlow().firstOrNull()
+
+/**
+ * Await the first item from this [Multi], throwing [NoSuchElementException] if empty.
+ */
+suspend fun <T> Multi<T>.awaitFirstOrThrow(): T =
+    asFlow().first()
+
+/**
+ * Await the last item from this [Multi], or `null` if the [Multi] completes empty.
+ */
+suspend fun <T> Multi<T>.awaitLast(): T? =
+    asFlow().lastOrNull()
+
+/**
+ * Await the last item from this [Multi], throwing [NoSuchElementException] if empty.
+ */
+suspend fun <T> Multi<T>.awaitLastOrThrow(): T =
+    asFlow().last()
+
+/**
+ * Process each item from this [Multi] using a suspend [action], suspending until completion.
+ */
+suspend fun <T> Multi<T>.awaitEach(action: suspend (T) -> Unit) =
+    asFlow().collect { action(it) }

--- a/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/MultiBuilders.kt
+++ b/kotlin/src/main/kotlin/io/smallrye/mutiny/coroutines/MultiBuilders.kt
@@ -1,0 +1,51 @@
+package io.smallrye.mutiny.coroutines
+
+import io.smallrye.mutiny.Multi
+import io.smallrye.mutiny.MultiEmitterScope
+import io.smallrye.mutiny.MultiEmitterScopeAdapter
+import io.smallrye.mutiny.subscription.BackPressureStrategy
+import io.smallrye.mutiny.subscription.MultiEmitter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+/**
+ * Build a [Multi] from a suspending block using [MultiEmitterScope].
+ *
+ * The [supplier] block is launched in the provided [context] (defaulting to [GlobalScope]).
+ * When the block completes normally, [MultiEmitter.complete] is called automatically.
+ * Exceptions thrown from the block are propagated as [MultiEmitter.fail].
+ * Cancellation of the Multi subscription cancels the coroutine job.
+ *
+ * @param context the coroutine scope to launch the supplier in, defaults to [GlobalScope]
+ * @param backPressure the back-pressure strategy, defaults to [BackPressureStrategy.BUFFER]
+ * @param supplier the suspending block that emits items via [MultiEmitterScope]
+ */
+@ExperimentalCoroutinesApi
+@OptIn(DelicateCoroutinesApi::class)
+fun <T> multi(
+    context: CoroutineScope = GlobalScope,
+    backPressure: BackPressureStrategy = BackPressureStrategy.BUFFER,
+    supplier: suspend MultiEmitterScope<T>.() -> Unit
+): Multi<T> = Multi.createFrom().emitter({ emitter ->
+    val scope = MultiEmitterScopeAdapter(emitter)
+    val job = context.launch {
+        try {
+            scope.supplier()
+            if (!emitter.isCancelled) {
+                emitter.complete()
+            }
+        } catch (th: Throwable) {
+            if (!emitter.isCancelled) {
+                emitter.fail(th)
+            }
+        }
+    }
+    emitter.onTermination {
+        if (job.isActive) {
+            job.cancel()
+        }
+    }
+}, backPressure)

--- a/kotlin/src/test/kotlin/io/smallrye/mutiny/FailureExtTest.kt
+++ b/kotlin/src/test/kotlin/io/smallrye/mutiny/FailureExtTest.kt
@@ -1,0 +1,64 @@
+package io.smallrye.mutiny
+
+import io.smallrye.mutiny.helpers.test.AssertSubscriber
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber
+import java.io.IOException
+import kotlin.test.Test
+import org.assertj.core.api.Assertions.assertThat
+
+class FailureExtTest {
+
+    @Test
+    fun `test Uni reified onFailure recovers from matching exception`() {
+        val uni = Uni.createFrom().failure<String>(IOException("disk full"))
+        val subscriber = UniAssertSubscriber.create<String>()
+        uni.onFailure<String, IOException>().recoverWithItem("recovered")
+            .subscribe().withSubscriber(subscriber)
+        assertThat(subscriber.awaitItem().item).isEqualTo("recovered")
+    }
+
+    @Test
+    fun `test Uni reified onFailure does not recover from non-matching exception`() {
+        val uni = Uni.createFrom().failure<String>(IllegalStateException("bad state"))
+        val subscriber = UniAssertSubscriber.create<String>()
+        uni.onFailure<String, IOException>().recoverWithItem("recovered")
+            .subscribe().withSubscriber(subscriber)
+        assertThat(subscriber.awaitFailure().failure).isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `test Uni reified onFailure with no failure passes item through`() {
+        val uni = Uni.createFrom().item("hello")
+        val subscriber = UniAssertSubscriber.create<String>()
+        uni.onFailure<String, IOException>().recoverWithItem("recovered")
+            .subscribe().withSubscriber(subscriber)
+        assertThat(subscriber.awaitItem().item).isEqualTo("hello")
+    }
+
+    @Test
+    fun `test Multi reified onFailure recovers from matching exception`() {
+        val multi = Multi.createFrom().failure<String>(IOException("disk full"))
+        val subscriber = AssertSubscriber.create<String>(10)
+        multi.onFailure<String, IOException>().recoverWithItem("recovered")
+            .subscribe().withSubscriber(subscriber)
+        subscriber.awaitCompletion().assertItems("recovered")
+    }
+
+    @Test
+    fun `test Multi reified onFailure does not recover from non-matching exception`() {
+        val multi = Multi.createFrom().failure<String>(IllegalStateException("bad state"))
+        val subscriber = AssertSubscriber.create<String>(10)
+        multi.onFailure<String, IOException>().recoverWithItem("recovered")
+            .subscribe().withSubscriber(subscriber)
+        subscriber.awaitFailure().assertFailedWith(IllegalStateException::class.java, "bad state")
+    }
+
+    @Test
+    fun `test Multi reified onFailure with no failure passes items through`() {
+        val multi = Multi.createFrom().items("a", "b", "c")
+        val subscriber = AssertSubscriber.create<String>(10)
+        multi.onFailure<String, IOException>().recoverWithItem("recovered")
+            .subscribe().withSubscriber(subscriber)
+        subscriber.awaitCompletion().assertItems("a", "b", "c")
+    }
+}

--- a/kotlin/src/test/kotlin/io/smallrye/mutiny/MultiBuilderTest.kt
+++ b/kotlin/src/test/kotlin/io/smallrye/mutiny/MultiBuilderTest.kt
@@ -1,0 +1,104 @@
+package io.smallrye.mutiny
+
+import io.smallrye.mutiny.helpers.test.AssertSubscriber
+import io.smallrye.mutiny.subscription.BackPressureStrategy
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+import org.assertj.core.api.Assertions.assertThat
+
+class MultiBuilderTest {
+
+    @Test
+    fun `test build multi from items`() {
+        val multi = multi<Int> {
+            emit(1)
+            emit(2)
+            emit(3)
+        }
+        val subscriber = AssertSubscriber.create<Int>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitCompletion().assertItems(1, 2, 3)
+    }
+
+    @Test
+    fun `test build multi with explicit complete`() {
+        val multi = multi<String> {
+            emit("hello")
+            complete()
+        }
+        val subscriber = AssertSubscriber.create<String>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitCompletion().assertItems("hello")
+    }
+
+    @Test
+    fun `test build multi from failure`() {
+        val multi = multi<String> {
+            emit("before")
+            fail(RuntimeException("Kaboom"))
+        }
+        val subscriber = AssertSubscriber.create<String>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitFailure().assertFailedWith(RuntimeException::class.java, "Kaboom")
+        assertThat(subscriber.items).containsExactly("before")
+    }
+
+    @Test
+    fun `test build multi from exception in supplier`() {
+        val multi = multi<String> {
+            throw IllegalStateException("boom")
+        }
+        val subscriber = AssertSubscriber.create<String>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitFailure().assertFailedWith(IllegalStateException::class.java, "boom")
+    }
+
+    @Test
+    fun `test build empty multi`() {
+        val multi = multi<String> { }
+        val subscriber = AssertSubscriber.create<String>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitCompletion().assertHasNotReceivedAnyItem()
+    }
+
+    @Test
+    fun `verify that supplier is called lazily`() {
+        val supplierWasCalled = AtomicBoolean(false)
+        val multi = multi<Int> {
+            supplierWasCalled.set(true)
+            emit(1)
+        }
+        assertThat(supplierWasCalled.get()).isFalse()
+        val subscriber = AssertSubscriber.create<Int>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitCompletion()
+        assertThat(supplierWasCalled.get()).isTrue()
+    }
+
+    @Test
+    fun `test isCancelled is accessible`() {
+        val multi = multi<Int> {
+            var i = 0
+            while (!isCancelled && i < 100) {
+                emit(i++)
+            }
+        }
+        val subscriber = AssertSubscriber.create<Int>(5)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.request(100)
+        subscriber.awaitCompletion()
+    }
+
+    @Test
+    fun `test build multi with DROP back-pressure strategy`() {
+        val multi = multi<Int>(backPressure = BackPressureStrategy.DROP) {
+            emit(1)
+            emit(2)
+            emit(3)
+        }
+        val subscriber = AssertSubscriber.create<Int>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitCompletion()
+        assertThat(subscriber.items).isNotEmpty
+    }
+}

--- a/kotlin/src/test/kotlin/io/smallrye/mutiny/TupleExtTest.kt
+++ b/kotlin/src/test/kotlin/io/smallrye/mutiny/TupleExtTest.kt
@@ -1,0 +1,115 @@
+package io.smallrye.mutiny
+
+import io.smallrye.mutiny.tuples.Tuple2
+import io.smallrye.mutiny.tuples.Tuple3
+import io.smallrye.mutiny.tuples.Tuple4
+import io.smallrye.mutiny.tuples.Tuple5
+import io.smallrye.mutiny.tuples.Tuple6
+import io.smallrye.mutiny.tuples.Tuple7
+import io.smallrye.mutiny.tuples.Tuple8
+import io.smallrye.mutiny.tuples.Tuple9
+import kotlin.test.Test
+import org.assertj.core.api.Assertions.assertThat
+
+class TupleExtTest {
+
+    @Test
+    fun `test Tuple2 destructuring`() {
+        val tuple = Tuple2.of("a", 1)
+        val (first, second) = tuple
+        assertThat(first).isEqualTo("a")
+        assertThat(second).isEqualTo(1)
+    }
+
+    @Test
+    fun `test Tuple3 destructuring`() {
+        val tuple = Tuple3.of("a", 1, true)
+        val (first, second, third) = tuple
+        assertThat(first).isEqualTo("a")
+        assertThat(second).isEqualTo(1)
+        assertThat(third).isTrue()
+    }
+
+    @Test
+    fun `test Tuple4 destructuring`() {
+        val tuple = Tuple4.of("a", 1, true, 2.0)
+        val (first, second, third, fourth) = tuple
+        assertThat(first).isEqualTo("a")
+        assertThat(second).isEqualTo(1)
+        assertThat(third).isTrue()
+        assertThat(fourth).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `test Tuple5 destructuring`() {
+        val tuple = Tuple5.of("a", 1, true, 2.0, 'x')
+        val (first, second, third, fourth, fifth) = tuple
+        assertThat(first).isEqualTo("a")
+        assertThat(second).isEqualTo(1)
+        assertThat(third).isTrue()
+        assertThat(fourth).isEqualTo(2.0)
+        assertThat(fifth).isEqualTo('x')
+    }
+
+    @Test
+    fun `test Tuple6 destructuring`() {
+        val tuple = Tuple6.of("a", 1, true, 2.0, 'x', 6L)
+        val (first, second, third, fourth, fifth, sixth) = tuple
+        assertThat(first).isEqualTo("a")
+        assertThat(second).isEqualTo(1)
+        assertThat(third).isTrue()
+        assertThat(fourth).isEqualTo(2.0)
+        assertThat(fifth).isEqualTo('x')
+        assertThat(sixth).isEqualTo(6L)
+    }
+
+    @Test
+    fun `test Tuple7 destructuring`() {
+        val tuple = Tuple7.of("a", 1, true, 2.0, 'x', 6L, 7.toShort())
+        val (first, second, third, fourth, fifth, sixth, seventh) = tuple
+        assertThat(first).isEqualTo("a")
+        assertThat(second).isEqualTo(1)
+        assertThat(third).isTrue()
+        assertThat(fourth).isEqualTo(2.0)
+        assertThat(fifth).isEqualTo('x')
+        assertThat(sixth).isEqualTo(6L)
+        assertThat(seventh).isEqualTo(7.toShort())
+    }
+
+    @Test
+    fun `test Tuple8 destructuring`() {
+        val tuple = Tuple8.of("a", 1, true, 2.0, 'x', 6L, 7.toShort(), 8.toByte())
+        val (first, second, third, fourth, fifth, sixth, seventh, eighth) = tuple
+        assertThat(first).isEqualTo("a")
+        assertThat(second).isEqualTo(1)
+        assertThat(third).isTrue()
+        assertThat(fourth).isEqualTo(2.0)
+        assertThat(fifth).isEqualTo('x')
+        assertThat(sixth).isEqualTo(6L)
+        assertThat(seventh).isEqualTo(7.toShort())
+        assertThat(eighth).isEqualTo(8.toByte())
+    }
+
+    @Test
+    fun `test Tuple9 destructuring`() {
+        val tuple = Tuple9.of("a", 1, true, 2.0, 'x', 6L, 7.toShort(), 8.toByte(), 9.0f)
+        val (first, second, third, fourth, fifth, sixth, seventh, eighth, ninth) = tuple
+        assertThat(first).isEqualTo("a")
+        assertThat(second).isEqualTo(1)
+        assertThat(third).isTrue()
+        assertThat(fourth).isEqualTo(2.0)
+        assertThat(fifth).isEqualTo('x')
+        assertThat(sixth).isEqualTo(6L)
+        assertThat(seventh).isEqualTo(7.toShort())
+        assertThat(eighth).isEqualTo(8.toByte())
+        assertThat(ninth).isEqualTo(9.0f)
+    }
+
+    @Test
+    fun `test Tuple2 destructuring with nullable values`() {
+        val tuple: Tuple2<String?, String?> = Tuple2.of(null, null)
+        val (first, second) = tuple
+        assertThat(first).isNull()
+        assertThat(second).isNull()
+    }
+}

--- a/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/MultiAwaitTest.kt
+++ b/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/MultiAwaitTest.kt
@@ -1,0 +1,240 @@
+package io.smallrye.mutiny.coroutines
+
+import io.smallrye.mutiny.Multi
+import io.smallrye.mutiny.subscription.MultiEmitter
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import org.assertj.core.api.Assertions.assertThat
+
+class MultiAwaitTest {
+
+    @Test
+    fun `test awaitList with items`() {
+        testBlocking {
+            val multi = Multi.createFrom().items(1, 2, 3)
+            val list = multi.awaitList()
+            assertThat(list).containsExactly(1, 2, 3)
+        }
+    }
+
+    @Test
+    fun `test awaitList with empty multi`() {
+        testBlocking {
+            val multi = Multi.createFrom().empty<String>()
+            val list = multi.awaitList()
+            assertThat(list).isEmpty()
+        }
+    }
+
+    @Test
+    fun `test awaitList with failure`() {
+        assertFailsWith<RuntimeException>("boom") {
+            testBlocking {
+                val multi = Multi.createFrom().failure<String>(RuntimeException("boom"))
+                multi.awaitList()
+            }
+        }
+    }
+
+    @Test
+    fun `test awaitFirst with items`() {
+        testBlocking {
+            val multi = Multi.createFrom().items("a", "b", "c")
+            val first = multi.awaitFirst()
+            assertThat(first).isEqualTo("a")
+        }
+    }
+
+    @Test
+    fun `test awaitFirst with empty multi returns null`() {
+        testBlocking {
+            val multi = Multi.createFrom().empty<String>()
+            val first = multi.awaitFirst()
+            assertThat(first).isNull()
+        }
+    }
+
+    @Test
+    fun `test awaitFirstOrThrow with items`() {
+        testBlocking {
+            val multi = Multi.createFrom().items("a", "b", "c")
+            val first = multi.awaitFirstOrThrow()
+            assertThat(first).isEqualTo("a")
+        }
+    }
+
+    @Test
+    fun `test awaitFirstOrThrow with empty multi throws`() {
+        assertFailsWith<NoSuchElementException> {
+            testBlocking {
+                val multi = Multi.createFrom().empty<String>()
+                multi.awaitFirstOrThrow()
+            }
+        }
+    }
+
+    @Test
+    fun `test awaitLast with items`() {
+        testBlocking {
+            val multi = Multi.createFrom().items("a", "b", "c")
+            val last = multi.awaitLast()
+            assertThat(last).isEqualTo("c")
+        }
+    }
+
+    @Test
+    fun `test awaitLast with empty multi returns null`() {
+        testBlocking {
+            val multi = Multi.createFrom().empty<String>()
+            val last = multi.awaitLast()
+            assertThat(last).isNull()
+        }
+    }
+
+    @Test
+    fun `test awaitLastOrThrow with items`() {
+        testBlocking {
+            val multi = Multi.createFrom().items("a", "b", "c")
+            val last = multi.awaitLastOrThrow()
+            assertThat(last).isEqualTo("c")
+        }
+    }
+
+    @Test
+    fun `test awaitLastOrThrow with empty multi throws`() {
+        assertFailsWith<NoSuchElementException> {
+            testBlocking {
+                val multi = Multi.createFrom().empty<String>()
+                multi.awaitLastOrThrow()
+            }
+        }
+    }
+
+    @Test
+    fun `test awaitEach processes all items`() {
+        testBlocking {
+            val multi = Multi.createFrom().items(1, 2, 3)
+            val collected = mutableListOf<Int>()
+            multi.awaitEach { collected.add(it) }
+            assertThat(collected).containsExactly(1, 2, 3)
+        }
+    }
+
+    @Test
+    fun `test awaitEach with empty multi`() {
+        testBlocking {
+            val multi = Multi.createFrom().empty<String>()
+            val collected = mutableListOf<String>()
+            multi.awaitEach { collected.add(it) }
+            assertThat(collected).isEmpty()
+        }
+    }
+
+    @Test
+    fun `test awaitEach with failure`() {
+        assertFailsWith<RuntimeException>("boom") {
+            testBlocking {
+                val multi = Multi.createFrom().emitter { em: MultiEmitter<in Int> ->
+                    em.emit(1)
+                    em.fail(RuntimeException("boom"))
+                }
+                multi.awaitEach { }
+            }
+        }
+    }
+
+    @Test
+    fun `test awaitLast with failure after items`() {
+        assertFailsWith<RuntimeException>("boom") {
+            testBlocking {
+                val multi = Multi.createFrom().emitter { em: MultiEmitter<in String> ->
+                    em.emit("a")
+                    em.emit("b")
+                    em.fail(RuntimeException("boom"))
+                }
+                multi.awaitLast()
+            }
+        }
+    }
+
+    @Test
+    fun `test awaitLastOrThrow with failure`() {
+        assertFailsWith<RuntimeException>("boom") {
+            testBlocking {
+                val multi = Multi.createFrom().failure<String>(RuntimeException("boom"))
+                multi.awaitLastOrThrow()
+            }
+        }
+    }
+
+    @Test
+    fun `test awaitFirstOrThrow with failure`() {
+        assertFailsWith<RuntimeException>("boom") {
+            testBlocking {
+                val multi = Multi.createFrom().failure<String>(RuntimeException("boom"))
+                multi.awaitFirstOrThrow()
+            }
+        }
+    }
+
+    @Test
+    fun `test awaitEach with failure after items delivers items then throws`() {
+        val collected = mutableListOf<String>()
+        assertFailsWith<RuntimeException>("boom") {
+            testBlocking {
+                val multi = Multi.createFrom().emitter { em: MultiEmitter<in String> ->
+                    em.emit("a")
+                    em.emit("b")
+                    em.fail(RuntimeException("boom"))
+                }
+                multi.awaitEach { collected.add(it) }
+            }
+        }
+        assertThat(collected).isNotEmpty
+    }
+
+    @Test
+    fun `test awaitEach supports suspend action`() {
+        testBlocking {
+            val multi = Multi.createFrom().items(1, 2, 3)
+            val collected = mutableListOf<Int>()
+            multi.awaitEach { item ->
+                delay(1.milliseconds)
+                collected.add(item)
+            }
+            assertThat(collected).containsExactly(1, 2, 3)
+        }
+    }
+
+    @Test
+    fun `test awaitList respects coroutine cancellation`() {
+        assertFailsWith<TimeoutCancellationException> {
+            testBlocking {
+                val multi = Multi.createFrom().nothing<String>()
+                withTimeout(50.milliseconds) {
+                    multi.awaitList()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test awaitFirst with delayed items`() {
+        testBlocking {
+            val multi = Multi.createFrom().emitter { em: MultiEmitter<in String> ->
+                embeddedScope().launch {
+                    delay(50.milliseconds)
+                    em.emit("delayed")
+                    em.complete()
+                }
+            }
+            val first = multi.awaitFirst()
+            assertThat(first).isEqualTo("delayed")
+        }
+    }
+}

--- a/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/MultiCoroutineBuilderTest.kt
+++ b/kotlin/src/test/kotlin/io/smallrye/mutiny/coroutines/MultiCoroutineBuilderTest.kt
@@ -1,0 +1,118 @@
+package io.smallrye.mutiny.coroutines
+
+import io.smallrye.mutiny.helpers.test.AssertSubscriber
+import io.smallrye.mutiny.subscription.BackPressureStrategy
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import org.assertj.core.api.Assertions.assertThat
+
+@ExperimentalCoroutinesApi
+class MultiCoroutineBuilderTest {
+
+    @Test
+    fun `test build multi from suspend items`() {
+        val multi = multi<Int> {
+            delay(1.milliseconds)
+            emit(1)
+            delay(1.milliseconds)
+            emit(2)
+            delay(1.milliseconds)
+            emit(3)
+        }
+        val subscriber = AssertSubscriber.create<Int>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitCompletion().assertItems(1, 2, 3)
+    }
+
+    @Test
+    fun `test build multi from suspend with failure`() {
+        val multi = multi<String> {
+            delay(1.milliseconds)
+            throw RuntimeException("Kaboom")
+        }
+        val subscriber = AssertSubscriber.create<String>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitFailure().assertFailedWith(RuntimeException::class.java, "Kaboom")
+    }
+
+    @Test
+    fun `test build multi from suspend with explicit fail`() {
+        val multi = multi<String> {
+            delay(1.milliseconds)
+            emit("before")
+            fail(IllegalStateException("boom"))
+        }
+        val subscriber = AssertSubscriber.create<String>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitFailure().assertFailedWith(IllegalStateException::class.java, "boom")
+        assertThat(subscriber.items).containsExactly("before")
+    }
+
+    @Test
+    fun `test build empty multi from suspend`() {
+        val multi = multi<String> {
+            delay(1.milliseconds)
+        }
+        val subscriber = AssertSubscriber.create<String>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitCompletion().assertHasNotReceivedAnyItem()
+    }
+
+    @Test
+    fun `test build multi with custom scope`() {
+        val multi = multi<Int>(context = embeddedScope()) {
+            delay(1.milliseconds)
+            emit(42)
+        }
+        val subscriber = AssertSubscriber.create<Int>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitCompletion().assertItems(42)
+    }
+
+    @Test
+    fun `test build multi with DROP back-pressure strategy`() {
+        val multi = multi<Int>(backPressure = BackPressureStrategy.DROP) {
+            delay(1.milliseconds)
+            emit(1)
+            emit(2)
+        }
+        val subscriber = AssertSubscriber.create<Int>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitCompletion()
+        assertThat(subscriber.items).isNotEmpty
+    }
+
+    @Test
+    fun `test exception after emitting items delivers items then failure`() {
+        val multi = multi<Int> {
+            delay(1.milliseconds)
+            emit(1)
+            emit(2)
+            throw RuntimeException("late boom")
+        }
+        val subscriber = AssertSubscriber.create<Int>(10)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitFailure().assertFailedWith(RuntimeException::class.java, "late boom")
+        assertThat(subscriber.items).containsExactly(1, 2)
+    }
+
+    @Test
+    fun `test cancellation cancels the coroutine`() {
+        val multi = multi<Int> {
+            var i = 0
+            while (!isCancelled) {
+                emit(i++)
+                delay(10.milliseconds)
+            }
+        }
+        val subscriber = AssertSubscriber.create<Int>(5)
+        multi.subscribe().withSubscriber(subscriber)
+        subscriber.awaitItems(5)
+        subscriber.cancel()
+        val countAfterCancel = subscriber.items.size
+        Thread.sleep(100)
+        assertThat(subscriber.items.size).isEqualTo(countAfterCancel)
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,8 @@
 
         <!-- Configuration of mutiny-kotlin module -->
         <kotlin.version>2.4.0</kotlin.version>
-        <kotlin.compiler.apiVersion>2.1</kotlin.compiler.apiVersion>
-        <kotlin.compiler.languageVersion>2.1</kotlin.compiler.languageVersion>
+        <kotlin.compiler.apiVersion>2.2</kotlin.compiler.apiVersion>
+        <kotlin.compiler.languageVersion>2.2</kotlin.compiler.languageVersion>
         <coroutines.version>1.11.0</coroutines.version>
         <kotlin.compiler.jvmTarget>${maven.compiler.target}</kotlin.compiler.jvmTarget>
         <dokka.version>2.2.0</dokka.version>


### PR DESCRIPTION
Add new Kotlin extension APIs to the mutiny-kotlin module:

- multi {} builder (non-suspend and suspend variants) with back-pressure strategy support
- Suspend terminal operations for Multi: awaitList, awaitFirst, awaitFirstOrThrow, awaitLast, awaitLastOrThrow, awaitEach
- Reified onFailure<E>() extensions for Uni and Multi
- Tuple destructuring (componentN operators) for Tuple2 through Tuple9

  Update the Kotlin documentation guide with new sections and code snippets.
  Bump Kotlin compiler language/api version from 2.1 to 2.2.
