### PR TITLE
refactor: use spotless-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
         <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
         <bom-builder3.version>1.3.3</bom-builder3.version>
         <bnd-maven-plugin.version>7.3.0</bnd-maven-plugin.version>
+        <version.spotless.plugin>2.44.5</version.spotless.plugin>
     </properties>
 
     <dependencyManagement>
@@ -263,27 +264,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <!-- Overridden from Smallrye build parent for module-info.java support -->
-                    <groupId>net.revelc.code</groupId>
-                    <artifactId>impsort-maven-plugin</artifactId>
-                    <version>${version.impsort.plugin}</version>
-                    <configuration>
-                        <compliance>${maven-compiler-plugin.release}</compliance>
-                        <groups>java.,javax.,jakarta.,org.,com.</groups>
-                        <staticGroups>*</staticGroups>
-                        <skip>${format.skip}</skip>
-                        <removeUnused>true</removeUnused>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>sort-imports</id>
-                            <goals>
-                                <goal>sort</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -456,6 +436,59 @@
                     <!-- Do not compute compatibility on the documentation -->
                     <skip>${revapi.skip}</skip>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>format-sources</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code</groupId>
+                <artifactId>impsort-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>sort-imports</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${version.spotless.plugin}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>smallrye-code-rules</artifactId>
+                        <version>2</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <skip>${format.skip}</skip>
+                    <java>
+                        <eclipse>
+                            <file>io/smallrye/coderules/eclipse-format.xml</file>
+                        </eclipse>
+                        <importOrder>
+                            <order>java,javax,jakarta,org,com</order>
+                        </importOrder>
+                        <removeUnusedImports/>
+                    </java>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>spotless-apply</id>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This replaces formatter-maven-plugin + impsort-maven-plugin and keeps the same rules.