### PR TITLE
fix: race between size-based and timer-based flushes in MultiBufferWithTimeoutOp

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOp.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiBufferWithTimeoutOp.java
@@ -75,14 +75,14 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
         private final Duration duration;
         private final ScheduledExecutorService executor;
         private final Supplier<List<T>> supplier;
-        private final Runnable flush;
 
         private final AtomicInteger terminated = new AtomicInteger(RUNNING);
         private final AtomicLong requested = new AtomicLong();
         private final AtomicInteger index = new AtomicInteger();
+        private final AtomicLong generation = new AtomicLong();
         private final boolean emitEmptyListIfNoItem;
         private List<T> current;
-        private ScheduledFuture<?> task;
+        private volatile ScheduledFuture<?> task;
 
         MultiBufferWithTimeoutProcessor(MultiSubscriber<? super List<T>> downstream, int size, Duration timeout,
                 ScheduledExecutorService executor, Supplier<List<T>> supplier, boolean emitEmptyListIfNoItem) {
@@ -92,32 +92,44 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
             this.supplier = supplier;
             this.size = size;
             this.emitEmptyListIfNoItem = emitEmptyListIfNoItem;
+        }
 
-            this.flush = () -> {
-                if (terminated.get() == RUNNING) {
-                    int index;
-                    for (;;) {
-                        index = this.index.get();
-                        if (index == 0 && !emitEmptyListIfNoItem) {
-                            return;
-                        }
-                        if (this.index.compareAndSet(index, 0)) {
-                            break;
-                        }
-                    }
-                    flushCallback();
+        private void scheduleFlush() {
+            long gen = generation.incrementAndGet();
+            try {
+                task = executor.schedule(() -> timerFired(gen), duration.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (RejectedExecutionException rejected) {
+                onFailure(rejected);
+            }
+        }
+
+        private void timerFired(long expectedGen) {
+            if (terminated.get() != RUNNING) {
+                return;
+            }
+            if (generation.get() != expectedGen) {
+                return;
+            }
+            int idx;
+            for (;;) {
+                idx = this.index.get();
+                if (idx == 0 && !emitEmptyListIfNoItem) {
+                    return;
                 }
-            };
+                if (this.index.compareAndSet(idx, 0)) {
+                    break;
+                }
+            }
+            if (generation.get() != expectedGen) {
+                return;
+            }
+            flushCallback();
         }
 
         private void doOnSubscribe() {
             current = supplier.get();
             if (emitEmptyListIfNoItem) {
-                try {
-                    task = executor.schedule(flush, duration.toMillis(), TimeUnit.MILLISECONDS);
-                } catch (RejectedExecutionException rejected) {
-                    onFailure(rejected);
-                }
+                scheduleFlush();
             }
         }
 
@@ -149,7 +161,7 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
                 long req = requested.get();
                 MultiSubscriber<? super List<T>> subscriber = downstream;
                 if (emitEmptyListIfNoItem && terminated.get() == RUNNING) {
-                    task = executor.schedule(this.flush, duration.toMillis(), TimeUnit.MILLISECONDS);
+                    scheduleFlush();
                 }
                 if (req != 0L) {
 
@@ -181,28 +193,27 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
         @Override
         public void onItem(final T value) {
             int index;
+            boolean atBoundary;
             for (;;) {
-                index = this.index.get() + 1;
-                if (this.index.compareAndSet(index - 1, index)) {
+                int current = this.index.get();
+                index = current + 1;
+                atBoundary = (index % size == 0);
+                if (this.index.compareAndSet(current, atBoundary ? 0 : index)) {
                     break;
                 }
             }
 
-            if (index == 1 && !emitEmptyListIfNoItem) { // If emitEmptyListIfNoItem, the task has been started in subscribe
-                try {
-                    task = executor.schedule(flush, duration.toMillis(), TimeUnit.MILLISECONDS);
-                } catch (RejectedExecutionException rejected) {
-                    onFailure(rejected);
-                    return;
-                }
+            if (index == 1 && !emitEmptyListIfNoItem) {
+                scheduleFlush();
             }
 
             nextCallback(value);
 
-            if (this.index.get() % size == 0) {
-                this.index.lazySet(0);
-                if (task != null) {
-                    task.cancel(false);
+            if (atBoundary) {
+                generation.incrementAndGet();
+                ScheduledFuture<?> t = task;
+                if (t != null) {
+                    t.cancel(false);
                     task = null;
                 }
                 flushCallback();
@@ -237,8 +248,9 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
         @Override
         public void onCompletion() {
             if (terminated.compareAndSet(RUNNING, SUCCEED)) {
-                if (task != null) {
-                    task.cancel(false);
+                ScheduledFuture<?> t = task;
+                if (t != null) {
+                    t.cancel(false);
                     task = null;
                 }
                 checkedComplete();
@@ -273,8 +285,9 @@ public final class MultiBufferWithTimeoutOp<T> extends AbstractMultiOperator<T, 
         @Override
         public void cancel() {
             if (terminated.compareAndSet(RUNNING, CANCELLED)) {
-                if (task != null) {
-                    task.cancel(false);
+                ScheduledFuture<?> t = task;
+                if (t != null) {
+                    t.cancel(false);
                     task = null;
                 }
                 super.cancel();

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
@@ -11,14 +11,21 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -27,6 +34,7 @@ import java.util.function.Consumer;
 
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
@@ -1066,6 +1074,214 @@ public class MultiGroupTest {
         }
     }
 
+    @Nested
+    class BufferWithTimeoutStaleTimerTest {
+
+        @Test
+        void staleTimerAfterSizeFlushMustNotEmitOrReschedule() {
+            ControllableScheduler scheduler = new ControllableScheduler();
+            AtomicReference<MultiEmitter<? super Integer>> emitterRef = new AtomicReference<>();
+
+            Multi<List<Integer>> multi = new MultiBufferWithTimeoutOp<>(
+                    Multi.createFrom().<Integer> emitter(emitterRef::set),
+                    3, Duration.ofHours(1), scheduler, true);
+
+            AssertSubscriber<List<Integer>> sub = multi.subscribe()
+                    .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+
+            assertThat(scheduler.taskCount()).isEqualTo(1);
+
+            MultiEmitter<? super Integer> emitter = emitterRef.get();
+            emitter.emit(1);
+            emitter.emit(2);
+            emitter.emit(3);
+
+            assertThat(sub.getItems()).hasSize(1);
+            assertThat(sub.getItems().get(0)).containsExactly(1, 2, 3);
+            assertThat(scheduler.taskCount()).isEqualTo(2);
+
+            scheduler.runTask(0);
+
+            assertThat(sub.getItems()).hasSize(1);
+            assertThat(scheduler.taskCount()).isEqualTo(2);
+        }
+
+        @Test
+        void staleTimerAfterSizeFlushMustNotFlushWithEmitEmptyDisabled() {
+            ControllableScheduler scheduler = new ControllableScheduler();
+            AtomicReference<MultiEmitter<? super Integer>> emitterRef = new AtomicReference<>();
+
+            Multi<List<Integer>> multi = new MultiBufferWithTimeoutOp<>(
+                    Multi.createFrom().<Integer> emitter(emitterRef::set),
+                    3, Duration.ofHours(1), scheduler, false);
+
+            AssertSubscriber<List<Integer>> sub = multi.subscribe()
+                    .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+
+            assertThat(scheduler.taskCount()).isEqualTo(0);
+
+            MultiEmitter<? super Integer> emitter = emitterRef.get();
+            emitter.emit(1);
+            assertThat(scheduler.taskCount()).isEqualTo(1);
+            emitter.emit(2);
+            emitter.emit(3);
+
+            assertThat(sub.getItems()).hasSize(1);
+            assertThat(sub.getItems().get(0)).containsExactly(1, 2, 3);
+
+            scheduler.runTask(0);
+
+            assertThat(sub.getItems()).hasSize(1);
+        }
+
+        private static class ControllableScheduler implements ScheduledExecutorService {
+
+            private static class CapturedTask {
+                final Runnable command;
+                final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+                CapturedTask(Runnable command) {
+                    this.command = command;
+                }
+            }
+
+            private final List<CapturedTask> tasks = new ArrayList<>();
+
+            @Override
+            public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+                CapturedTask task = new CapturedTask(command);
+                tasks.add(task);
+                return new ScheduledFuture<>() {
+                    @Override
+                    public long getDelay(TimeUnit unit) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public int compareTo(Delayed o) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public boolean cancel(boolean mayInterruptIfRunning) {
+                        return !task.cancelled.getAndSet(true);
+                    }
+
+                    @Override
+                    public boolean isCancelled() {
+                        return task.cancelled.get();
+                    }
+
+                    @Override
+                    public boolean isDone() {
+                        return task.cancelled.get();
+                    }
+
+                    @Override
+                    public Object get() {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public Object get(long timeout, TimeUnit unit) {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+
+            @Override
+            public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period,
+                    TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+                    TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void shutdown() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public List<Runnable> shutdownNow() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isShutdown() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isTerminated() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean awaitTermination(long timeout, TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> Future<T> submit(Callable<T> task) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> Future<T> submit(Runnable task, T result) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Future<?> submit(Runnable task) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
+                    TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> T invokeAny(Collection<? extends Callable<T>> tasks) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void execute(Runnable command) {
+                throw new UnsupportedOperationException();
+            }
+
+            void runTask(int index) {
+                tasks.get(index).command.run();
+            }
+
+            int taskCount() {
+                return tasks.size();
+            }
+        }
+    }
+
     @Test
     void testUpstreamRequestsNotBlownOutOfProportion() {
         ExecutorService executor = Executors.newFixedThreadPool(100);
@@ -1167,4 +1383,5 @@ public class MultiGroupTest {
             executor.shutdownNow();
         }
     }
+
 }

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/MultiGroupTest.java
@@ -1134,6 +1134,34 @@ public class MultiGroupTest {
             assertThat(sub.getItems()).hasSize(1);
         }
 
+        @RepeatedTest(1000)
+        void sizeFlushAndTimerFlushMustNotRace() {
+            ScheduledThreadPoolExecutor scheduler = new ScheduledThreadPoolExecutor(2);
+            try {
+                AtomicReference<MultiEmitter<? super Integer>> emitterRef = new AtomicReference<>();
+
+                Multi<List<Integer>> multi = new MultiBufferWithTimeoutOp<>(
+                        Multi.createFrom().<Integer> emitter(emitterRef::set),
+                        5, Duration.ofMillis(1), scheduler, false);
+
+                AssertSubscriber<List<Integer>> sub = multi.subscribe()
+                        .withSubscriber(AssertSubscriber.create(Long.MAX_VALUE));
+
+                MultiEmitter<? super Integer> emitter = emitterRef.get();
+                for (int i = 0; i < 100; i++) {
+                    emitter.emit(i);
+                }
+                emitter.complete();
+
+                sub.awaitCompletion(Duration.ofSeconds(2));
+
+                int total = sub.getItems().stream().mapToInt(List::size).sum();
+                assertThat(total).isEqualTo(100);
+            } finally {
+                scheduler.shutdownNow();
+            }
+        }
+
         private static class ControllableScheduler implements ScheduledExecutorService {
 
             private static class CapturedTask {


### PR DESCRIPTION
A stale timer (already executing when cancel(false) is called) could CAS(0,0) the index, emit a spurious empty list, and accumulate orphaned scheduled tasks over time.

Add a generation counter for stale-timer detection, and move the boundary decision into the CAS loop for atomic flush ownership.

Fixes #2187