### PR TITLE
Fix race between size-based and timer-based flushes in buffer-with-timeout

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOp.java
@@ -75,7 +75,6 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
         private final Duration duration;
         private final ScheduledExecutorService executor;
         private final Supplier<List<T>> supplier;
-        private final Runnable flush;
 
         private final AtomicInteger terminated = new AtomicInteger(RUNNING);
         private final AtomicLong requested = new AtomicLong();
@@ -92,32 +91,54 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
             this.supplier = supplier;
             this.size = size;
             this.emitEmptyListIfNoItem = emitEmptyListIfNoItem;
+        }
 
-            this.flush = () -> {
-                if (terminated.get() == RUNNING) {
-                    int index;
-                    for (;;) {
-                        index = this.index.get();
-                        if (index == 0 && !emitEmptyListIfNoItem) {
-                            return;
-                        }
-                        if (this.index.compareAndSet(index, 0)) {
-                            break;
-                        }
-                    }
-                    flushCallback();
+        /**
+         * Schedules the timeout flush and remembers the scheduled task, so that a late firing can be
+         * detected as stale when the size-based flush has already replaced or cancelled it.
+         *
+         * @return {@code true} if the task has been scheduled, {@code false} if the executor rejected it
+         */
+        private boolean scheduleFlush() {
+            try {
+                ScheduledFuture<?>[] self = new ScheduledFuture<?>[1];
+                self[0] = executor.schedule(() -> timerFired(self[0]), duration.toMillis(), TimeUnit.MILLISECONDS);
+                task = self[0];
+                return true;
+            } catch (RejectedExecutionException rejected) {
+                onFailure(rejected);
+                return false;
+            }
+        }
+
+        private void timerFired(ScheduledFuture<?> self) {
+            if (terminated.get() != RUNNING) {
+                return;
+            }
+            synchronized (this) {
+                if (terminated.get() != RUNNING) {
+                    return;
                 }
-            };
+                if (task != self) {
+                    // The size-based flush has already consumed the current window and replaced
+                    // or cancelled this task: this firing is stale and must not emit.
+                    return;
+                }
+                task = null;
+
+                int index = this.index.get();
+                if (index == 0 && !emitEmptyListIfNoItem) {
+                    return;
+                }
+                this.index.set(0);
+                flushCallback();
+            }
         }
 
         private void doOnSubscribe() {
             current = supplier.get();
             if (emitEmptyListIfNoItem) {
-                try {
-                    task = executor.schedule(flush, duration.toMillis(), TimeUnit.MILLISECONDS);
-                } catch (RejectedExecutionException rejected) {
-                    onFailure(rejected);
-                }
+                scheduleFlush();
             }
         }
 
@@ -149,7 +170,7 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
                 long req = requested.get();
                 MultiSubscriber<? super List<T>> subscriber = downstream;
                 if (emitEmptyListIfNoItem && terminated.get() == RUNNING) {
-                    task = executor.schedule(this.flush, duration.toMillis(), TimeUnit.MILLISECONDS);
+                    scheduleFlush();
                 }
                 if (req != 0L) {
 
@@ -180,32 +201,31 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
 
         @Override
         public void onItem(final T value) {
-            int index;
-            for (;;) {
-                index = this.index.get() + 1;
-                if (this.index.compareAndSet(index - 1, index)) {
-                    break;
+            synchronized (this) {
+                int index;
+                for (;;) {
+                    index = this.index.get() + 1;
+                    if (this.index.compareAndSet(index - 1, index)) {
+                        break;
+                    }
                 }
-            }
 
-            if (index == 1 && !emitEmptyListIfNoItem) { // If emitEmptyListIfNoItem, the task has been started in subscribe
-                try {
-                    task = executor.schedule(flush, duration.toMillis(), TimeUnit.MILLISECONDS);
-                } catch (RejectedExecutionException rejected) {
-                    onFailure(rejected);
-                    return;
+                if (index == 1 && !emitEmptyListIfNoItem) { // If emitEmptyListIfNoItem, the task has been started in subscribe
+                    if (!scheduleFlush()) {
+                        return;
+                    }
                 }
-            }
 
-            nextCallback(value);
+                nextCallback(value);
 
-            if (this.index.get() % size == 0) {
-                this.index.lazySet(0);
-                if (task != null) {
-                    task.cancel(false);
-                    task = null;
+                if (index % size == 0) {
+                    this.index.set(0);
+                    if (task != null) {
+                        task.cancel(false);
+                        task = null;
+                    }
+                    flushCallback();
                 }
-                flushCallback();
             }
         }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOpTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOpTest.java
@@ -1,0 +1,219 @@
+package io.smallrye.mutiny.operators.multi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+
+/**
+ * Reproducers for <a href="https://github.com/smallrye/smallrye-mutiny/issues/2187">#2187</a>:
+ * the size-based flush (in {@code onItem}) and the timer-based flush must not both act on the
+ * same buffer window.
+ *
+ * The timers are driven manually so the problematic interleavings are deterministic: invoking a
+ * captured runnable after its task was cancelled with {@code cancel(false)} models a timer that
+ * already started running when the cancellation arrived.
+ */
+class MultiBufferWithTimeoutOpTest {
+
+    @Test
+    void staleTimerMustNotEmitPartialWindowAfterSizeFlush() {
+        ManualScheduler scheduler = new ManualScheduler();
+        AssertSubscriber<List<Integer>> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
+
+        MultiBufferWithTimeoutOp.MultiBufferWithTimeoutProcessor<Integer> processor = processor(scheduler, subscriber,
+                2, false);
+
+        processor.onSubscribe(emptySubscription());
+        processor.request(Long.MAX_VALUE);
+
+        processor.onItem(1); // arms the timeout task T0
+        processor.onItem(2); // size boundary: cancels T0 and emits [1, 2]
+        assertThat(subscriber.getItems()).containsExactly(List.of(1, 2));
+
+        processor.onItem(3); // arms the timeout task T1
+
+        // T0 fires even though it has been cancelled: cancel(false) does not stop an
+        // already-running timer, so this emulates the raced interleaving.
+        scheduler.run(0);
+
+        // The stale timer must not flush the partial window [3].
+        assertThat(subscriber.getItems()).containsExactly(List.of(1, 2));
+    }
+
+    @Test
+    void staleTimerMustNotEmitEmptyWindowAfterSizeFlushWhenEmitEmptyEnabled() {
+        ManualScheduler scheduler = new ManualScheduler();
+        AssertSubscriber<List<Integer>> subscriber = AssertSubscriber.create(Long.MAX_VALUE);
+
+        MultiBufferWithTimeoutOp.MultiBufferWithTimeoutProcessor<Integer> processor = processor(scheduler, subscriber,
+                2, true);
+
+        processor.onSubscribe(emptySubscription()); // schedules S0 right away
+        processor.request(Long.MAX_VALUE);
+
+        processor.onItem(1);
+        scheduler.run(0); // S0 fires on time: emits [1] and schedules S1
+        assertThat(subscriber.getItems()).containsExactly(List.of(1));
+
+        processor.onItem(2);
+        processor.onItem(3); // size boundary: cancels S1 and emits [2, 3], schedules S2
+        assertThat(subscriber.getItems()).containsExactly(List.of(1), List.of(2, 3));
+
+        Runnable s1 = scheduler.task(1);
+        s1.run(); // S1 fires even though it has been cancelled at the size boundary
+
+        // The stale timer must neither emit an empty group nor schedule an extra task.
+        assertThat(subscriber.getItems()).containsExactly(List.of(1), List.of(2, 3));
+        assertThat(scheduler.taskCount()).isEqualTo(3); // S0, S1, S2 - no extra scheduling
+    }
+
+    private static MultiBufferWithTimeoutOp.MultiBufferWithTimeoutProcessor<Integer> processor(
+            ManualScheduler scheduler, AssertSubscriber<List<Integer>> subscriber, int size, boolean emitEmpty) {
+        return new MultiBufferWithTimeoutOp.MultiBufferWithTimeoutProcessor<>(
+                subscriber, size, Duration.ofMillis(100), scheduler, ArrayList::new, emitEmpty);
+    }
+
+    private static Subscription emptySubscription() {
+        return new Subscription() {
+            @Override
+            public void request(long n) {
+            }
+
+            @Override
+            public void cancel() {
+            }
+        };
+    }
+
+    /**
+     * A scheduler that never fires anything on its own; tests decide when (and in which order)
+     * the scheduled tasks run, which makes the race interleavings deterministic.
+     */
+    static final class ManualScheduler extends AbstractExecutorService implements ScheduledExecutorService {
+
+        private final List<Runnable> tasks = new CopyOnWriteArrayList<>();
+        private final List<ScheduledFuture<?>> futures = new CopyOnWriteArrayList<>();
+
+        void run(int index) {
+            tasks.get(index).run();
+        }
+
+        Runnable task(int index) {
+            return tasks.get(index);
+        }
+
+        int taskCount() {
+            return tasks.size();
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            tasks.add(command);
+            FakeScheduledFuture future = new FakeScheduledFuture();
+            futures.add(future);
+            return future;
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+                TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void shutdown() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static final class FakeScheduledFuture implements ScheduledFuture<Object> {
+
+        private final AtomicBoolean cancelled = new AtomicBoolean();
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            cancelled.set(true);
+            return true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled.get();
+        }
+
+        @Override
+        public boolean isDone() {
+            return cancelled.get();
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return 0;
+        }
+
+        @Override
+        public int compareTo(Delayed other) {
+            return 0;
+        }
+
+        @Override
+        public Object get() {
+            return null;
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2187

## Summary

`MultiBufferWithTimeoutOp.MultiBufferWithTimeoutProcessor` coordinated the *size-based* flush (in `onItem()`) and the *timer-based* flush through a shared `AtomicInteger index` without any common mutual exclusion. Several interleavings let both paths act on the same buffer window:

- **Stale timer after a size flush**: the producer cancelled the pending task and reset `index`, but an already-running timer (cancel(false) does not interrupt it) could still CAS-reset the counter and call `flushCallback()`, emitting a premature/partial group — or an empty one when `emitEmptyListIfNoItem` is enabled.
- **Timer firing while the producer crossed the size boundary**: the timer's reset made the producer's post-`nextCallback` check (`index % size == 0`) spuriously true, producing duplicate emissions or cancelling the freshly re-scheduled task without replacement.

## Fix

The window-ownership decision now happens under the same monitor that guards the buffer, and each scheduled timer carries its own `ScheduledFuture` handle so a late firing can detect supersession:

- `onItem()` performs index bookkeeping, buffering, and the boundary flush inside `synchronized (this)` (the same lock already used by `flushCallback()`).
- `scheduleFlush()` is the single place that arms the timer; it stores the returned future in `task` and hands that handle to the runnable.
- The timer runnable passes its own handle to `timerFired(self)`; under the lock, `task != self` means a size-based flush already consumed/replaced this window, so the stale timer exits without emitting or re-scheduling.
- `flushCallback()`'s rescheduling branch now also goes through `scheduleFlush()`, gaining `RejectedExecutionException` handling it previously lacked.

Emission still happens only via `flushCallback()`, downstream ordering is preserved, and at most one timer task is live at any time.

## Reproducer tests

New `MultiBufferWithTimeoutOpTest` drives the processor with a manual scheduler so both interleavings are deterministic (a captured runnable is invoked after its task was cancelled with `cancel(false)`, modelling a timer that was already in flight):

- `staleTimerMustNotEmitPartialWindowAfterSizeFlush`
- `staleTimerMustNotEmitEmptyWindowAfterSizeFlushWhenEmitEmptyEnabled`

Both fail on `main` and pass with this change:

| commit | MultiBufferWithTimeoutOpTest | MultiGroupTest |
|---|---|---|
| main (before) | 2 run, **2 fail** | 94 run, 0 fail |
| this PR | 2 run, 0 fail | 94 run, 0 fail |