### PR TITLE
fix(multi): conserve demand in MultiSplitter under reentrant replenishment

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/split/MultiSplitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/split/MultiSplitter.java
@@ -137,11 +137,10 @@ public class MultiSplitter<T, K extends Enum<K>> {
             if (key == null) {
                 throw new NullPointerException("The splitter function returned null");
             }
-            // Note: if the target subscriber was removed between the last upstream demand and now, it is simply discarded
+            // An item routed to a branch with no demand is discarded rather than delivered without demand
             SplitMulti.Split target = splits.get(key);
-            if (target != null) {
+            if (target != null && claimDemand(target.demand)) {
                 target.downstream.onItem(item);
-                Subscriptions.produced(target.demand, 1L);
             }
             upstreamRequestInFlight.set(false);
             onSplitRequest();
@@ -149,6 +148,23 @@ public class MultiSplitter<T, K extends Enum<K>> {
             terminalFailure = err;
             state.set(State.FAILED);
             onUpstreamFailure();
+        }
+    }
+
+    // Decrements demand by one, leaving an unbounded (Long.MAX_VALUE) demand untouched.
+    // Returns false when there is no demand to claim.
+    private static boolean claimDemand(AtomicLong demand) {
+        for (;;) {
+            long current = demand.get();
+            if (current <= 0L) {
+                return false;
+            }
+            if (current == Long.MAX_VALUE) {
+                return true;
+            }
+            if (demand.compareAndSet(current, current - 1L)) {
+                return true;
+            }
         }
     }
 

--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/split/MultiSplitter.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/split/MultiSplitter.java
@@ -4,6 +4,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -99,6 +100,9 @@ public class MultiSplitter<T, K extends Enum<K>> {
 
     private Flow.Subscription upstreamSubscription;
 
+    // At most one upstream request is in flight at a time
+    private final AtomicBoolean upstreamRequestInFlight = new AtomicBoolean();
+
     private void onSplitRequest() {
         if (state.get() != State.SUBSCRIBED || splits.size() < requiredNumberOfSubscribers) {
             return;
@@ -108,7 +112,9 @@ public class MultiSplitter<T, K extends Enum<K>> {
                 return;
             }
         }
-        upstreamSubscription.request(1L);
+        if (upstreamRequestInFlight.compareAndSet(false, true)) {
+            upstreamSubscription.request(1L);
+        }
     }
 
     private void onUpstreamFailure() {
@@ -135,11 +141,10 @@ public class MultiSplitter<T, K extends Enum<K>> {
             SplitMulti.Split target = splits.get(key);
             if (target != null) {
                 target.downstream.onItem(item);
-                if (splits.size() == requiredNumberOfSubscribers
-                        && Subscriptions.produced(target.demand, 1L) > 0L) {
-                    upstreamSubscription.request(1L);
-                }
+                Subscriptions.produced(target.demand, 1L);
             }
+            upstreamRequestInFlight.set(false);
+            onSplitRequest();
         } catch (Throwable err) {
             terminalFailure = err;
             state.set(State.FAILED);

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/split/MultiSplitterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/split/MultiSplitterTest.java
@@ -3,13 +3,16 @@ package io.smallrye.mutiny.operators.multi.split;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Flow;
 
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Context;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
 
 class MultiSplitterTest {
 
@@ -235,5 +238,50 @@ class MultiSplitterTest {
 
         odd.assertCompleted().assertItems(1, 3, 5);
         even.assertCompleted().assertItems(2, 4, 6);
+    }
+
+    @Test
+    void doNotOverDeliverToABoundedSubscriberReplenishingOneByOne() {
+        var splitter = Multi.createFrom().range(1, 100)
+                .split(OddEven.class, n -> (n % 2 == 0) ? OddEven.EVEN : OddEven.ODD);
+
+        // ODD replenishes one item at a time and stops after two, EVEN is unbounded.
+        var odd = new OneByOneSubscriber(2);
+        splitter.get(OddEven.ODD).subscribe().withSubscriber(odd);
+        splitter.get(OddEven.EVEN).subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+
+        assertThat(odd.items).containsExactly(1, 3);
+    }
+
+    static final class OneByOneSubscriber implements MultiSubscriber<Integer> {
+        final List<Integer> items = new ArrayList<>();
+        private final int cap;
+        private Flow.Subscription subscription;
+
+        OneByOneSubscriber(int cap) {
+            this.cap = cap;
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            this.subscription = subscription;
+            subscription.request(1);
+        }
+
+        @Override
+        public void onItem(Integer item) {
+            items.add(item);
+            if (items.size() < cap) {
+                subscription.request(1);
+            }
+        }
+
+        @Override
+        public void onFailure(Throwable failure) {
+        }
+
+        @Override
+        public void onCompletion() {
+        }
     }
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/split/MultiSplitterTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/split/MultiSplitterTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
@@ -251,6 +252,36 @@ class MultiSplitterTest {
         splitter.get(OddEven.EVEN).subscribe().withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
 
         assertThat(odd.items).containsExactly(1, 3);
+    }
+
+    @Test
+    void doNotDeliverInFlightItemToAResubscribedZeroDemandSubscriber() {
+        AtomicReference<Flow.Subscriber<? super Integer>> upstream = new AtomicReference<>();
+        Multi<Integer> source = Multi.createFrom().publisher(subscriber -> {
+            upstream.set(subscriber);
+            subscriber.onSubscribe(new Flow.Subscription() {
+                @Override
+                public void request(long n) {
+                }
+
+                @Override
+                public void cancel() {
+                }
+            });
+        });
+
+        var splitter = source.split(OddEven.class, n -> (n % 2 == 0) ? OddEven.EVEN : OddEven.ODD);
+
+        var odd = splitter.get(OddEven.ODD).subscribe().withSubscriber(AssertSubscriber.create(1));
+        splitter.get(OddEven.EVEN).subscribe().withSubscriber(AssertSubscriber.create(1));
+
+        // ODD cancels, then a new ODD subscriber takes its place without requesting anything
+        odd.cancel();
+        var resubscribed = splitter.get(OddEven.ODD).subscribe().withSubscriber(AssertSubscriber.create());
+
+        upstream.get().onNext(1);
+
+        resubscribed.assertHasNotReceivedAnyItem();
     }
 
     static final class OneByOneSubscriber implements MultiSubscriber<Integer> {


### PR DESCRIPTION
Fixes #2140.

`MultiSplitter` could signal more `onNext` to a branch than were requested, and could hand an item to a branch that had no demand. This addresses both.

### Over-delivery under reentrant replenishment

The upstream was requested on two uncoordinated paths: the branch `request()` path and the post-delivery path in `onUpstreamItem`. When a branch replenishes its demand one item at a time from inside `onItem`, both paths pull upstream for the same logical item, so the splitter delivers more than was requested. With the released code the reproducer prints `delivered = 201` for `requested = 101`, and a later `request(1)` then drains the rest of the source at once.

Fix: gate the upstream request behind a single in-flight flag (`AtomicBoolean`, `compareAndSet(false, true)`), so at most one upstream item is outstanding no matter how many paths would otherwise request. The flag is cleared once per upstream item and the request decision is re-evaluated from one place.

### Delivery to a zero-demand branch

The delivery target is resolved by key at delivery time and delivered to whenever non-null, so an in-flight item could be handed to a branch that had cancelled and re-subscribed with zero demand.

Fix: claim a demand unit before delivering (`claimDemand`). Delivery happens only if the routed branch still has demand, otherwise the item is discarded. `Long.MAX_VALUE` is treated as unbounded and left untouched.

### No starvation

The in-flight flag is cleared for every upstream item, delivered or discarded, and the request decision is then re-evaluated. A discarded item still frees the in-flight slot, so a branch that has demand keeps being served and the splitter does not wedge on a discard.

### Relationship to #2127

#2127 changed the same `onUpstreamItem` line (`decrementAndGet() > 0` to `Subscriptions.produced(...) > 0`), which clamps the demand counter at zero and removes the negative-demand and spurious-unbounded symptoms. It does not change the over-delivery or the zero-demand delivery: against a #2127 build the reproducer still prints `delivered = 201`. This builds on #2127 and makes the demand check and the upstream request indivisible.

### Tests

Two commits, each isolating one fix with its own regression test:
- over-delivery: `doNotOverDeliverToABoundedSubscriberReplenishingOneByOne`
- zero-demand delivery: `doNotDeliverInFlightItemToAResubscribedZeroDemandSubscriber`

Only `MultiSplitter.java` and `MultiSplitterTest.java` change, so no public API change. The fix preserves the existing Reactive Streams TCK behavior (`MultiSplitTckTest`).

Happy to adjust the approach. I know the original design had to avoid request starvation, so glad to discuss alternatives.
