### PR TITLE
fix: do not let gather request more upstream items than its downstream demand

### DIFF
--- a/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiGather.java
+++ b/implementation/src/main/java/io/smallrye/mutiny/operators/multi/MultiGather.java
@@ -29,6 +29,8 @@ public class MultiGather<I, ACC, O> extends AbstractMultiOperator<I, O> {
 
         private ACC acc;
         private final AtomicLong demand = new AtomicLong();
+        // number of upstream requests in flight, each one backed by a unit of demand taken from `demand`
+        private final AtomicLong reserved = new AtomicLong();
         private volatile boolean upstreamHasCompleted;
         private final AtomicInteger drainWip = new AtomicInteger();
 
@@ -62,9 +64,27 @@ public class MultiGather<I, ACC, O> extends AbstractMultiOperator<I, O> {
                 if (upstreamHasCompleted) {
                     drainRemainingElements();
                 } else {
-                    upstream.request(1L);
+                    requestNextUpstreamItem();
                 }
             }
+        }
+
+        // Extracted items are forwarded downstream as soon as upstream items arrive, so we must not have more upstream
+        // items on their way than what the downstream asked for: request one item at a time, and only when a unit of
+        // demand can be reserved for it.
+        private void requestNextUpstreamItem() {
+            if (reserved.get() > 0L) {
+                return;
+            }
+            long current;
+            do {
+                current = demand.get();
+                if (current <= 0L) {
+                    return;
+                }
+            } while (current != Long.MAX_VALUE && !demand.compareAndSet(current, current - 1L));
+            reserved.incrementAndGet();
+            upstream.request(1L);
         }
 
         @Override
@@ -91,12 +111,11 @@ public class MultiGather<I, ACC, O> extends AbstractMultiOperator<I, O> {
                     if (value == null) {
                         throw new NullPointerException("The extractor returned a null value to emit");
                     }
-                    long remaining = demand.decrementAndGet();
+                    reserved.decrementAndGet();
                     downstream.onItem(value);
-                    if (remaining > 0L) {
-                        upstream.request(1L);
-                    }
+                    requestNextUpstreamItem();
                 } else {
+                    // nothing was extracted, the reserved unit of demand carries over to the next upstream item
                     upstream.request(1L);
                 }
             } catch (Throwable err) {
@@ -110,6 +129,10 @@ public class MultiGather<I, ACC, O> extends AbstractMultiOperator<I, O> {
                 return;
             }
             upstreamHasCompleted = true;
+            long unused = reserved.getAndSet(0L);
+            if (unused > 0L) {
+                Subscriptions.add(demand, unused);
+            }
             drainRemainingElements();
         }
 

--- a/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiGatherTest.java
+++ b/implementation/src/test/java/io/smallrye/mutiny/operators/multi/MultiGatherTest.java
@@ -6,6 +6,9 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import org.junit.jupiter.api.Test;
@@ -15,6 +18,7 @@ import io.smallrye.mutiny.groups.Gatherer;
 import io.smallrye.mutiny.groups.Gatherer.Extraction;
 import io.smallrye.mutiny.groups.Gatherers;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.subscription.MultiEmitter;
 
 class MultiGatherTest {
 
@@ -333,6 +337,76 @@ class MultiGatherTest {
         sub.assertFailedWith(RuntimeException.class, "boom");
         sub.request(Long.MAX_VALUE);
         sub.assertHasNotReceivedAnyItem();
+    }
+
+    @Test
+    void requestsIssuedWhileDeliveringAnItemMustNotOverRequestUpstream() {
+        AtomicReference<MultiEmitter<? super Integer>> emitter = new AtomicReference<>();
+        AtomicLong upstreamRequested = new AtomicLong();
+        AtomicLong downstreamRequested = new AtomicLong();
+        AtomicLong received = new AtomicLong();
+        AtomicLong outstanding = new AtomicLong();
+        boolean[] keepRequesting = { true };
+
+        Multi<Integer> multi = Multi.createFrom().<Integer> emitter(emitter::set)
+                .onRequest().invoke(upstreamRequested::addAndGet)
+                .onItem().gather(Gatherers.window(1))
+                .onItem().transform(list -> list.get(0));
+
+        // A subscriber that keeps a bounded buffer of 16 items and replenishes it while an item is being delivered,
+        // which is what stream adapters such as the Vert.x ReadStreamSubscriber do
+        multi.subscribe().withSubscriber(new Flow.Subscriber<Integer>() {
+            Flow.Subscription subscription;
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                this.subscription = subscription;
+                request();
+            }
+
+            private void request() {
+                if (keepRequesting[0] && outstanding.get() < 8) {
+                    long n = 16 - outstanding.get();
+                    outstanding.addAndGet(n);
+                    downstreamRequested.addAndGet(n);
+                    subscription.request(n);
+                }
+            }
+
+            @Override
+            public void onNext(Integer item) {
+                received.incrementAndGet();
+                outstanding.decrementAndGet();
+                request();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                throw new AssertionError(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
+
+        // Serve the upstream demand one item at a time, never emitting more than what was requested
+        for (int i = 0; i < 10_000; i++) {
+            if (emitter.get().requested() > 0) {
+                emitter.get().emit(i);
+            }
+        }
+        assertThat(received.get()).isLessThanOrEqualTo(downstreamRequested.get());
+        assertThat(upstreamRequested.get())
+                .as("the operator must not request more items than its downstream did")
+                .isLessThanOrEqualTo(downstreamRequested.get());
+
+        // The downstream stops requesting: serving the remaining upstream demand must not deliver more than requested
+        keepRequesting[0] = false;
+        while (emitter.get().requested() > 0) {
+            emitter.get().emit(-1);
+        }
+        assertThat(received.get()).isLessThanOrEqualTo(downstreamRequested.get());
     }
 
     @Test


### PR DESCRIPTION
`MultiGather.request()` forwards one `upstream.request(1)` for every downstream `request()` call, in addition to the `request(1)` issued after each emitted item. When the downstream replenishes its demand from inside `onItem` (which bounded-buffer adapters such as the Vert.x bindings' `ReadStreamSubscriber` do every time their buffer drops below half), each of those calls adds a credit at the source that nobody consumes. With a `Multi<Buffer>` piped into a Vert.x `HttpClientRequest` the surplus reaches ~11,000 credits per 100,000 items. As soon as the downstream pauses, the source keeps serving the surplus and `onItem` forwards every extracted item without looking at the demand, so the paused subscriber buffers tens of thousands of items and the application runs out of memory. This is the root cause of quarkusio/quarkus#53099.

This PR makes the operator request a single upstream item at a time, and only after reserving a unit of downstream demand for it:

- `requestNextUpstreamItem()` skips when a request is already in flight, otherwise takes one unit from `demand` (left untouched at `Long.MAX_VALUE`) and requests one item;
- when an upstream item does not produce an extraction, the reserved unit carries over and the next item is requested directly;
- unused reservations are given back to `demand` on upstream completion so `drainRemainingElements()` sees the right count.

`MultiGatherTest#requestsIssuedWhileDeliveringAnItemMustNotOverRequestUpstream` drives the operator with an emitter served one item at a time and a subscriber that replenishes a 16-item buffer from `onNext`; before the fix the operator requests ~11% more items than the downstream did and delivers ~1,100 items after the subscriber stopped requesting.

Verified with the reporter's Quarkus reproducer: with the current operator it runs out of a 1 GB heap within seconds, with this patch it streams for a minute with the source requested count equal to the item count. The `MultiGatherTckTest` and the full `implementation` suite (12,255 tests) pass.
